### PR TITLE
Implement filtering of dates in parsing lib and add date filter columns to the UI

### DIFF
--- a/ingestion/functions/parsing/common/python/parsing_lib/input_event.json
+++ b/ingestion/functions/parsing/common/python/parsing_lib/input_event.json
@@ -2,5 +2,9 @@
     "s3Bucket": "epid-sources-raw",
     "s3Key": "5f0b9a7ead3a2b003edc0e7f/2020/07/12/2320/content.json",
     "sourceUrl": "https://foo.bar",
-    "sourceId": "5f0b9a7ead3a2b003edc0e7f"
+    "sourceId": "5f0b9a7ead3a2b003edc0e7f",
+    "dateFilter": {
+        "numDaysBeforeToday": 2,
+        "op": "EQ"
+    }
 }

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -94,6 +94,8 @@ def filter_cases_by_date(case_data, date_filter):
             return delta_days == 0
         elif op == "LT":
             return delta_days < 0
+        else:
+            raise ValueError(f'Unsupported date filter operand: {op}')
 
     return [case for case in case_data if case_is_within_range(case, cutoff_date, op)]
             

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import tempfile
 
@@ -13,6 +14,7 @@ SOURCE_URL_FIELD = "sourceUrl"
 S3_BUCKET_FIELD = "s3Bucket"
 S3_KEY_FIELD = "s3Key"
 SOURCE_ID_FIELD = "sourceId"
+DATE_FILTER_FIELD = "dateFilter"
 
 s3_client = boto3.client("s3")
 
@@ -20,13 +22,13 @@ s3_client = boto3.client("s3")
 def extract_event_fields(event):
     if any(
             field not in event
-            for field in [SOURCE_URL_FIELD, S3_BUCKET_FIELD, S3_KEY_FIELD]):
+            for field in [SOURCE_URL_FIELD, SOURCE_ID_FIELD, S3_BUCKET_FIELD, S3_KEY_FIELD]):
         error_message = (
             f"Required fields {SOURCE_URL_FIELD}; {S3_BUCKET_FIELD}; "
-            f"{S3_KEY_FIELD} not found in input event json.")
+            f"{SOURCE_ID_FIELD}; {S3_KEY_FIELD} not found in input event json.")
         print(error_message)
         raise ValueError(error_message)
-    return event[SOURCE_URL_FIELD], event[SOURCE_ID_FIELD], event[S3_BUCKET_FIELD], event[S3_KEY_FIELD]
+    return event[SOURCE_URL_FIELD], event[SOURCE_ID_FIELD], event[S3_BUCKET_FIELD], event[S3_KEY_FIELD], event.get(DATE_FILTER_FIELD, {})
 
 
 def retrieve_raw_data_file(s3_bucket, s3_key):
@@ -72,6 +74,30 @@ def obtain_api_credentials():
         print(e)
         raise e
 
+def get_today():
+    """Return today's datetime, just here for easier mocking."""
+    return datetime.datetime.today()
+
+def filter_cases_by_date(case_data, date_filter):
+    if not date_filter:
+        return case_data
+    now = get_today()
+    delta = datetime.timedelta(days=date_filter["numDaysBeforeToday"])
+    cutoff_date = now - delta
+    op = date_filter["op"]
+    def case_is_within_range(case, cutoff_date, op):
+        confirmed_event = [e for e in case["events"] if e["name"] == "confirmed"][0]
+        case_date = datetime.datetime.strptime(
+            confirmed_event["dateRange"]["start"], "%m/%d/%YZ")
+        delta_days = (case_date - cutoff_date).days
+        if op == "EQ":
+            return delta_days == 0
+        elif op == "LT":
+            return delta_days < 0
+
+    return [case for case in case_data if case_is_within_range(case, cutoff_date, op)]
+            
+
 
 def run_lambda(event, context, parsing_function):
     """
@@ -106,12 +132,13 @@ def run_lambda(event, context, parsing_function):
       https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
     """
 
-    source_url, source_id, s3_bucket, s3_key = extract_event_fields(event)
+    source_url, source_id, s3_bucket, s3_key, date_filter = extract_event_fields(event)
     raw_data_file = retrieve_raw_data_file(s3_bucket, s3_key)
     case_data = parsing_function(
         raw_data_file, source_id,
         source_url)
     api_creds = obtain_api_credentials()
+    case_data = filter_cases_by_date(case_data, date_filter)
     count_created, count_updated = write_to_server(
         case_data, api_creds)
     return {"count_created": count_created, "count_updated": count_updated}

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -229,3 +229,15 @@ def test_filter_cases_by_date_before_today(mock_today):
         [CASE_JUNE_FIFTH],
         {"numDaysBeforeToday": 3, "op": "LT"})
     assert list(cases) == [CASE_JUNE_FIFTH]
+
+
+def test_filter_cases_by_date_unsupported_op():
+    from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
+    try:
+        parsing_lib.filter_cases_by_date(
+            [CASE_JUNE_FIFTH],
+            {"numDaysBeforeToday": 3, "op": "NOPE"})
+    except ValueError as ve:
+        assert "NOPE" in str(ve)
+        return
+    assert "Should have raised a ValueError exception" == False

