### PR TITLE
Add batchUpsert method to data service case API

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -151,7 +151,7 @@ paths:
           $ref: "#/components/responses/500"
   /cases/symptoms:
     get:
-      summary: Lists most frequently used sypmtoms
+      summary: Lists most frequently used symptoms
       operationId: listSymptoms
       parameters:
         - name: limit

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -131,6 +131,24 @@ paths:
           $ref: "#/components/responses/207BatchValidateCaseResponse"
         "500":
           $ref: "#/components/responses/500"
+  /cases/batchUpsert:
+    post:
+      summary: Batch upserts cases
+      operationId: batchUpsertCases
+      requestBody:
+        description: Cases to upsert
+        required: true
+        content:
+          application/json:
+            schema:
+                $ref: "#/components/schemas/CaseArray"
+      responses:
+        "207":
+          $ref: "#/components/responses/207BatchUpsertCaseResponse"
+        "422":
+          $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
   /cases/symptoms:
     get:
       summary: Lists most frequently used sypmtoms
@@ -244,6 +262,20 @@ components:
               - message
       required:
         - errors
+    BatchUpsertCaseResponse:
+      description: Response to batch upsert case API requests
+      properties:
+        createdCaseIds:
+          type: array
+          items:
+            type: string
+        updatedCaseIds:
+          type: array
+          items:
+            type: string
+      required:
+        - createdCaseIds
+        - updatedCaseIds
     Case:
       description: A single line-list case.
       properties:
@@ -524,6 +556,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/BatchValidateCaseResponse'
+    "207BatchUpsertCaseResponse":
+      description: Multi-status
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BatchUpsertCaseResponse'
     "400":
       description: Malformed request
     "403":

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -62,6 +62,7 @@ new OpenApiValidator({
         apiRouter.get('/cases/symptoms', caseController.listSymptoms);
         apiRouter.post('/cases', setRevisionMetadata, caseController.create);
         apiRouter.post('/cases/batchValidate', caseController.batchValidate);
+        apiRouter.post('/cases/batchUpsert', caseController.batchUpsert);
         apiRouter.put('/cases', setRevisionMetadata, caseController.upsert);
         apiRouter.put(
             '/cases/:id([a-z0-9]{24})',

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -1,6 +1,7 @@
 import { Case } from '../../src/model/case';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import app from './../../src/index';
+import fullCase from './../model/data/case.full.json';
 import minimalCase from './../model/data/case.minimal.json';
 import mongoose from 'mongoose';
 import request from 'supertest';


### PR DESCRIPTION
Primary goal here is to make the bulk upsert MongoDB invocation more efficient.

In pursuit of avoiding a super large/dense PR, I'm cutting this at what's _sort of_ an intermediate state. Rather than expose this endpoint directly in a subsequent PR, I'll probably wrap it together with the existing batchValidate method before doing so (in that same PR). Happy to hear thoughts on this.