### PR TITLE
bring back timeouts of lambdas

### DIFF
--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -24,7 +24,8 @@ Resources:
       Policies:
         - AWSLambdaFullAccess
         - S3WritePolicy:
-            BucketName: !Ref RawSourcesBucket
+          BucketName: !Ref RawSourcesBucket
+      Timeout: 300
       Layers:
         - !Ref CommonLibLayer
       Environment:
@@ -70,6 +71,7 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
+      Timeout: 300
       Layers:
         - !Ref ParsingLibLayer
         - !Ref CommonLibLayer
@@ -95,6 +97,7 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
+      Timeout: 300
       Layers:
         - !Ref ParsingLibLayer
         - !Ref CommonLibLayer
@@ -113,6 +116,7 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
+      Timeout: 300
       Layers:
         - !Ref ParsingLibLayer
         - !Ref CommonLibLayer


### PR DESCRIPTION
I removed the timeout param in https://github.com/globaldothealth/list/pull/827/files  but it turns out the default is 3s which is not enough to do anything in our case. Using the max value possible instead (5min)