### PR TITLE
Increase allowable body size, and increase response timeout, for curator ingress

### DIFF
--- a/aws/curator-ingress.yaml
+++ b/aws/curator-ingress.yaml
@@ -10,6 +10,10 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     # Use this issuer defined in letsencrypt.yaml to get certs automatically.
     cert-manager.io/issuer: "letsencrypt-prod"
+    # Set the max size of requests to the service.
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
+    # Set the timeout (in seconds) for the response to nginx.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
This prevents 413s and 504s for large batch requests.

We're still getting 500 after a minute (`socket hang up`), but I believe that's a node issue as opposed to nginx.