### PR TITLE
Specify unordered for the batchUpsert bulk write operation.

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -257,6 +257,7 @@ export const batchUpsert = async (
                     };
                 }
             }),
+            { ordered: false },
         );
         res.status(207).json({
             // Types are a little goofy here. We're grabbing the string ID from


### PR DESCRIPTION
This option allows for (theoretically) better parallelization for our bulk work.

Difference is pretty slight locally, but might be more perceptible in Atlas.