### PR TITLE
remove reserved env var override

### DIFF
--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -32,9 +32,6 @@ Resources:
         Variables:
           SOURCE_API_URL:
             Ref: SourceApiUrl
-          # Workaround for a bug with the existing SAM CLI 1.0 Docker images.
-          # Re: https://github.com/awslabs/aws-sam-cli/issues/2135
-          AWS_SESSION_TOKEN: ""
   ParsingLibLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:
@@ -82,9 +79,6 @@ Resources:
         Variables:
           SOURCE_API_URL:
             Ref: SourceApiUrl
-          # Workaround for a bug with the existing SAM CLI 1.0 Docker images.
-          # Re: https://github.com/awslabs/aws-sam-cli/issues/2135
-          AWS_SESSION_TOKEN: ""
   HongKongParsingFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
@@ -104,9 +98,6 @@ Resources:
         Variables:
           SOURCE_API_URL:
             Ref: SourceApiUrl
-          # Workaround for a bug with the existing SAM CLI 1.0 Docker images.
-          # Re: https://github.com/awslabs/aws-sam-cli/issues/2135
-          AWS_SESSION_TOKEN: ""
   CHZurichParsingFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
@@ -126,9 +117,6 @@ Resources:
         Variables:
           SOURCE_API_URL:
             Ref: SourceApiUrl
-          # Workaround for a bug with the existing SAM CLI 1.0 Docker images.
-          # Re: https://github.com/awslabs/aws-sam-cli/issues/2135
-          AWS_SESSION_TOKEN: ""
 
 # Declare values that can be imported to other CloudFormation stacks, or should
 # be made easily visible on the console.


### PR DESCRIPTION
For #810 

Deploy script [fails](https://github.com/globaldothealth/list/runs/997734463?check_suite_focus=true) with 
```
Lambda was unable to   
                                                                           configure your         
                                                                           environment variables  
                                                                           because the            
                                                                           environment variables  
                                                                           you have provided      
                                                                           contains reserved keys 
                                                                           that are currently not 
                                                                           supported for          
                                                                           modification. Reserved 
                                                                           keys used in this      
                                                                           request:               
                                                                           AWS_SESSION_TOKEN
```

Cf. https://seed.run/docs/serverless-errors/lambda-was-unable-to-configure-your-environment-variables.html

I removed the ovverride from the template.yaml and I could run the functions locally just fine.