### PR TITLE
Fix bug with csv format command in export_data.sh

### DIFF
--- a/data-serving/scripts/export-data/export_data.sh
+++ b/data-serving/scripts/export-data/export_data.sh
@@ -44,19 +44,13 @@ function export_data() {
     output_file="$collection.$output_format"
     print "Exporting data to $output_file"
 
-    extra_flags=""
-    if [[ $output_format == 'json' ]]; then
-        # For exporting valid JSON.
-        extra_flags='--jsonArray'
-    fi
-
     mongoexport \
         --uri="$mongodb_connection_string" \
         --collection="$collection" \
         --fields="$fields" \
         --type="$output_format" \
         --out="$output_file" \
-        "$extra_flags"
+        --jsonArray
 }
 
 # Establish run order


### PR DESCRIPTION
My b-- introduced a bug in #806 that caused the workflow to fail on CSV (that's what I get for only testing with JSON)

Apparently the CSV export doesn't mind an extra --jsonArray flag, but it *does* mind an empty string.