### PR TITLE
Move table actions to spec-ed locations

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -48,7 +48,7 @@ describe('Bulk upload form', function () {
         );
         cy.server();
         cy.route('get', '/api/cases/*').as('viewCase');
-        cy.get('[title="View this case details"]').click({ force: true });
+        cy.contains('td', 'Male').click({ force: true });
         cy.wait('@viewCase');
 
         // Case data

--- a/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
@@ -191,7 +191,8 @@ describe('Curator', function () {
             cy.visit('/cases');
 
             // Edit the case.
-            cy.get('button[title="Edit this case"]').click({ force: true });
+            cy.get('button[data-testid="row menu"]').click();
+            cy.contains('li', 'Edit').click();
 
             // Everything should be there.
             // Source.
@@ -311,9 +312,7 @@ describe('Curator', function () {
             cy.contains('Asian');
 
             // View full details about the case
-            cy.get('button[title="View this case details"]').click({
-                force: true,
-            });
+            cy.contains('td', 'Asian').click({ force: true });
             // Case data.
             cy.contains('www.example.com');
             cy.contains('testSourceEntryID123');

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -38,7 +38,8 @@ describe('Linelist table', function () {
         cy.visit('/cases');
         cy.contains('some notes');
         cy.contains('Edit case').should('not.exist');
-        cy.get('button[title="Edit this case"]').click({ force: true });
+        cy.get('button[data-testid="row menu"]').click();
+        cy.contains('li', 'Edit').click();
         cy.contains('Edit case');
         cy.get('button[aria-label="close overlay"').click();
         cy.contains('Edit case').should('not.exist');
@@ -53,7 +54,7 @@ describe('Linelist table', function () {
         cy.visit('/cases');
         cy.contains('some notes');
         cy.contains('View case').should('not.exist');
-        cy.get('button[title="View this case details"]').click({ force: true });
+        cy.contains('td', 'France').click({ force: true });
         cy.contains('View case');
         cy.get('button[aria-label="close overlay"').click();
         cy.contains('View case').should('not.exist');
@@ -68,8 +69,8 @@ describe('Linelist table', function () {
         cy.visit('/cases');
         cy.contains('some notes');
 
-        cy.get('button[title="Delete"]').click({ force: true });
-        cy.get('button[title="Save"]').click({ force: true });
+        cy.get('button[data-testid="row menu"]').click();
+        cy.contains('li', 'Delete').click();
 
         cy.contains('some notes').should('not.exist');
     });

--- a/verification/curator-service/ui/src/components/AppModal.tsx
+++ b/verification/curator-service/ui/src/components/AppModal.tsx
@@ -23,9 +23,6 @@ const styles = (theme: Theme) =>
             // Remainder of the screen width accounting for left shift
             width: 'calc(100vw - 15%)',
         },
-        appBar: {
-            background: 'white',
-        },
         container: {
             height: 'calc(100% - 80px)',
             overflow: 'auto',
@@ -46,7 +43,7 @@ class AppModal extends React.Component<Props, {}> {
             <>
                 <Modal open={true}>
                     <div className={classes.modalContents}>
-                        <AppBar position="relative" className={classes.appBar}>
+                        <AppBar position="relative">
                             <Toolbar>
                                 <IconButton
                                     color="inherit"

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -141,7 +141,7 @@ it('API errors are displayed', async () => {
     };
     mockedAxios.get.mockResolvedValueOnce(axiosResponse);
 
-    const { getByText, findByText } = render(
+    const { getByText, findByText, getByTestId } = render(
         <MemoryRouter>
             <LinelistTable user={curator} />
         </MemoryRouter>,
@@ -153,10 +153,8 @@ it('API errors are displayed', async () => {
     // Throw error on delete request.
     mockedAxios.delete.mockRejectedValueOnce(new Error('Request failed'));
 
-    const deleteButton = getByText(/delete_outline/);
-    fireEvent.click(deleteButton);
-    const confirmButton = getByText(/check/);
-    fireEvent.click(confirmButton);
+    fireEvent.click(getByTestId(/row menu/));
+    fireEvent.click(getByText(/Delete/));
     expect(mockedAxios.delete).toHaveBeenCalledTimes(1);
 
     const error = await findByText('Error: Request failed');
@@ -202,7 +200,7 @@ it('can delete a row', async () => {
     mockedAxios.get.mockResolvedValueOnce(axiosGetResponse);
 
     // Load table
-    const { getByText, findByText } = render(
+    const { getByText, findByText, getByTestId } = render(
         <MemoryRouter>
             <LinelistTable user={curator} />
         </MemoryRouter>,
@@ -235,10 +233,8 @@ it('can delete a row', async () => {
     mockedAxios.get.mockResolvedValueOnce(axiosGetAfterDeleteResponse);
     mockedAxios.delete.mockResolvedValueOnce(axiosDeleteResponse);
 
-    const deleteButton = getByText(/delete_outline/);
-    fireEvent.click(deleteButton);
-    const confirmButton = getByText(/check/);
-    fireEvent.click(confirmButton);
+    fireEvent.click(getByTestId(/row menu/));
+    fireEvent.click(getByText(/Delete/));
     expect(mockedAxios.delete).toHaveBeenCalledTimes(1);
     expect(mockedAxios.delete).toHaveBeenCalledWith(
         '/api/cases/' + cases[0]._id,


### PR DESCRIPTION
Moves edit and delete within a three-dot menu. The details view can be accessed by clicking anywhere on the row. 

I don't think the three-dot menu can be moved to the left of the checkboxes until https://github.com/mbrn/material-table/issues/2317 is fixed.

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/30459667/90160905-491bb780-dd8a-11ea-86eb-b296f5f4e6f4.gif)

