### PR TITLE
support csv in retrieval lambda

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -59,8 +59,7 @@ def get_source_details(source_id, api_headers):
         r = requests.get(source_api_endpoint, headers=api_headers)
         api_json = r.json()
         print(f"Received source API response: {api_json}")
-        return api_json["origin"]["url"], "JSON", api_json.get(
-            "automation", {}).get(
+        return api_json["origin"]["url"], api_json["format"], api_json.get("automation", {}).get(
             "parser", {}).get(
             "awsLambdaArn", "")
     except Exception as e:
@@ -76,25 +75,25 @@ def retrieve_content(source_id, url, source_format):
         print(f"Downloading {source_format} content from {url}")
         headers = {"user-agent": "GHDSI/1.0 (http://ghdsi.org)"}
         r = requests.get(url, headers=headers)
-        # TODO: Support other formats here.
-        # https://github.com/globaldothealth/list/issues/723
         if source_format == "JSON":
-            data = json.dumps(r.json(), indent=4)
+            data = json.dumps(r.json(), indent=4).encode('utf-8')
             extension = "json"
+        elif source_format == "CSV":
+            data = r.content
+            extension = "csv"
         else:
             error_message = f"Unsupported source format: {source_format}"
             print(error_message)
             raise ValueError(error_message)
 
         key_filename_part = f"content.{extension}"
-        file = open(f"/tmp/{key_filename_part}", "w")
-        file.write(data)
-        file.close()
-        s3_object_key = (
-            f"{source_id}"
-            f"{datetime.now(timezone.utc).strftime(TIME_FILEPART_FORMAT)}"
-            f"{key_filename_part}")
-        return (file.name, s3_object_key)
+        with open(f"/tmp/{key_filename_part}", "wb") as f:
+            f.write(data)
+            s3_object_key = (
+                f"{source_id}"
+                f"{datetime.now(timezone.utc).strftime(TIME_FILEPART_FORMAT)}"
+                f"{key_filename_part}")
+            return (f.name, s3_object_key)
     except requests.RequestException as e:
         print(e)
         raise e

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -54,7 +54,7 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3):
     lambda_arn = "arn"
     requests_mock.get(
         full_source_url,
-        json={"origin": {"url": origin_url},
+        json={"origin": {"url": origin_url}, "format": "JSON",
               "automation": {"parser": {"awsLambdaArn": lambda_arn}}})
     requests_mock.get(origin_url, json={"data": "yes"})
 
@@ -80,17 +80,17 @@ def test_extract_source_id_raises_error_if_event_lacks_id(invalid_event):
         retrieval.extract_source_id(invalid_event)
 
 
-def test_get_source_details_returns_url_and_json_format(requests_mock):
+def test_get_source_details_returns_url_and_format(requests_mock):
     from retrieval import retrieval  # Import locally to avoid superseding mock
     source_api_url = "http://foo.bar"
     source_id = "id"
     content_url = "http://bar.baz"
     os.environ["SOURCE_API_URL"] = source_api_url
     requests_mock.get(f"{source_api_url}/sources/{source_id}",
-                      json={"origin": {"url": content_url}})
+                      json={"format": "CSV", "origin": {"url": content_url}})
     result = retrieval.get_source_details(source_id, {})
     assert result[0] == content_url
-    assert result[1] == "JSON"
+    assert result[1] == "CSV"
     assert result[2] == ""
 
 
