### PR TITLE
remove unused url filtering in source controller API

### DIFF
--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -56,14 +56,6 @@ paths:
             minimum: 1
             maximum: 100
             default: 10
-        - name: url
-          in: query
-          description: Origin URL substring on which to filter the result set
-          required: false
-          allowEmptyValue: true
-          allowReserved: true
-          schema:
-            type: string
         - name: access_token
           in: query
           required: false

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -28,14 +28,9 @@ export default class SourcesController {
             res.status(422).json('limit must be > 0');
             return;
         }
-        const filter = req.query.url
-            ? {
-                  'origin.url': new RegExp(req.query.url as string, 'i'),
-              }
-            : {};
         try {
             const [docs, total] = await Promise.all([
-                Source.find(filter)
+                Source.find()
                     .skip(limit * (page - 1))
                     .limit(limit + 1),
                 Source.countDocuments({}),

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -79,27 +79,6 @@ describe('GET', () => {
         // No continuation expected.
         expect(res.body.nextPage).toBeUndefined();
     });
-    it('list should filter by url if supplied', async () => {
-        const relevantSource = await new Source({
-            name: 'test-source',
-            origin: { url: 'http://foo.bar' },
-            format: 'JSON',
-        }).save();
-        await new Source({
-            name: 'test-source',
-            origin: { url: 'http://bar.baz' },
-            format: 'JSON',
-        }).save();
-
-        const res = await curatorRequest
-            .get('/api/sources?url=foo')
-            .expect(200)
-            .expect('Content-Type', /json/);
-
-        expect(await relevantSource.collection.countDocuments()).toEqual(2);
-        expect(res.body.sources).toHaveLength(1);
-        expect(res.body.sources[0]._id).toEqual(relevantSource.id);
-    });
     it('list should paginate', async () => {
         for (const i of Array.from(Array(15).keys())) {
             await new Source({


### PR DESCRIPTION
This seems unused afaict, we used to have columns filtering in the table but disabled it, if we ever need this we should switch to the same UI/full text search/keyword search pattern as for the linelist imo.