### PR TITLE
Use Mongoose useCreateIndex option to prevent deprecation warnings.

### DIFF
--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -109,6 +109,7 @@ new OpenApiValidator({
         );
 
         await mongoose.connect(mongoURL, {
+            useCreateIndex: true,
             useNewUrlParser: true,
             useUnifiedTopology: true,
             useFindAndModify: false,

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -61,6 +61,7 @@ console.log(
 
 mongoose
     .connect(mongoURL, {
+        useCreateIndex: true,
         useNewUrlParser: true,
         useUnifiedTopology: true,
         useFindAndModify: false,

--- a/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
+++ b/verification/curator-service/api/test/geocoding/adminsFetcher.test.ts
@@ -16,6 +16,7 @@ let mongoServer: MongoMemoryServer;
 beforeAll(async () => {
     mongoServer = new MongoMemoryServer();
     await mongoose.connect(await mongoServer.getUri(), {
+        useCreateIndex: true,
         useNewUrlParser: true,
         useUnifiedTopology: true,
         useFindAndModify: false,


### PR DESCRIPTION
![create_idx_warning](https://user-images.githubusercontent.com/63060924/89805194-45c2ca80-db03-11ea-9e4e-6fab7e07be61.png)

https://mongoosejs.com/docs/deprecations.html