### PR TITLE
Make error checking (type-) safer in parsing/retrieval.

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -43,13 +43,13 @@ def create_upload_record(source_id, headers):
     res = requests.post(post_api_url,
                         json={"status": "IN_PROGRESS", "summary": {}},
                         headers=headers)
-    res_json = res.json()
-    if res.status_code != 201:
-        e = RuntimeError(
-            f'Error creating upload record, status={res.status_code}, response={res_json}')
-        complete_with_error(e)
-    # TODO: Look for "errors" in res_json and handle them in some way.
-    return res_json["_id"]
+    if res and res.status_code == 201:
+        res_json = res.json()
+        # TODO: Look for "errors" in res_json and handle them in some way.
+        return res_json["_id"]
+    e = RuntimeError(
+        f'Error creating upload record, status={res.status_code}, response={res.text}')
+    complete_with_error(e)
 
 
 # TODO: Move this into common_lib.py after that's merged.
@@ -66,11 +66,10 @@ def finalize_upload(
     res = requests.put(put_api_url,
                        json=update,
                        headers=headers)
-    res_json = res.json()
     # TODO: Look for "errors" in res_json and handle them in some way.
-    if res.status_code != 200:
+    if not res or res.status_code != 200:
         e = RuntimeError(
-            f'Error updating upload record, status={res.status_code}, response={res_json}')
+            f'Error updating upload record, status={res.status_code}, response={res.text}')
         complete_with_error(e, UploadError.INTERNAL_ERROR,
                             source_id, upload_id, headers)
 


### PR DESCRIPTION
Addresses two issues:

1. If we don't receive a 2xx from the server, we can't be sure the response contains json (and `res.json()` will fail with a decoding error).
2. If something goes _truly_ wrong in `requests.$verb([...])`, it's possible `r/res` will be None.