### PR TITLE
Use only boundaries API admin areas 

### DIFF
--- a/verification/curator-service/api/src/geocoding/README.md
+++ b/verification/curator-service/api/src/geocoding/README.md
@@ -38,4 +38,6 @@ It allows us to query administrative area names in the world based on the centro
 
 Note that this API is private and its official documentation is kind of lacking... Once you register, Mapbox folks send you a bunch of files with more information on administrative levels (like names in various languages, centroids, etc).
 
+You can check a live demo of the coverage of the boundaries API at https://www.mapbox.com/boundaries/#coverage-map. This is also useful to check why such an admin is empty (Brasil doesn't have admin 3 for example).
+
 We preprocess these files with the `/verification/scripts/gen_boundaries.sh` script and import the mapping of admin IDs to their English names in Mongo DB with the `/verification/scripts/import_boundaries.sh`. This process only needs to be done once for the lifetime of the Mongo DB database.

--- a/verification/curator-service/api/src/geocoding/adminsFetcher.ts
+++ b/verification/curator-service/api/src/geocoding/adminsFetcher.ts
@@ -2,77 +2,7 @@ import { GeocodeResult, Resolution } from './geocoder';
 
 import { Admin } from '../model/admin';
 import axios from 'axios';
-
-/**
- * Mapbox administrative area fetcher using the boundaries API.
- * https://www.mapbox.com/boundaries/.
- *
- * Some geocoding results do not contain the full administrative area details,
- * such details can be subsequently fetched using the boundaries API by doing a
- * tilequery fetch of the center of the geocode result with the administrative
- * boundaries layers.
- * Cf. https://docs.mapbox.com/help/glossary/tilequery-api/
- * It uses a mapping of mapbox administrative areas IDs to their names stored
- * in the admins Mongo DB collection.
- */
-export default class MapboxAdminsFetcher {
-    constructor(private readonly accessToken: string) {}
-
-    // Fill in missing admin levels for the given GeocodeResult.
-    async fillAdmins(geocode: GeocodeResult): Promise<void> {
-        // Get missing admins from geocode result.
-        const missingAdmins = new Set<Resolution>();
-        if (geocode.administrativeAreaLevel1 === '') {
-            missingAdmins.add(Resolution.Admin1);
-        }
-        if (geocode.administrativeAreaLevel2 === '') {
-            missingAdmins.add(Resolution.Admin2);
-        }
-        if (geocode.administrativeAreaLevel3 === '') {
-            missingAdmins.add(Resolution.Admin3);
-        }
-        if (missingAdmins.size === 0) {
-            return;
-        }
-        // Fetch all missing admins in one query.
-        const url = `https://api.mapbox.com/v4/${getLayersParam(
-            missingAdmins,
-        )}/tilequery/${geocode.geometry.longitude},${
-            geocode.geometry.latitude
-        }.json?access_token=${this.accessToken}`;
-        try {
-            const resp = await axios.get<BoundariesResponse>(url);
-            for (const feature of resp.data.features) {
-                switch (feature.properties.tilequery.layer) {
-                    case 'boundaries_admin_1':
-                        geocode.administrativeAreaLevel1 = await this.getName(
-                            feature.properties.id,
-                        );
-                    case 'boundaries_admin_2':
-                        geocode.administrativeAreaLevel2 = await this.getName(
-                            feature.properties.id,
-                        );
-                    case 'boundaries_admin_3':
-                        geocode.administrativeAreaLevel3 = await this.getName(
-                            feature.properties.id,
-                        );
-                }
-            }
-        } catch (e) {
-            // Fail gracefully, not being able to fetch all admins isn't a huge deal.
-            console.error(`Retrieving admins from url: ${url}:`, e);
-            return;
-        }
-    }
-
-    async getName(id: string): Promise<string> {
-        const admin = await Admin.findOne({ id: id }, 'name').exec();
-        if (!admin?.name) {
-            throw Error(`Could not find admin name with ID ${id}`);
-        }
-        return admin.name;
-    }
-}
+import LRUCache from 'lru-cache';
 
 // Mapbox boundaries types definitions, not part of the mapbox SDK.
 interface BoundariesResponse {
@@ -98,7 +28,6 @@ const adminToLayer = new Map<Resolution, string>([
     [Resolution.Admin2, 'mapbox.enterprise-boundaries-a2-v2'],
     [Resolution.Admin3, 'mapbox.enterprise-boundaries-a3-v2'],
 ]);
-
 // getLayersParams return the layers query param used by the mapbox boundaries API based on missing admin levels.
 function getLayersParam(admins: Set<Resolution>): string {
     const layers = [];
@@ -106,4 +35,87 @@ function getLayersParam(admins: Set<Resolution>): string {
         layers.push(adminToLayer.get(admin));
     }
     return layers.sort().join(',');
+}
+
+/**
+ * Mapbox administrative area fetcher using the boundaries API.
+ * https://www.mapbox.com/boundaries/.
+ *
+ * Some geocoding results do not contain the full administrative area details,
+ * such details can be subsequently fetched using the boundaries API by doing a
+ * tilequery fetch of the center of the geocode result with the administrative
+ * boundaries layers.
+ * Cf. https://docs.mapbox.com/help/glossary/tilequery-api/
+ * It uses a mapping of mapbox administrative areas IDs to their names stored
+ * in the admins Mongo DB collection.
+ */
+export default class MapboxAdminsFetcher {
+    private cache: LRUCache<GeocodeResult, BoundariesResponse>;
+    constructor(private readonly accessToken: string) {
+        this.cache = new LRUCache<GeocodeResult, BoundariesResponse>({
+            max: 500,
+        });
+    }
+
+    // Fill in missing admin levels for the given GeocodeResult.
+    async fillAdmins(geocode: GeocodeResult): Promise<void> {
+        // Get missing admins from geocode result.
+        const missingAdmins = new Set<Resolution>();
+        if (geocode.administrativeAreaLevel1 === '') {
+            missingAdmins.add(Resolution.Admin1);
+        }
+        if (geocode.administrativeAreaLevel2 === '') {
+            missingAdmins.add(Resolution.Admin2);
+        }
+        if (geocode.administrativeAreaLevel3 === '') {
+            missingAdmins.add(Resolution.Admin3);
+        }
+        if (missingAdmins.size === 0) {
+            return;
+        }
+        const cachedResult = this.cache.get(geocode);
+        let resp: BoundariesResponse;
+        if (cachedResult) {
+            resp = cachedResult;
+        } else {
+            // Fetch all missing admins in one query.
+            const url = `https://api.mapbox.com/v4/${getLayersParam(
+                missingAdmins,
+            )}/tilequery/${geocode.geometry.longitude},${
+                geocode.geometry.latitude
+            }.json?access_token=${this.accessToken}`;
+            try {
+                resp = (await axios.get<BoundariesResponse>(url)).data;
+                this.cache.set(geocode, resp);
+            } catch (e) {
+                // Fail gracefully, not being able to fetch all admins isn't a huge deal.
+                console.error(`Retrieving admins from url: ${url}:`, e);
+                return;
+            }
+        }
+        for (const feature of resp.features) {
+            switch (feature.properties.tilequery.layer) {
+                case 'boundaries_admin_1':
+                    geocode.administrativeAreaLevel1 = await this.getName(
+                        feature.properties.id,
+                    );
+                case 'boundaries_admin_2':
+                    geocode.administrativeAreaLevel2 = await this.getName(
+                        feature.properties.id,
+                    );
+                case 'boundaries_admin_3':
+                    geocode.administrativeAreaLevel3 = await this.getName(
+                        feature.properties.id,
+                    );
+            }
+        }
+    }
+
+    async getName(id: string): Promise<string> {
+        const admin = await Admin.findOne({ id: id }, 'name').exec();
+        if (!admin?.name) {
+            throw Error(`Could not find admin name with ID ${id}`);
+        }
+        return admin.name;
+    }
 }

--- a/verification/curator-service/api/src/geocoding/geocoder.ts
+++ b/verification/curator-service/api/src/geocoding/geocoder.ts
@@ -6,26 +6,17 @@ export interface GeocodeResult {
     };
     country: string;
     // First administrative division (state in the US, Länder in Germany, ...).
-    administrativeAreaLevel1: string | undefined;
+    administrativeAreaLevel1?: string;
     // Second administrative division (county in the US, departments in France, ...).
-    administrativeAreaLevel2: string | undefined;
+    administrativeAreaLevel2?: string;
     // Third administrative division (cities usually).
-    administrativeAreaLevel3: string | undefined;
+    administrativeAreaLevel3?: string;
     // A precise location, such as an establishment or POI.
     place: string | undefined;
     // Human readable place name.
     name: string;
     // How granular the geocode is.
     geoResolution: Resolution;
-}
-
-// Returns whether a given geocode result is missing some administrative areas levels.
-export function isMissingAdmins(result: GeocodeResult): boolean {
-    return (
-        result.administrativeAreaLevel1 === '' ||
-        result.administrativeAreaLevel2 === '' ||
-        result.administrativeAreaLevel3 === ''
-    );
 }
 
 export enum Resolution {

--- a/verification/curator-service/api/src/geocoding/mapbox.ts
+++ b/verification/curator-service/api/src/geocoding/mapbox.ts
@@ -1,9 +1,4 @@
-import {
-    GeocodeOptions,
-    GeocodeResult,
-    Resolution,
-    isMissingAdmins,
-} from './geocoder';
+import { GeocodeOptions, GeocodeResult, Resolution } from './geocoder';
 import Geocoding, {
     GeocodeFeature,
     GeocodeMode,
@@ -131,25 +126,12 @@ export default class MapboxGeocoder {
                             latitude: feature.center[1],
                         },
                         country: getFeatureTypeFromContext(contexts, 'country'),
-                        administrativeAreaLevel1: getFeatureTypeFromContext(
-                            contexts,
-                            'region',
-                        ),
-                        administrativeAreaLevel2: getFeatureTypeFromContext(
-                            contexts,
-                            'district',
-                        ),
-                        administrativeAreaLevel3: getFeatureTypeFromContext(
-                            contexts,
-                            'place',
-                        ),
                         place: getFeatureTypeFromContext(contexts, 'poi'),
                         name: feature.place_name,
                         geoResolution: getResolution(contexts),
                     };
-                    if (isMissingAdmins(res)) {
-                        await this.adminsFetcher.fillAdmins(res);
-                    }
+                    // Fill in the administrative areas.
+                    await this.adminsFetcher.fillAdmins(res);
                     return res;
                 }),
             );

