### PR TITLE
Add openAPI validation on select fields and remove TODOs

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -315,6 +315,7 @@ components:
           properties:
             gender:
               type: string
+              enum: [null, Male, Female, Non-binary/Third gender, Other]
             ageRange:
               type: object
               properties:
@@ -352,6 +353,7 @@ components:
           properties:
             status:
               type: string
+              enum: [null, Asymptomatic, Symptomatic, Presymptomatic]
             values:
               type: array
               items:
@@ -396,6 +398,7 @@ components:
                     $ref: "#/components/schemas/Location"
                   purpose:
                     type: string
+                    enum: [null, Business, Leisure, Family, Other]
                   methods:
                     type: array
                     items:

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Demographics.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Demographics.tsx
@@ -35,7 +35,7 @@ const styles = () =>
 
 type DemographicsProps = WithStyles<typeof styles>;
 
-// TODO: get values from DB.
+// If changing this list, also modify https://github.com/globaldothealth/list/blob/main/data-serving/data-service/api/openapi.yaml
 const genderValues = [
     'Unknown',
     'Male',

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Events.tsx
@@ -8,7 +8,6 @@ import { useFormikContext } from 'formik';
 
 const yesNoUndefined = ['Unknown', 'Yes', 'No'];
 
-// TODO: get values from DB.
 const methodsOfConfirmation = [
     'Unknown',
     'PCR test',

--- a/verification/curator-service/ui/src/components/new-case-form-fields/Symptoms.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/Symptoms.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles(() => ({
     },
 }));
 
-// TODO: get values from DB
+// If changing this list, also modify https://github.com/globaldothealth/list/blob/main/data-serving/data-service/api/openapi.yaml
 const symptomStatusValues = [
     'Unknown',
     'Asymptomatic',

--- a/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
+++ b/verification/curator-service/ui/src/components/new-case-form-fields/TravelHistory.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles(() => ({
 
 const hasTravelledValues = ['Unknown', 'Yes', 'No'];
 
-// TODO: get values from DB.
+// If changing this list, also modify https://github.com/globaldothealth/list/blob/main/data-serving/data-service/api/openapi.yaml
 const travelPurposes = ['Unknown', 'Business', 'Leisure', 'Family', 'Other'];
 
 const travelMethods = [


### PR DESCRIPTION
Since the values can't be extracted from the openAPI, we'll need to define the lists in two places anyways. So there's no harm in defining the lists in the UI rather than the API and removes the need for several more HTTP requests.