### PR TITLE
Fix bug in conversion pipeline

### DIFF
--- a/data-serving/scripts/data-pipeline/README.md
+++ b/data-serving/scripts/data-pipeline/README.md
@@ -22,5 +22,7 @@ python3 -m pip install -r requirements.txt
 [-r <sample_rate>] [-s <schema_path>]
 ```
 
+NOTE: `mongodb_connection_string` should contain the database in the path.
+
 It will default to running against your local MongoDB instance, the `covid19` database, the `cases` collection and
 associated schema, with a sample rate of 1 (i.e. converting and importing all cases without sampling).

--- a/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
+++ b/data-serving/scripts/data-pipeline/convert_and_import_latest_data.sh
@@ -76,7 +76,7 @@ function import_data() {
         --collection $collection \
         --file $CONVERTED_DATA_PATH \
         --jsonArray \
-        --uri="$mongodb_connection_string/$db"
+        --uri="$mongodb_connection_string"
 }
 
 function cleanup() {


### PR DESCRIPTION
The connection strings for the cron contain the db in the path, which they have to because of how they're structured; I forgot about that and didn't have it as an arg when running it locally, thought I was smart to add it in the script, and was not.