### PR TITLE
Use cypress action to run on firefox and chrome in parallel

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,11 +26,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build stack
         run: docker-compose -f dev/docker-compose.yml -f dev/docker-compose.ci.yml up --build -d -V
-      - name: Cypress integration tests
-        run: |
-          npm ci
-          npm run cypress-run
-        working-directory: verification/curator-service/ui
+      - uses: cypress-io/github-action@v2
+        with:
+          working-directory: verification/curator-service/ui
+          wait-on: 'http://localhost:3002'
+          wait-on-timeout: 300
         env:
           CI: true
       # Screenshots are only available on failures.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,6 +22,11 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        browser: ["chrome", "firefox"]
+    name: Cypress tests on v${{ matrix.browser }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Build stack
@@ -29,6 +34,7 @@ jobs:
       - uses: cypress-io/github-action@v2
         with:
           working-directory: verification/curator-service/ui
+          browser: ${{ matrix.browser }}
           wait-on: 'http://localhost:3002'
           wait-on-timeout: 300
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         browser: ["chrome", "firefox"]
-    name: Cypress tests on v${{ matrix.browser }}
+    name: Cypress tests on ${{ matrix.browser }}
 
     steps:
       - uses: actions/checkout@v2

--- a/verification/curator-service/ui/package.json
+++ b/verification/curator-service/ui/package.json
@@ -64,7 +64,9 @@
     "test-silent": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
     "cypress-open": "cypress open",
-    "cypress-run": "cypress run"
+    "cypress-run": "cypress run",
+    "cypress-run-ff": "cypress run --browser firefox",
+    "cypress-run-edge": "cypress run --browser edge"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Fixes #776 

Haven't looked into edge yet, it's not bundled with ubuntu by default (figures...) so we'd need to spin a windows VM, will look into that next.