### PR TITLE
add basic search query parser

### DIFF
--- a/data-serving/data-service/package-lock.json
+++ b/data-serving/data-service/package-lock.json
@@ -8061,6 +8061,11 @@
         "xmlchars": "^2.1.1"
       }
     },
+    "search-query-parser": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/search-query-parser/-/search-query-parser-1.5.5.tgz",
+      "integrity": "sha512-8hKmRbHShAc+LJtUu7mu4L/oWVgICG1GCzWZtlR11Vl3T/v4aTGv+Ie2bPg+8ueJn+l8zMHCQhzrBNMoV/t2qw=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",

--- a/data-serving/data-service/package.json
+++ b/data-serving/data-service/package.json
@@ -63,6 +63,7 @@
     "express-validator": "^6.6.0",
     "mongodb": "^3.5.9",
     "mongoose": "^5.9.23",
+    "search-query-parser": "^1.5.5",
     "swagger-ui-express": "^4.1.4",
     "yamljs": "^0.3.0"
   },

--- a/data-serving/data-service/src/util/search.ts
+++ b/data-serving/data-service/src/util/search.ts
@@ -1,0 +1,25 @@
+import { parse, SearchParserResult } from 'search-query-parser';
+
+export interface ParsedSearch {
+    fullTextSearch?: string;
+}
+
+export default function parseSearchQuery(q: string): ParsedSearch {
+    q = q.trim();
+    const parsedSearch = parse(q, {
+        offsets: false,
+        // TODO: Specify tokens here.
+    });
+    const res: ParsedSearch = {};
+    // When no tokens are specified or found, the returned value is a string.
+    if (typeof parsedSearch === 'string') {
+        res.fullTextSearch = parsedSearch as string;
+    } else {
+        // When tokens are found, searchResult is a struct with tokens as properties
+        // and full text search is contained in the "text" property.
+        const searchParsedResult = parsedSearch as SearchParserResult;
+        // We don't tokenize so "text" is a string, not an array of strings.
+        res.fullTextSearch = searchParsedResult.text as string;
+    }
+    return res;
+}

--- a/data-serving/data-service/test/util/search.test.ts
+++ b/data-serving/data-service/test/util/search.test.ts
@@ -1,0 +1,18 @@
+import parseSearchQuery from '../../src/util/search';
+
+describe('search query', () => {
+    it('is parsed with full text search', () => {
+        const res = parseSearchQuery('some query');
+        expect(res).toEqual({ fullTextSearch: 'some query' });
+    });
+
+    it('is parsed with empty query', () => {
+        const res = parseSearchQuery('');
+        expect(res).toEqual({ fullTextSearch: '' });
+    });
+
+    it('is parsed with negative searches', () => {
+        const res = parseSearchQuery('want -nogood');
+        expect(res).toEqual({ fullTextSearch: 'want -nogood' });
+    });
+});


### PR DESCRIPTION
For #679

This makes use of https://www.npmjs.com/package/search-query-parser which is a zero-dependency parser that does what we want AFAICT. I'm happy to not have to write such a common parser/tokenizer, next step is to specify keywords and modify the mongo query accordingly.