### PR TITLE
Add upload ID to the case data model

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -309,6 +309,9 @@ components:
               pattern: '^[a-f\d]{24}$'
             sourceUrl:
               type: string
+            uploadId:
+              type: string
+              pattern: '^[a-f\d]{24}$'
             additionalSources:
               type: array
               items:

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -310,6 +310,10 @@ components:
             sourceUrl:
               type: string
             uploadId:
+              description: >
+                The UUID of the upload in which the batch of cases including
+                this case document was entered into the G.h system. This field
+                is only populated for cases entered via automated ingestion.
               type: string
               pattern: '^[a-f\d]{24}$'
             additionalSources:

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -22,6 +22,9 @@
           "sourceUrl": {
             "bsonType": "string"
           },
+          "uploadId": {
+            "bsonType": "string"
+          },
           "additionalSources": {
             "bsonType": "array",
             "uniqueItems": true,

--- a/data-serving/data-service/src/model/case-reference.ts
+++ b/data-serving/data-service/src/model/case-reference.ts
@@ -11,6 +11,7 @@ export const caseReferenceSchema = new mongoose.Schema(
             type: String,
             required: true,
         },
+        uploadId: String,
         additionalSources: [
             {
                 sourceUrl: String,
@@ -30,6 +31,9 @@ export type CaseReferenceDocument = mongoose.Document & {
 
     /** The URL of the source of the case data at the time of ingestion. */
     sourceUrl: string;
+
+    /** The UUID of the upload by which this case was entered into the DB. */
+    uploadId: string;
 
     additionalSources: [
         {

--- a/data-serving/data-service/src/model/case-reference.ts
+++ b/data-serving/data-service/src/model/case-reference.ts
@@ -32,7 +32,13 @@ export type CaseReferenceDocument = mongoose.Document & {
     /** The URL of the source of the case data at the time of ingestion. */
     sourceUrl: string;
 
-    /** The UUID of the upload by which this case was entered into the DB. */
+    /**
+     * The UUID of the upload in which the batch of cases including this
+     * case document was entered into the DB.
+     *
+     * At present, this is only populated for cases created via automated
+     * ingestion.
+     */
     uploadId: string;
 
     additionalSources: [

--- a/data-serving/data-service/test/model/data/case-reference.full.json
+++ b/data-serving/data-service/test/model/data/case-reference.full.json
@@ -2,6 +2,7 @@
     "sourceId": "5ef8e943dfe6e00030892d58",
     "sourceEntryId": "entryId",
     "sourceUrl": "cdc.gov",
+    "uploadId": "012345678901234567890123",
     "additionalSources": [
         {
             "sourceUrl": "twitter.com/a-tweet"

--- a/data-serving/data-service/test/model/data/case-reference.minimal.json
+++ b/data-serving/data-service/test/model/data/case-reference.minimal.json
@@ -1,4 +1,5 @@
 {
     "sourceId": "5ef8e943dfe6e00030892d58",
-    "sourceUrl": "cdc.gov"
+    "sourceUrl": "cdc.gov",
+    "uploadId": "012345678901234567890123"
 }

--- a/data-serving/data-service/test/model/data/case.full.json
+++ b/data-serving/data-service/test/model/data/case.full.json
@@ -3,6 +3,7 @@
         "sourceId": "5ea86423bae6982635d2e1f8",
         "sourceEntryId": "entryId",
         "sourceUrl": "cdc.gov",
+        "uploadId": "012345678901234567890123",
         "additionalSources": [
             {
                 "sourceUrl": "twitter.com/a-tweet"
@@ -111,7 +112,9 @@
                         "longitude": -73.9740028
                     }
                 },
-                "methods": [ "Plane" ],
+                "methods": [
+                    "Plane"
+                ],
                 "purpose": "Family"
             }
         ],
@@ -148,9 +151,16 @@
         }
     },
     "transmission": {
-        "routes": [ "Vector borne" ],
-        "places": [ "Gym" ],
-        "linkedCaseIds": [ "abc", "def" ]
+        "routes": [
+            "Vector borne"
+        ],
+        "places": [
+            "Gym"
+        ],
+        "linkedCaseIds": [
+            "abc",
+            "def"
+        ]
     },
     "importedCase": {
         "ID": "xyz",

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -640,6 +640,9 @@ components:
               pattern: '^[a-f\d]{24}$'
             sourceUrl:
               type: string
+            uploadId:
+              type: string
+              pattern: '^[a-f\d]{24}$'
             additionalSources:
               type: array
               items:


### PR DESCRIPTION
Not making it required, for now. We could consider requiring this, and having it be ~unused for manual (and perhaps bulk) entry, but doesn't seem worthwhile at the moment.