### PR TITLE
Workflow to export prod db data daily and commit to repo

### DIFF
--- a/.github/workflows/case-data-export-prod.yml
+++ b/.github/workflows/case-data-export-prod.yml
@@ -1,0 +1,38 @@
+name: Export prod case data
+
+on:
+  schedule:
+    # Every day at 6AM UTC (data is typically ingested at 5AM UTC).
+    - cron: "0 6 * * *"
+
+jobs:
+  export-case-data-prod:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install MongoDB CLIs
+        run: |
+          wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA 656408E390CFB1F5
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
+
+      - name: Create gzip of CSV and JSON prod case data
+        run: |
+          ./data-serving/scripts/export-data/export_data.sh -m "${{ secrets.DB_CONNECTION_URL_PROD }}"
+          ./data-serving/scripts/export-data/export_data.sh -m "${{ secrets.DB_CONNECTION_URL_PROD }}" -o json
+          tar -cvzf data/cases.tar.gz cases.csv cases.json
+
+      - name: Push the data to the repo
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          token: ${{ secrets.$EXPORT_DATA_ACCESS_TOKEN }}
+          ssh-known-hosts: 'ssh-keyscan github.com`'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add data/cases.tar.gz
+          git commit -m "Automatic export of case data"
+          git push

--- a/.github/workflows/case-data-export-prod.yml
+++ b/.github/workflows/case-data-export-prod.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@master
+        with:
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
       - name: Install MongoDB CLIs
         run: |
           wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
@@ -24,15 +29,14 @@ jobs:
           ./data-serving/scripts/export-data/export_data.sh -m "${{ secrets.DB_CONNECTION_URL_PROD }}" -o json
           tar -cvzf data/cases.tar.gz cases.csv cases.json
 
-      - name: Push the data to the repo
-        uses: actions/checkout@v2
-        with:
-          ref: main
-          token: ${{ secrets.$EXPORT_DATA_ACCESS_TOKEN }}
-          ssh-known-hosts: 'ssh-keyscan github.com`'
+      - name: Commit files
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
           git add data/cases.tar.gz
           git commit -m "Automatic export of case data"
-          git push
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.EXPORT_DATA_ACCESS_TOKEN }}

--- a/data-serving/scripts/export-data/export_data.sh
+++ b/data-serving/scripts/export-data/export_data.sh
@@ -4,7 +4,6 @@
 
 readonly USAGE="Usage: $0 [-m <mongodb_connection_string>] [-c <collection>] [-o <csv|json>] [-f <field_filepath>]"
 readonly SCRIPT_PATH="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly EXPORT_FILENAME='export'
 
 mongodb_connection_string='mongodb://127.0.0.1:27017/covid19'
 collection='cases'
@@ -42,14 +41,15 @@ function read_fields() {
 }
 
 function export_data() {
-    print 'Exporting data'
+    output_file="$collection.$output_format"
+    print "Exporting data to $output_file"
 
     mongoexport \
         --uri="$mongodb_connection_string" \
         --collection="$collection" \
         --fields="$fields" \
         --type="$output_format" \
-        --out="$EXPORT_FILENAME.$output_format" 
+        --out="$output_file"
 }
 
 # Establish run order


### PR DESCRIPTION
The secret I'm using is my own PAT (with public_repo scope), and we should transition this to one of the future maintainers after I confirm this works

I tested it locally with `act` but it probably won't work the first time. Never has, never will!

```
act -j export-case-data-prod -P ubuntu-latest=nektos/act-environments-ubuntu:18.04-full -s DB_CONNECTION_URL=<CONN_STRING> -s EXPORT_DATA_ACCESS_TOKEN=<GITHUB_TOKEN>
```