### PR TITLE
Switch dates to UTC before submitting

### DIFF
--- a/verification/curator-service/ui/src/components/CaseForm.tsx
+++ b/verification/curator-service/ui/src/components/CaseForm.tsx
@@ -32,6 +32,7 @@ import { cloneDeep } from 'lodash';
 import { hasKey } from './Utils';
 import { makeStyles } from '@material-ui/core';
 import shortId from 'shortid';
+import { toUTCDate } from './util/date';
 import { useHistory } from 'react-router-dom';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
@@ -292,6 +293,12 @@ export default function CaseForm(props: Props): JSX.Element {
                     delete travel.dateRange.end;
                 }
             }
+            if (travel.dateRange?.start) {
+                travel.dateRange.start = toUTCDate(travel.dateRange.start);
+            }
+            if (travel.dateRange?.end) {
+                travel.dateRange.end = toUTCDate(travel.dateRange.end);
+            }
             if (travel.purpose === 'Unknown') {
                 travel.purpose = undefined;
             }
@@ -305,6 +312,11 @@ export default function CaseForm(props: Props): JSX.Element {
         const filteredGenomeSequences = cloneDeep(genomeSequences);
         filteredGenomeSequences?.forEach((genomeSequence) => {
             delete genomeSequence.reactId;
+            if (genomeSequence.sampleCollectionDate) {
+                genomeSequence.sampleCollectionDate = toUTCDate(
+                    genomeSequence.sampleCollectionDate,
+                );
+            }
         });
         return filteredGenomeSequences;
     };
@@ -392,8 +404,8 @@ export default function CaseForm(props: Props): JSX.Element {
                         name: elem.name,
                         dateRange: elem.dates
                             ? {
-                                  start: elem.dates,
-                                  end: elem.dates,
+                                  start: toUTCDate(elem.dates),
+                                  end: toUTCDate(elem.dates),
                               }
                             : undefined,
                         value: unknownOrEmptyToUndefined(elem.value),

--- a/verification/curator-service/ui/src/components/util/date.tsx
+++ b/verification/curator-service/ui/src/components/util/date.tsx
@@ -7,3 +7,16 @@ export default function renderDate(date: string | Date | null): string {
         date.getUTCMonth() + 1
     }-${date.getUTCDate()}`;
 }
+
+// Changes the date to be in UTC while maintaining the current date values
+export function toUTCDate(dateString: string): string {
+    const date = new Date(dateString);
+    // The datepicker sometimes returns the date at the
+    // user's current time and timezone. We need to convert
+    // it to a UTC date.
+    // https://github.com/mui-org/material-ui-pickers/issues/1348
+    const utcDate = new Date(
+        Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+    );
+    return utcDate.toString();
+}


### PR DESCRIPTION
The datepicker returns dates in the local timezone, which can then show up as the wrong date in UTC. So here we convert all dates to UTC (maintaining the current date values) before submitting.