### PR TITLE
Make the event names in the curator OpenAPI spec an enum

### DIFF
--- a/.github/workflows/case-data-update-dev.yml
+++ b/.github/workflows/case-data-update-dev.yml
@@ -2,9 +2,11 @@ name: Update case data in dev
 
 on:
   push:
-    # Update the data when the schema changes.
+    # Update the data when the schema or conversion script changes.
     branches: [main]
-    paths: ["data-serving/data-service/schemas/**"]
+    paths:
+      - "data-serving/data-service/schemas/**"
+      - "data-serving/scripts/convert-data/**"
 
 jobs:
   # NOTE: This job should be kept in sync with the prod version.

--- a/.github/workflows/case-data-update-prod.yml
+++ b/.github/workflows/case-data-update-prod.yml
@@ -2,9 +2,11 @@ name: Update case data in prod
 
 on:
   push:
-    # Update the data when the conversion script changes.
+    # Update the data when the schema or conversion script changes.
     branches: [main]
-    paths: ["data-serving/scripts/convert-data/**"]
+    paths:
+      - "data-serving/data-service/schemas/**"
+      - "data-serving/scripts/convert-data/**"
   repository_dispatch:
     # Update the data on a signal that the input data has changed.
     types: [latest-data-push]

--- a/data-serving/scripts/convert-data/convert_data.py
+++ b/data-serving/scripts/convert-data/convert_data.py
@@ -106,28 +106,32 @@ def convert(infile: str, outfile: str, geocoder: Any,
                     csv_case['latitude'],
                     csv_case['longitude'])
 
-                json_case['events'] = convert_events(csv_case['ID'], {
+                json_case['events'] = convert_events(csv_case['ID'], [
                     (
                         csv_case['date_onset_symptoms'],
+                        None,
                         'date_onset_symptoms',
                         'onsetSymptoms'
                     ),
                     (
                         csv_case['date_admission_hospital'],
+                        None,
                         'date_admission_hospital',
-                        'admissionHospital'
+                        'hospitalAdmission'
                     ),
                     (
                         csv_case['date_confirmation'],
+                        None,
                         'date_confirmation',
                         'confirmed'
                     ),
                     (
                         csv_case['date_death_or_discharge'],
+                        csv_case['outcome'],
                         'date_death_or_discharge',
-                        'deathOrDischarge'
+                        'outcome'
                     )
-                }, csv_case['outcome'])
+                ])
 
                 json_case['symptoms'] = convert_dictionary_field(
                     csv_case['ID'],

--- a/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
+++ b/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
@@ -76,7 +76,7 @@ function import_data() {
         --collection $collection \
         --file $CONVERTED_DATA_PATH \
         --jsonArray \
-        --uri="$mongodb_connection_string"
+        --uri="$mongodb_connection_string/$db"
 }
 
 function cleanup() {

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -570,16 +570,21 @@ components:
           $ref: "#/components/schemas/Location"
         events:
           # TODO: Make event names an enum.
-          description: > 
-            An event with name "confirmed" must be specified. Other event names
-            include onsetSymptoms, firstClinicalConsultation, selfIsolation,
-            hospitalAdmission, icuAdmission, and outcome.
+          description: An event with name "confirmed" is required.
           type: array
           items:
             type: object
             properties:
               name:
                 type: string
+                enum:
+                  - confirmed
+                  - firstClinicalConsultation
+                  - hospitalAdmission
+                  - icuAdmission
+                  - onsetSymptoms
+                  - outcome
+                  - selfIsolation
               dateRange:
                 $ref: "#/components/schemas/DateRange"
               value:

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -569,7 +569,6 @@ components:
         location:
           $ref: "#/components/schemas/Location"
         events:
-          # TODO: Make event names an enum.
           description: An event with name "confirmed" is required.
           type: array
           items:


### PR DESCRIPTION
Required a small fix in our data converter (wrong event name) -- found a couple other small things to fix along the way