### PR TITLE
Use the data service batchUpsert endpoint in the curator API.

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -214,7 +214,7 @@ export const batchUpsert = async (
                                 'caseReference.sourceEntryId':
                                     c.caseReference.sourceEntryId,
                             },
-                            update: { $set: { c } },
+                            update: c,
                             upsert: true,
                         },
                     };

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -257,6 +257,8 @@ describe('POST', () => {
             .expect(207);
         expect(res.body.createdCaseIds).toHaveLength(2);
         expect(res.body.updatedCaseIds).toHaveLength(1);
+        const updatedCaseInDb = await Case.findById(res.body.updatedCaseIds[0]);
+        expect(updatedCaseInDb?.notes).toEqual(existingCaseWithEntryId.notes);
     });
     it('batch upsert with any invalid case should return 422', async () => {
         await request(app)

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -318,6 +318,7 @@ class BulkCaseForm extends React.Component<
             {
                 cases: casesToSend,
             },
+            { maxContentLength: Infinity },
         );
         return response.data;
     }


### PR DESCRIPTION
Results in a 3-4X speed-up locally. Expecting the speed up in dev to be appreciably larger, given the appreciable increase in latency. Due to (what I think will be) an expensive query in the data service `batchUpsert` call, I think adding an index to support the query will further improve the performance. But, will send this change off to dev first in order to measure the impact of that index.