### PR TITLE
Format source URLs with strftime

### DIFF
--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -176,6 +176,12 @@ To accomodate for that, here is the procedure to write a parser that only import
 
 That parser will now import a day worth of data with a lag of 3 days, this delay is deemed is acceptable given the inability to dedupe cases.
 
+### Handling sources with unstable URLs
+
+If a source has a time-based URL scheme you can use standard Python [date formatting parameters](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) in the source URL and those will be automatically applied when retrieving the source content.
+
+For example if a source publishes its data every day at a URL like `https://source.com/data/year-month-day.json` you can set the source URL to `https://source.com/data/%Y-%m-%d.json` and it will fetch the URL `https://source.com/data/2020-04-20.json` on the 4th of April 2020 for example.
+
 ## Parsers
 
 You can find a list of issues/FR for parsers using the [importer tag](https://github.com/globaldothealth/list/issues?q=is%3Aopen+is%3Aissue+label%3AImporter).

--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -180,7 +180,7 @@ That parser will now import a day worth of data with a lag of 3 days, this delay
 
 If a source has a time-based URL scheme you can use standard Python [date formatting parameters](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) in the source URL and those will be automatically applied when retrieving the source content.
 
-For example if a source publishes its data every day at a URL like `https://source.com/data/year-month-day.json` you can set the source URL to `https://source.com/data/%Y-%m-%d.json` and it will fetch the URL `https://source.com/data/2020-04-20.json` on the 4th of April 2020 for example.
+For example if a source publishes its data every day at a URL like `https://source.com/data/year-month-day.json` you can set the source URL to `https://source.com/data/%Y-%m-%d.json` and it will fetch the URL `https://source.com/data/2020-04-20.json` on the 4th of April 2020.
 
 ## Parsers
 

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -206,6 +206,17 @@ def invoke_parser(
         complete_with_error(e, UploadError.INTERNAL_ERROR,
                             source_id, upload_id, api_headers)
 
+def get_today():
+    """Return today's datetime, just here for easier mocking."""
+    return datetime.today()
+
+def format_source_url(url: str) -> str:
+    """
+    Formats the given url with the date formatting params contained in it if any.
+    Cf. https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+    """
+    return get_today().strftime(url)
+
 def lambda_handler(event, context):
     """Global ingestion retrieval function.
 
@@ -235,6 +246,7 @@ def lambda_handler(event, context):
     upload_id = create_upload_record(source_id, auth_headers)
     url, source_format, parser_arn, date_filter = get_source_details(
         source_id, upload_id, auth_headers)
+    url = format_source_url(url)
     file_name, s3_object_key = retrieve_content(
         source_id, upload_id, url, source_format, auth_headers)
     upload_to_s3(file_name, s3_object_key, source_id, upload_id, auth_headers)

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -45,11 +45,6 @@ def test_format_url_leaves_unchanged_if_no_format_params():
     url = "http://foo.bar"
     assert retrieval.format_source_url(url) == url
 
-def test_format_url_removes_non_time_format_param():
-    from retrieval import retrieval  # Import locally to avoid superseding mock
-    url = "http://foo.bar/%(nope"
-    assert retrieval.format_source_url(url) == "http://foo.bar/(nope"
-
 @patch('retrieval.retrieval.get_today')
 def test_format_url(mock_today):
     from retrieval import retrieval  # Import locally to avoid superseding mock

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -1,11 +1,11 @@
 import boto3
+import datetime
 import json
 import os
 import pytest
 
 from moto import mock_s3
-from unittest.mock import MagicMock
-
+from unittest.mock import MagicMock, patch
 
 @pytest.fixture()
 def aws_credentials():
@@ -40,6 +40,22 @@ def invalid_event():
     with open(file_path) as event_file:
         return json.load(event_file)
 
+def test_format_url_leaves_unchanged_if_no_format_params():
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    url = "http://foo.bar"
+    assert retrieval.format_source_url(url) == url
+
+def test_format_url_removes_non_time_format_param():
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    url = "http://foo.bar/%(nope"
+    assert retrieval.format_source_url(url) == "http://foo.bar/(nope"
+
+@patch('retrieval.retrieval.get_today')
+def test_format_url(mock_today):
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    mock_today.return_value = datetime.datetime(2020, 6, 8)
+    url = "http://foo.bar/%Y-%m-%d.json"
+    assert retrieval.format_source_url(url) == "http://foo.bar/2020-06-08.json"
 
 @mock_s3
 def test_lambda_handler_e2e(valid_event, requests_mock, s3):


### PR DESCRIPTION
We could also abstract python away and provide our own $YEAR, $MONTH, $DAY params instead but I am not sure the added indirection is worth doing just yet.

Fixes #831