--- a/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
+++ b/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
@@ -114,5 +114,11 @@ describe('Admins', () => {
         expect(geocode.administrativeAreaLevel1).toBe('some admin 1');
         expect(geocode.administrativeAreaLevel2).toBe('some admin 2');
         expect(geocode.administrativeAreaLevel3).toBe('some admin 3');
+        // Call again, cache should be hit.
+        geocode.administrativeAreaLevel1 = '';
+        geocode.administrativeAreaLevel2 = '';
+        geocode.administrativeAreaLevel3 = '';
+        await fetcher.fillAdmins(geocode);
+        expect(mockedAxios.get).toHaveBeenCalledTimes(1);
     });
 });

--- a/verification/curator-service/api/test/geocoding/mapbox.test.ts
+++ b/verification/curator-service/api/test/geocoding/mapbox.test.ts
@@ -58,9 +58,6 @@ describe('geocode', () => {
         });
         expect(feats).toHaveLength(1);
         const wantFeature: GeocodeResult = {
-            /*administrativeAreaLevel1: 'Rhône',
-            administrativeAreaLevel2: '',
-            administrativeAreaLevel3: 'Lyon',*/
             country: 'France',
             geometry: { latitude: 45.75889, longitude: 4.84139 },
             place: '',

--- a/verification/curator-service/api/test/geocoding/mapbox.test.ts
+++ b/verification/curator-service/api/test/geocoding/mapbox.test.ts
@@ -58,9 +58,9 @@ describe('geocode', () => {
         });
         expect(feats).toHaveLength(1);
         const wantFeature: GeocodeResult = {
-            administrativeAreaLevel1: 'Rhône',
+            /*administrativeAreaLevel1: 'Rhône',
             administrativeAreaLevel2: '',
-            administrativeAreaLevel3: 'Lyon',
+            administrativeAreaLevel3: 'Lyon',*/
             country: 'France',
             geometry: { latitude: 45.75889, longitude: 4.84139 },
             place: '',


### PR DESCRIPTION
Turns out administrative areas are hard [citation needed], we were previously trying to guess them from the geocode feature context but it was mostly wrong past the admin 1, admin 2 and admin 3 definitions depend on countries (for example Brasil doesn't have an admin 3, UK has "country" as admin 1, county as admin 2, etc. It's a mess and we can't just try to get the feature type "region" for admin 1, "district" for admin2 etc as we were trying to do before.
From now on we'll rely on the mapbox boundaries API which has very decent coverage and give us correct results.

Just check out https://www.mapbox.com/boundaries/#coverage-map and visit various countries to see how many different admin level -> meaning there are. I realized that looking at that page, hence this PR.

Also:
- reorder definitions of methods in admin fetcher (some lint issues when using stuff that wasn't defined prior to being used, worked but I am not sure what the problem was about...)

- cache results of boundaries API to lessen the costs and get faster results as we do for geocode results

Example of wrong geocode before:
![image](https://user-images.githubusercontent.com/1255432/88635901-8872b480-d0b8-11ea-8821-983c50fa872f.png)

Example of correct geocode after:
![image](https://user-images.githubusercontent.com/1255432/88635885-81e43d00-d0b8-11ea-9155-1031dfc9add1.png)

For #572 