@@ -103,7 +103,7 @@ def test_get_source_details_returns_parser_arn_if_present(requests_mock):
     lambda_arn = "lambdaArn"
     requests_mock.get(
         f"{source_api_url}/sources/{source_id}",
-        json={"origin": {"url": content_url},
+        json={"origin": {"url": content_url}, "format": "JSON",
               "automation": {"parser": {"awsLambdaArn": lambda_arn}}})
     result = retrieval.get_source_details(source_id, {})
     assert result[2] == lambda_arn
@@ -121,6 +121,18 @@ def test_retrieve_content_persists_downloaded_json_locally(requests_mock):
     with open("/tmp/content.json", "r") as f:
         assert json.load(f)["data"] == "yes"
 
+def test_retrieve_content_persists_downloaded_csv_locally(requests_mock):
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    source_id = "id"
+    content_url = "http://foo.bar/"
+    format = "CSV"
+    requests_mock.get(content_url, content=b"foo,bar")
+    retrieval.retrieve_content(source_id, content_url, format)
+    assert requests_mock.request_history[0].url == content_url
+    assert "GHDSI" in requests_mock.request_history[0].headers["user-agent"]
+    with open("/tmp/content.csv", "r") as f:
+        assert f.read() == "foo,bar"
+
 
 def test_retrieve_content_returns_local_and_s3_object_names(requests_mock):
     from retrieval import retrieval  # Import locally to avoid superseding mock
@@ -132,9 +144,9 @@ def test_retrieve_content_returns_local_and_s3_object_names(requests_mock):
     assert source_id in result[1]
 
 
-def test_retrieve_content_raises_error_for_non_json_format(requests_mock):
+def test_retrieve_content_raises_error_for_non_supported_format(requests_mock):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    bad_format = "CSV"
+    bad_format = "PDF"
     content_url = "http://foo.bar/"
     requests_mock.get(content_url)
     with pytest.raises(ValueError, match=bad_format):


### PR DESCRIPTION
Tested locally after adding a source in the UI:

```
SOURCE_API_URL=http://localhost:3001/api sam local invoke "RetrievalFunction" -e retrieval/valid_scheduled_event.json --docker-network=host
Invoking retrieval.lambda_handler (python3.6)
Failed to download a new amazon/aws-sam-cli-emulation-image-python3.6:rapid-1.0.0 image. Invoking with the already downloaded image.
Mounting /Users/timothe/healthmap/healthmap-gdo-temp/ingestion/functions/.aws-sam/build/RetrievalFunction as /var/task:ro,delegated inside runtime container
05 Aug 2020 15:13:05,298 [INFO] (/var/runtime/awslambda/bootstrap.py) main started at epoch 1596640385298
05 Aug 2020 15:13:09,304 [INFO] (/var/runtime/awslambda/bootstrap.py) init complete at epoch 1596640389305
START RequestId: 97982b06-b371-1cd5-e7d9-964b738db44d Version: $LATEST
Retrieving service account credentials from s3://epid-ingestion/covid-19-map-277002-0943eeb6776b.json
Requesting source configuration from http://localhost:3001/api/sources/5f2acbe8df34a7051c8b01f4
Received source API response: {'_id': '5f2acbe8df34a7051c8b01f4', 'name': 'zurich', 'origin': {'_id': '5f2acbe8df34a7051c8b01f5', 'url': 'https://github.com/openZH/covid_19/blob/master/fallzahlen_kanton_alter_geschlecht_csv/COVID19_Fallzahlen_Kanton_ZH_alter_geschlecht.csv'}, 'format': 'CSV', '__v': 0}
Downloading CSV content from https://github.com/openZH/covid_19/blob/master/fallzahlen_kanton_alter_geschlecht_csv/COVID19_Fallzahlen_Kanton_ZH_alter_geschlecht.csv
Uploaded source content to s3://epid-sources-raw/5f2acbe8df34a7051c8b01f4/2020/08/05/1513/content.csv
END RequestId: 97982b06-b371-1cd5-e7d9-964b738db44d
REPORT RequestId: 97982b06-b371-1cd5-e7d9-964b738db44d	Init Duration: 4300.84 ms	Duration: 8343.34 ms	Billed Duration: 8400 ms	Memory Size: 128 MB	Max Memory Used: 53 MB

{"bucket":"epid-sources-raw","key":"5f2acbe8df34a7051c8b01f4/2020/08/05/1513/content.csv"}
```

For #723 