### PR TITLE
Use the sam CLI, now installed by default in action images, to sam deploy pushes to main

### DIFF
--- a/.github/workflows/ingestion-aws-sam-deploy.yml
+++ b/.github/workflows/ingestion-aws-sam-deploy.yml
@@ -6,24 +6,28 @@ on:
     paths:
     - '.github/workflows/ingestion-aws-sam-deploy.yml'
     - 'ingestion/functions/**'
+  # Temporary, for testing.
+  pull_request:
+    branches: [main]
+    paths:
+    - '.github/workflows/ingestion-aws-sam-build.yml'
 
 jobs:
-  deploy:
+  sam-deploy:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ingestion/functions
     steps:
     - uses: actions/checkout@v2
-    - name: sam build
-      uses: youyo/aws-sam-action/python3.8@master
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
       with:
-        sam_command: build -t ingestion/functions/template.yaml
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: us-east-1
-    - name: sam deploy
-      uses: youyo/aws-sam-action/python3.8@master
-      with:
-        sam_command: 'deploy -t ingestion/functions/template.yaml --no-confirm-changeset --no-fail-on-empty-changeset'
+        python-version: 3.8
+    - name: sam build and deploy
+      run: |
+        sam build
+        sam deploy
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ingestion-aws-sam-deploy.yml
+++ b/.github/workflows/ingestion-aws-sam-deploy.yml
@@ -27,7 +27,7 @@ jobs:
     - name: sam build and deploy
       run: |
         sam build
-        sam deploy
+        sam deploy --no-confirm-changeset --no-fail-on-empty-changeset
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ingestion-aws-sam-deploy.yml
+++ b/.github/workflows/ingestion-aws-sam-deploy.yml
@@ -6,11 +6,6 @@ on:
     paths:
     - '.github/workflows/ingestion-aws-sam-deploy.yml'
     - 'ingestion/functions/**'
-  # Temporary, for testing.
-  pull_request:
-    branches: [main]
-    paths:
-    - '.github/workflows/ingestion-aws-sam-deploy.yml'
 
 jobs:
   sam-deploy:

--- a/.github/workflows/ingestion-aws-sam-deploy.yml
+++ b/.github/workflows/ingestion-aws-sam-deploy.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-    - '.github/workflows/ingestion-aws-sam-build.yml'
+    - '.github/workflows/ingestion-aws-sam-deploy.yml'
 
 jobs:
   sam-deploy:


### PR DESCRIPTION
Apologies for any commit churn. Not feasible to test this locally with `act`.

(Checks aren't run on this final commit, since it isn't against `main`, but you can view previous successful runs in the Checks tab.)