### PR TITLE
Fix typo in event param and handle dates consistently

### DIFF
--- a/ingestion/functions/parsing/ch_zurich/input_event.json
+++ b/ingestion/functions/parsing/ch_zurich/input_event.json
@@ -1,6 +1,10 @@
 {
     "s3Bucket": "epid-sources-raw",
-    "s3Key": "5f2acbe8df34a7051c8b01f4/2020/08/05/1806/content.csv",
+    "s3Key": "5f32be3fe3f3ef002e849307/2020/08/11/1552/content.csv",
     "sourceUrl": "https://github.com/openZH/covid_19/blob/master/fallzahlen_kanton_alter_geschlecht_csv/COVID19_Fallzahlen_Kanton_ZH_alter_geschlecht.csv",
-    "sourceId": "5f2acbe8df34a7051c8b01f4"
+    "sourceId": "5f32be3fe3f3ef002e849307",
+    "dateFilter": {
+        "numDaysBeforeToday": 3,
+        "op": "LT"
+    }
 }

--- a/ingestion/functions/parsing/ch_zurich/zurich.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich.py
@@ -31,6 +31,16 @@ _GENDER_INDEX = 3
 _CONFIRMED_INDEX = 4
 _SOURCE_INDEX = 6
 
+def convert_date(raw_date):
+    """
+    Convert raw date field into a value interpretable by the dataserver.
+
+    The date is listed in dd-mm-YYYY format, but the date filtering API
+    expects mm/dd/YYYYZ format.
+    """
+    date = datetime.strptime(raw_date, "%Y-%m-%d")
+    return date.strftime("%m/%d/%YZ")
+
 def convert_gender(raw_gender: str):
     if raw_gender.upper() == "M":
         return "Male"
@@ -79,8 +89,8 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                             "name": "confirmed",
                             "dateRange":
                             {
-                                "start": row[_DATE_INDEX],
-                                "end": row[_DATE_INDEX],
+                                "start": convert_date(row[_DATE_INDEX]),
+                                "end": convert_date(row[_DATE_INDEX]),
                             },
                         },
                     ],

--- a/ingestion/functions/parsing/ch_zurich/zurich.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich.py
@@ -35,7 +35,7 @@ def convert_date(raw_date):
     """
     Convert raw date field into a value interpretable by the dataserver.
 
-    The date is listed in dd-mm-YYYY format, but the date filtering API
+    The date is listed in YYYY-mm-dd format, but the date filtering API
     expects mm/dd/YYYYZ format.
     """
     date = datetime.strptime(raw_date, "%Y-%m-%d")

--- a/ingestion/functions/parsing/ch_zurich/zurich_test.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich_test.py
@@ -32,8 +32,8 @@ _PARSED_CASE = (
                 "name": "confirmed",
                 "dateRange":
                         {
-                            "start": "2020-02-27",
-                            "end": "2020-02-27",
+                            "start": "02/27/2020Z",
+                            "end": "02/27/2020Z",
                         },
             },
         ],

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -20,6 +20,7 @@ s3_client = boto3.client("s3")
 
 
 def extract_event_fields(event):
+    print('Extracting fields from event', event)
     if any(
             field not in event
             for field in [SOURCE_URL_FIELD, SOURCE_ID_FIELD, S3_BUCKET_FIELD, S3_KEY_FIELD]):

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -117,7 +117,7 @@ def invoke_parser(parser_arn, source_id, s3_object_key, source_url, date_filter)
         "sourceId": source_id,
         "s3Key": s3_object_key,
         "sourceUrl": source_url,
-        "date_filter": date_filter,
+        "dateFilter": date_filter,
     }
     print(f"Invoking parser (ARN: {parser_arn}")
     response = lambda_client.invoke(


### PR DESCRIPTION
The dates filtering code expects the dates to be formatted in a certain way, the zurich parser wasn't producing them accordingly (they were understandable by JS on the backend but not by the python code).

Also logs received event that should help debugging.

Confirmed that the date filtering now works as expected.