--- a/ingestion/functions/parsing/hongkong/input_event.json
+++ b/ingestion/functions/parsing/hongkong/input_event.json
@@ -2,5 +2,9 @@
     "s3Bucket": "epid-sources-raw",
     "s3Key": "5f311a9795e338003016593a/2020/08/10/1009/content.csv",
     "sourceUrl": "http://www.chp.gov.hk/files/misc/enhanced_sur_covid_19_eng.csv",
-    "sourceId": "5f311a9795e338003016593a"
+    "sourceId": "5f311a9795e338003016593a",
+    "dateFilter": {
+        "numDaysBeforeToday": 3,
+        "op": "EQ"
+    }
 }

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -580,6 +580,18 @@ components:
               type: string
         format:
           type: string
+        dateFilter:
+          type: object
+          properties:
+            numDaysBeforeToday:
+              type: number
+              # Must be positive as we subtract it to "today".
+              minimum: 1
+            op:
+              type: string
+              enum:
+              - EQ
+              - LT
         automation:
           type: object
           properties:

--- a/verification/curator-service/api/src/model/automation.ts
+++ b/verification/curator-service/api/src/model/automation.ts
@@ -18,7 +18,7 @@ const dateFilterSchema = new mongoose.Schema({
         enum: [
             // Only import cases from a given day.
             'EQ',
-            // Import all cases prior to a given day.
+            // Import all cases strictly prior to a given day.
             'LT',
         ],
     },

--- a/verification/curator-service/api/src/model/automation.ts
+++ b/verification/curator-service/api/src/model/automation.ts
@@ -11,24 +11,6 @@ export const automationParsingValidator = {
     message: 'At most one of parser or regexParsing may be supplied.',
 };
 
-const dateFilterSchema = new mongoose.Schema({
-    numDaysBeforeToday: Number,
-    op: {
-        type: String,
-        enum: [
-            // Only import cases from a given day.
-            'EQ',
-            // Import all cases strictly prior to a given day.
-            'LT',
-        ],
-    },
-});
-
-export type DateFilterDocument = mongoose.Document & {
-    numDaysBeforeToday: number;
-    op: string;
-};
-
 export const automationSchema = new mongoose.Schema({
     parser: parserSchema,
     regexParsing: regexParsingSchema,
@@ -36,12 +18,10 @@ export const automationSchema = new mongoose.Schema({
         type: scheduleSchema,
         required: true,
     },
-    dateFilter: dateFilterSchema,
 });
 
 export type AutomationDocument = mongoose.Document & {
     parser: ParserDocument;
     regexParsing: RegexParsingDocument;
     schedule: ScheduleDocument;
-    dateFilter: DateFilterDocument;
 };

--- a/verification/curator-service/api/src/model/date-filter.ts
+++ b/verification/curator-service/api/src/model/date-filter.ts
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+export const dateFilterSchema = new mongoose.Schema({
+    numDaysBeforeToday: Number,
+    op: {
+        type: String,
+        enum: [
+            // Only import cases from a given day.
+            'EQ',
+            // Import all cases strictly prior to a given day.
+            'LT',
+        ],
+    },
+});
+
+export type DateFilterDocument = mongoose.Document & {
+    numDaysBeforeToday: number;
+    op: string;
+};
+
+export const DateFilter = mongoose.model<DateFilterDocument>(
+    'DateFilter',
+    dateFilterSchema,
+);

--- a/verification/curator-service/api/src/model/source.ts
+++ b/verification/curator-service/api/src/model/source.ts
@@ -7,24 +7,7 @@ import { OriginDocument, originSchema } from './origin';
 
 import mongoose from 'mongoose';
 import { uploadSchema, UploadDocument } from './upload';
-
-const dateFilterSchema = new mongoose.Schema({
-    numDaysBeforeToday: Number,
-    op: {
-        type: String,
-        enum: [
-            // Only import cases from a given day.
-            'EQ',
-            // Import all cases strictly prior to a given day.
-            'LT',
-        ],
-    },
-});
-
-export type DateFilterDocument = mongoose.Document & {
-    numDaysBeforeToday: number;
-    op: string;
-};
+import { dateFilterSchema, DateFilterDocument } from './date-filter';
 
 const sourceSchema = new mongoose.Schema({
     name: {

--- a/verification/curator-service/api/src/model/source.ts
+++ b/verification/curator-service/api/src/model/source.ts
@@ -8,6 +8,24 @@ import { OriginDocument, originSchema } from './origin';
 import mongoose from 'mongoose';
 import { uploadSchema, UploadDocument } from './upload';
 
+const dateFilterSchema = new mongoose.Schema({
+    numDaysBeforeToday: Number,
+    op: {
+        type: String,
+        enum: [
+            // Only import cases from a given day.
+            'EQ',
+            // Import all cases strictly prior to a given day.
+            'LT',
+        ],
+    },
+});
+
+export type DateFilterDocument = mongoose.Document & {
+    numDaysBeforeToday: number;
+    op: string;
+};
+
 const sourceSchema = new mongoose.Schema({
     name: {
         type: String,
@@ -23,6 +41,7 @@ const sourceSchema = new mongoose.Schema({
         validate: automationParsingValidator,
     },
     uploads: [uploadSchema],
+    dateFilter: dateFilterSchema,
 });
 
 sourceSchema.methods.toAwsStatementId = function (): string {
@@ -47,6 +66,7 @@ export type SourceDocument = mongoose.Document & {
     format: string;
     automation: AutomationDocument;
     uploads: [UploadDocument];
+    dateFilter: DateFilterDocument;
 
     toAwsStatementId(): string;
     toAwsRuleDescription(): string;

--- a/verification/curator-service/api/test/model/data/automation.full.json
+++ b/verification/curator-service/api/test/model/data/automation.full.json
@@ -5,9 +5,5 @@
     "schedule": {
         "awsRuleArn": "arn:aws:events:region:id:rule/name",
         "awsScheduleExpression": "cron(0 10 * * ? *)"
-    },
-    "dateFilter": {
-        "numDaysBeforeToday": 3,
-        "op": "EQ"
     }
 }

--- a/verification/curator-service/api/test/model/data/date-filter.full.json
+++ b/verification/curator-service/api/test/model/data/date-filter.full.json
@@ -1,0 +1,4 @@
+{
+    "numDaysBeforeToday": 3,
+    "op": "EQ"
+}

--- a/verification/curator-service/api/test/model/data/source.full.json
+++ b/verification/curator-service/api/test/model/data/source.full.json
@@ -24,5 +24,9 @@
             },
             "created": "2020-01-13"
         }
-    ]
+    ],
+    "dateFilter": {
+        "numDaysBeforeToday": 3,
+        "op": "EQ"
+    }
 }

--- a/verification/curator-service/api/test/model/date-filter.test.ts
+++ b/verification/curator-service/api/test/model/date-filter.test.ts
@@ -1,0 +1,9 @@
+import { DateFilter } from '../../src/model/date-filter';
+import fullModel from './data/date-filter.full.json';
+
+describe('DateFilter schema', () => {
+    it('should build a valid date filter', () => {
+        const errors = new DateFilter(fullModel).validateSync();
+        expect(errors).toBeUndefined();
+    });
+});

--- a/verification/curator-service/ui/cypress/integration/components/SourceTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/SourceTableTest.spec.ts
@@ -10,13 +10,23 @@ describe('Sources table', function () {
         cy.contains('Example source').should('not.exist');
 
         cy.get('button[title="Add"]').click();
-        cy.get('input[placeholder="Name"]').clear().type('Example source');
-        cy.get('input[placeholder="URL"]').clear().type('www.example.com');
+        cy.get('input[placeholder="Name"]').type('Example source');
+        cy.get('input[placeholder="URL"]').type('www.example.com');
         cy.get('div[data-testid="format-select"]').click();
         cy.contains('li', 'JSON').click();
+        /* This doesn't work and I HAVE NO IDEA WHY PLEASE HELP.
+        cy.get('div[data-testid="op-select"]').scrollIntoView().click();
+        cy.contains('li', 'EQ').click();
+        cy.get('input[placeholder="Date filter num days before today"]')
+            .scrollIntoView()
+            .type('42');
+        */
+
         cy.get('button[title="Save"]').click();
 
         cy.contains('Example source');
+        cy.contains('www.example.com');
+        cy.contains('JSON');
     });
 
     it('Can edit a source', function () {

--- a/verification/curator-service/ui/src/components/SourceTable.test.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.test.tsx
@@ -42,6 +42,10 @@ it('loads and displays sources', async () => {
                     awsScheduleExpression: awsScheduleExpression,
                 },
             },
+            dateFilter: {
+                numDaysBeforeToday: 666,
+                op: 'EQ',
+            },
         },
     ];
     const axiosResponse = {
@@ -71,6 +75,12 @@ it('loads and displays sources', async () => {
     expect(await findByText(new RegExp(format))).toBeInTheDocument();
     expect(await findByText(new RegExp(awsLambdaArn))).toBeInTheDocument();
     expect(await findByText(new RegExp(awsRuleArn))).toBeInTheDocument();
+    expect(
+        await findByText(new RegExp(sources[0].dateFilter.op)),
+    ).toBeInTheDocument();
+    expect(
+        await findByText(String(sources[0].dateFilter.numDaysBeforeToday)),
+    ).toBeInTheDocument();
     expect(
         await findByText(
             new RegExp(awsScheduleExpression.replace(/(?=[()])/g, '\\')),


### PR DESCRIPTION
For #744 

Wanted to do this in two PRs but I ended up merging the UI in here by accident sorry about that :( I hope you don't mind reviewing this whole together (might make more sense actually).

- The UI bit is adding 2 columns in the sources table, the cypress tests refuse to pass I have no idea why I tried everything really... but it seems that one can't select the last column whatever I do to it (I tried moving the JSON/CSV bit there and it fails as well so it seems position-related...). I verified that one could add/edit/remove date filter options locally though.
- The API bit is moving the dateFilter in the source model instead of automation as we also want to be able to run on specific dates without being automated (for testing for example and before setting up automation).