### PR TITLE
fix search bar ui

### DIFF
--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -101,6 +101,10 @@ const searchBarStyles = makeStyles((theme: Theme) => ({
         display: 'flex',
         alignItems: 'center',
     },
+    tooltip: {
+        marginLeft: theme.spacing(1),
+        marginRight: theme.spacing(1),
+    },
 }));
 
 function SearchBar(props: {
@@ -162,6 +166,7 @@ function SearchBar(props: {
                 )}
             />
             <HtmlTooltip
+                className={classes.tooltip}
                 title={
                     <React.Fragment>
                         <h4>Search syntax</h4>

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -7,7 +7,6 @@ import {
     Tooltip,
     makeStyles,
     withStyles,
-    Grid,
 } from '@material-ui/core';
 import { Case, VerificationStatus } from './Case';
 import MaterialTable, { QueryResult } from 'material-table';
@@ -23,7 +22,6 @@ import { Link } from 'react-router-dom';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import MuiAlert from '@material-ui/lab/Alert';
 import Paper from '@material-ui/core/Paper';
-import SearchIcon from '@material-ui/icons/SearchOutlined';
 import TextField from '@material-ui/core/TextField';
 import User from './User';
 import VerificationStatusHeader from './VerificationStatusHeader';

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -7,6 +7,7 @@ import {
     Tooltip,
     makeStyles,
     withStyles,
+    Grid,
 } from '@material-ui/core';
 import { Case, VerificationStatus } from './Case';
 import MaterialTable, { QueryResult } from 'material-table';
@@ -93,12 +94,14 @@ const styles = (theme: Theme) =>
     });
 
 const searchBarStyles = makeStyles((theme: Theme) => ({
-    searchBar: {
-        marginBottom: theme.spacing(2),
-        marginTop: theme.spacing(2),
-    },
     searchBarInput: {
-        borderRadius: theme.spacing(1),
+        borderRadius: '8px',
+    },
+    searchRoot: {
+        paddingTop: theme.spacing(1),
+        paddingBottom: theme.spacing(1),
+        display: 'flex',
+        alignItems: 'center',
     },
 }));
 
@@ -114,106 +117,101 @@ function SearchBar(props: {
 
     const classes = searchBarStyles();
     return (
-        <Autocomplete
-            options={[
-                'curator:',
-                'gender:',
-                'nationality:',
-                'occupation:',
-                'country:',
-                'outcome:',
-                'caseid:',
-                'source:',
-                'uploadid:',
-                'admin1:',
-                'admin2:',
-                'admin3:',
-            ]}
-            id="search-field"
-            freeSolo
-            value={search}
-            onKeyPress={(ev) => {
-                if (ev.key === 'Enter') {
-                    ev.preventDefault();
-                    props.onSearchChange(search);
-                    setOpen(false);
+        <div className={classes.searchRoot}>
+            <Autocomplete
+                options={[
+                    'curator:',
+                    'gender:',
+                    'nationality:',
+                    'occupation:',
+                    'country:',
+                    'outcome:',
+                    'caseid:',
+                    'source:',
+                    'uploadid:',
+                    'admin1:',
+                    'admin2:',
+                    'admin3:',
+                ]}
+                id="search-field"
+                freeSolo
+                value={search}
+                onKeyPress={(ev) => {
+                    if (ev.key === 'Enter') {
+                        ev.preventDefault();
+                        props.onSearchChange(search);
+                        setOpen(false);
+                    }
+                }}
+                onChange={(ev, val) => {
+                    setSearch(val || '');
+                }}
+                open={open}
+                onClose={() => setOpen(false)}
+                onOpen={() => setOpen(true)}
+                fullWidth
+                renderInput={(params) => (
+                    <TextField
+                        {...params}
+                        label="Search"
+                        variant="filled"
+                        InputProps={{
+                            ...params.InputProps,
+                            disableUnderline: true,
+                            classes: { root: classes.searchBarInput },
+                        }}
+                    />
+                )}
+            />
+            <HtmlTooltip
+                title={
+                    <React.Fragment>
+                        <h4>Search syntax</h4>
+                        <h5>Full text search</h5>
+                        Example: <i>"got infected at work" -India</i>
+                        <br />
+                        You can use arbitrary strings to search over those text
+                        fields:
+                        {[
+                            'notes',
+                            'curator',
+                            'occupation',
+                            'nationalities',
+                            'ethnicity',
+                            'country',
+                            'admin1',
+                            'admin2',
+                            'admin3',
+                            'place',
+                            'location name',
+                            'pathogen name',
+                            'source url',
+                            'upload ID',
+                        ].join(', ')}
+                        <h5>Keywords search</h5>
+                        Example:{' '}
+                        <i>
+                            curator:foo@bar.com,fez@meh.org country:Japan
+                            gender:female occupation:"healthcare worker"
+                        </i>
+                        <br />
+                        Values are OR'ed for the same keyword and all keywords
+                        are AND'ed.
+                        <br />
+                        Keyword values can be quoted for multi-words matches and
+                        concatenated with a comma to union them.
+                        <br />
+                        Only equality operator is supported.
+                        <br />
+                        Supported keywords are shown when the search bar is
+                        clicked.
+                    </React.Fragment>
                 }
-            }}
-            onChange={(ev, val) => {
-                setSearch(val || '');
-            }}
-            open={open}
-            onClose={() => setOpen(false)}
-            onOpen={() => setOpen(true)}
-            renderInput={(params) => (
-                <TextField
-                    {...params}
-                    label="Search"
-                    variant="filled"
-                    InputProps={{
-                        ...params.InputProps,
-                        disableUnderline: true,
-                        classes: { root: classes.searchBarInput },
-                        startAdornment: <SearchIcon />,
-                        endAdornment: (
-                            <HtmlTooltip
-                                title={
-                                    <React.Fragment>
-                                        <h4>Search syntax</h4>
-                                        <h5>Full text search</h5>
-                                        Example:{' '}
-                                        <i>"got infected at work" -India</i>
-                                        <br />
-                                        You can use arbitrary strings to search
-                                        over those text fields:
-                                        {[
-                                            'notes',
-                                            'curator',
-                                            'occupation',
-                                            'nationalities',
-                                            'ethnicity',
-                                            'country',
-                                            'admin1',
-                                            'admin2',
-                                            'admin3',
-                                            'place',
-                                            'location name',
-                                            'pathogen name',
-                                            'source url',
-                                            'upload ID',
-                                        ].join(', ')}
-                                        <h5>Keywords search</h5>
-                                        Example:{' '}
-                                        <i>
-                                            curator:foo@bar.com,fez@meh.org
-                                            country:Japan gender:female
-                                            occupation:"healthcare worker"
-                                        </i>
-                                        <br />
-                                        Values are OR'ed for the same keyword
-                                        and all keywords are AND'ed.
-                                        <br />
-                                        Keyword values can be quoted for
-                                        multi-words matches and concatenated
-                                        with a comma to union them.
-                                        <br />
-                                        Only equality operator is supported.
-                                        <br />
-                                        Supported keywords are shown when the
-                                        search bar is clicked.
-                                    </React.Fragment>
-                                }
-                                placement="left"
-                            >
-                                <HelpIcon />
-                            </HtmlTooltip>
-                        ),
-                    }}
-                    classes={{ root: classes.searchBar }}
-                    fullWidth
-                />
-            )}
-        />
+                placement="left"
+            >
+                <HelpIcon />
+            </HtmlTooltip>
+        </div>
     );
 }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1255432/91190487-ec0df300-e6f3-11ea-9cb5-afbcf67e8965.png)


After: 
![image](https://user-images.githubusercontent.com/1255432/91190433-dd274080-e6f3-11ea-9653-dba5edf4f57a.png)


I removed the search icon because when used as a start adornment the UI became what it was apparently that's a bug :(

Also moved the tooltip to a separate portion of the UI after the search bar so that we can have the X to clear input in it I think it's cleaner:
![image](https://user-images.githubusercontent.com/1255432/91190724-2ecfcb00-e6f4-11ea-8596-eac029feb18a.png)
