### PR TITLE
Remove conflicting packages during mongo install in workflows

### DIFF
--- a/.github/workflows/case-data-export-prod.yml
+++ b/.github/workflows/case-data-export-prod.yml
@@ -25,8 +25,9 @@ jobs:
           wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA 656408E390CFB1F5
+          sudo dpkg --purge mongodb-org-database-tools-extra
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
+          sudo apt-get install -f -y --allow-downgrades mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
 
       - name: Create gzip of CSV and JSON prod case data
         run: |

--- a/.github/workflows/case-data-update-dev.yml
+++ b/.github/workflows/case-data-update-dev.yml
@@ -21,8 +21,9 @@ jobs:
           wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
           echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5DC22404A6F9F1CA 656408E390CFB1F5
+          sudo dpkg --purge mongodb-org-database-tools-extra
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
+          sudo apt-get install -f -y --allow-downgrades mongodb-org=4.2.6 mongodb-org-server=4.2.6 mongodb-org-shell=4.2.6 mongodb-org-mongos=4.2.6 mongodb-org-tools=4.2.6 libcurl3
 
       - name: Set up Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
Workflows have been failing because MongoDB 4.4 split a package into to; 4.4 is installed by default on these images but we need 4.2

Failed workflow: https://github.com/globaldothealth/list/runs/1020205741?check_suite_focus=true

Error:
```
dpkg: error processing archive /var/cache/apt/archives/mongodb-org-tools_4.2.6_amd64.deb (--unpack):
 trying to overwrite '/usr/bin/install_compass', which is also in package mongodb-org-database-tools-extra 4.4.0
E: Sub-process /usr/bin/dpkg returned an error code (1)
##[error]Process completed with exit code 100.
```