### PR TITLE
Determine G.h environment in parsing functions via an env input parameter

### DIFF
--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -30,6 +30,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
           env:
+            - name: SERVICE_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels.environment
             - name: DATASERVER_URL
               value: "http://data-dev"
             - name: DB_CONNECTION_STRING

--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -9,6 +9,11 @@ import google
 from enum import Enum
 from google.oauth2 import service_account
 
+_ENV_TO_SOURCE_API_URL = {
+    "local": "http://localhost:3001/api",
+    "dev": "https://dev-curator.ghdsi.org/api",
+    "prod": "https://curator.ghdsi.org/api"
+}
 _SERVICE_ACCOUNT_CRED_FILE = "covid-19-map-277002-0943eeb6776b.json"
 _METADATA_BUCKET = "epid-ingestion"
 
@@ -100,3 +105,12 @@ def obtain_api_credentials(s3_client):
     except Exception as e:
         print(e)
         raise e
+
+
+def get_source_api_url(env):
+    """
+    Returns the URL at which to reach the Source API for the provided environment.
+    """
+    if env not in _ENV_TO_SOURCE_API_URL:
+        raise ValueError(f"No source API URL found for provided env: {env}")
+    return _ENV_TO_SOURCE_API_URL[env]

--- a/ingestion/functions/common/common_lib_test.py
+++ b/ingestion/functions/common/common_lib_test.py
@@ -112,3 +112,16 @@ def test_complete_with_error_updates_upload_if_provided_data(requests_mock):
         return
     # We got the wrong exception or no exception, fail the test.
     assert "Should have raised a ValueError exception" == False
+
+
+def test_get_source_api_url_returns_mapped_value():
+    for key, value in common_lib._ENV_TO_SOURCE_API_URL.items():
+        assert common_lib.get_source_api_url(key) == value
+
+
+def test_get_source_api_url_raises_error_for_unmapped_env():
+    try:
+        common_lib.get_source_api_url('not-an-env')
+    except ValueError:
+        return
+    assert "Should have raised a ValueError exception" == False

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -8,6 +8,7 @@ import requests
 
 from datetime import datetime, timezone
 
+ENV_FIELD = "env"
 OUTPUT_BUCKET = "epid-sources-raw"
 SOURCE_ID_FIELD = "sourceId"
 TIME_FILEPART_FORMAT = "/%Y/%m/%d/%H%M/"
@@ -27,36 +28,46 @@ import common_lib
 from common_lib import UploadError
 
 
-def extract_source_id(event):
-    if SOURCE_ID_FIELD not in event:
+def extract_event_fields(event):
+    print('Extracting fields from event', event)
+    if any(
+            field not in event
+            for field
+            in [ENV_FIELD, SOURCE_ID_FIELD]):
         error_message = (
-            f"Required field {SOURCE_ID_FIELD} not found in input event json.")
+            f"Required fields {ENV_FIELD}; {SOURCE_ID_FIELD} not found in input event json.")
         print(error_message)
         raise ValueError(error_message)
-    return event[SOURCE_ID_FIELD]
+    return event[ENV_FIELD], event[SOURCE_ID_FIELD]
 
 
-def get_source_details(source_id, upload_id, api_headers):
+def get_source_details(env, source_id, upload_id, api_headers):
     """
     Retrieves the content URL and format associated with the provided source ID.
     """
     try:
-        source_api_endpoint = f"{os.environ['SOURCE_API_URL']}/sources/{source_id}"
+        source_api_endpoint = f"{common_lib.get_source_api_url(env)}/sources/{source_id}"
         print(f"Requesting source configuration from {source_api_endpoint}")
         r = requests.get(source_api_endpoint, headers=api_headers)
-        api_json = r.json()
-        print(f"Received source API response: {api_json}")
-        return api_json["origin"]["url"], api_json["format"], api_json.get(
-            "automation", {}).get(
-            "parser", {}).get(
-            "awsLambdaArn", ""), api_json.get(
-            'dateFilter', {})
-    except Exception as e:
+        if r and r.status_code == 200:
+            api_json = r.json()
+            print(f"Received source API response: {api_json}")
+            return api_json["origin"]["url"], api_json["format"], api_json.get(
+                "automation", {}).get(
+                "parser", {}).get(
+                "awsLambdaArn", ""), api_json.get(
+                'dateFilter', {})
         upload_error = (
             UploadError.SOURCE_CONFIGURATION_NOT_FOUND
             if r.status_code == 404 else UploadError.INTERNAL_ERROR)
+        e = RuntimeError(
+            f"Error retrieving source details, status={r.status_code}, response={r.text}")
         common_lib.complete_with_error(
             e, upload_error, source_id, upload_id,
+            api_headers)
+    except ValueError as e:
+        common_lib.complete_with_error(
+            e, UploadError.INTERNAL_ERROR, source_id, upload_id,
             api_headers)
 
 
@@ -112,9 +123,10 @@ def upload_to_s3(file_name, s3_object_key, source_id, upload_id, api_headers):
 
 
 def invoke_parser(
-    parser_arn, source_id, upload_id, api_headers, s3_object_key,
+    env, parser_arn, source_id, upload_id, api_headers, s3_object_key,
         source_url, date_filter):
     payload = {
+        "env": env,
         "s3Bucket": OUTPUT_BUCKET,
         "sourceId": source_id,
         "s3Key": s3_object_key,
@@ -139,12 +151,14 @@ def get_today():
     """Return today's datetime, just here for easier mocking."""
     return datetime.today()
 
+
 def format_source_url(url: str) -> str:
     """
     Formats the given url with the date formatting params contained in it if any.
     Cf. https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
     """
     return get_today().strftime(url)
+
 
 def lambda_handler(event, context):
     """Global ingestion retrieval function.
@@ -170,19 +184,18 @@ def lambda_handler(event, context):
       https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
     """
 
-    source_id = extract_source_id(event)
+    env, source_id = extract_event_fields(event)
     auth_headers = common_lib.obtain_api_credentials(s3_client)
     upload_id = common_lib.create_upload_record(source_id, auth_headers)
     url, source_format, parser_arn, date_filter = get_source_details(
-        source_id, upload_id, auth_headers)
+        env, source_id, upload_id, auth_headers)
     url = format_source_url(url)
     file_name, s3_object_key = retrieve_content(
         source_id, upload_id, url, source_format, auth_headers)
     upload_to_s3(file_name, s3_object_key, source_id, upload_id, auth_headers)
     if parser_arn:
-        invoke_parser(
-            parser_arn, source_id, upload_id, auth_headers, s3_object_key, url,
-            date_filter)
+        invoke_parser(env, parser_arn, source_id, upload_id,
+                      auth_headers, s3_object_key, url, date_filter)
     return {
         "bucket": OUTPUT_BUCKET,
         "key": s3_object_key,

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -84,7 +84,8 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3,
     s3.create_bucket(Bucket=retrieval.OUTPUT_BUCKET)
 
     # Set up mock request values used in multiple requests.
-    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL  # Still needed for now.
+    # TODO: Complete removal of URL env var.
+    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL
     source_id = valid_event['sourceId']
     upload_id = "012345678901234567890123"
     origin_url = "http://bar.baz/"
@@ -173,7 +174,8 @@ def test_get_source_details_returns_parser_arn_if_present(
 def test_get_source_details_raises_error_if_source_not_found(
         requests_mock, mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL  # Still needed for now.
+    # TODO: Complete removal of URL env var.
+    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL
     source_id = "id"
     get_source_url = f"{_SOURCE_API_URL}/sources/{source_id}"
     requests_mock.get(get_source_url, status_code=404)
@@ -197,7 +199,8 @@ def test_get_source_details_raises_error_if_source_not_found(
 def test_get_source_details_raises_error_if_other_errors_getting_source(
         requests_mock, mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL  # Still needed for now.
+    # TODO: Complete removal of URL env var.
+    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL
     source_id = "sourceId"
     get_source_url = f"{_SOURCE_API_URL}/sources/{source_id}"
     requests_mock.get(get_source_url, status_code=500)
@@ -260,7 +263,8 @@ def test_retrieve_content_raises_error_for_non_supported_format(requests_mock):
     content_url = "http://foo.bar/"
     requests_mock.get(content_url)
     source_api_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
+    # TODO: Complete removal of URL env var.
+    os.environ["SOURCE_API_URL"] = source_api_url
     source_id = "source_id"
     upload_id = "123456789012345678901234"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
@@ -287,7 +291,8 @@ def test_retrieve_content_raises_error_for_source_content_not_found(
     content_url = "http://foo.bar/"
     requests_mock.get(content_url, status_code=404)
     source_api_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
+    # TODO: Complete removal of URL env var.
+    os.environ["SOURCE_API_URL"] = source_api_url
     source_id = "source_id"
     upload_id = "123456789012345678901234"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
@@ -313,7 +318,8 @@ def test_retrieve_content_raises_error_if_other_errors_getting_source_content(
     content_url = "http://foo.bar/"
     requests_mock.get(content_url, status_code=500)
     source_api_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
+    # TODO: Complete removal of URL env var.
+    os.environ["SOURCE_API_URL"] = source_api_url
     source_id = "source_id"
     upload_id = "123456789012345678901234"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
@@ -355,7 +361,8 @@ def test_upload_to_s3_writes_indicated_file_to_key(s3):
 def test_upload_to_s3_raises_error_on_s3_error(requests_mock, s3):
     from retrieval import retrieval  # Import locally to avoid superseding mock
     source_api_url = "http://foo.bar"
-    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
+    # TODO: Complete removal of URL env var.
+    os.environ["SOURCE_API_URL"] = source_api_url
     upload_id = "123456789012345678901234"
     source_id = "source_id"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -12,6 +12,12 @@ _SOURCE_API_URL = "http://foo.bar"
 
 @pytest.fixture()
 def mock_source_api_url_fixture():
+    """
+    Supplies a predetermined endpoint for G.h HTTP requests.
+
+    Because the retrieval library is imported locally, this fixture can't
+    be set to autouse.
+    """
     import common_lib
     common_lib.get_source_api_url = MagicMock(
         name="get_source_api_url", return_value=_SOURCE_API_URL)

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -7,6 +7,16 @@ import pytest
 from moto import mock_s3
 from unittest.mock import MagicMock, patch
 
+_SOURCE_API_URL = "http://foo.bar"
+
+
+@pytest.fixture()
+def mock_source_api_url_fixture():
+    import common_lib
+    common_lib.get_source_api_url = MagicMock(
+        name="get_source_api_url", return_value=_SOURCE_API_URL)
+
+
 @pytest.fixture()
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
@@ -40,10 +50,12 @@ def invalid_event():
     with open(file_path) as event_file:
         return json.load(event_file)
 
+
 def test_format_url_leaves_unchanged_if_no_format_params():
     from retrieval import retrieval  # Import locally to avoid superseding mock
     url = "http://foo.bar"
     assert retrieval.format_source_url(url) == url
+
 
 @patch('retrieval.retrieval.get_today')
 def test_format_url(mock_today):
@@ -52,8 +64,10 @@ def test_format_url(mock_today):
     url = "http://foo.bar/%Y-%m-%d.json"
     assert retrieval.format_source_url(url) == "http://foo.bar/2020-06-08.json"
 
+
 @mock_s3
-def test_lambda_handler_e2e(valid_event, requests_mock, s3):
+def test_lambda_handler_e2e(valid_event, requests_mock, s3,
+                            mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
 
     # Mock/stub retrieving credentials, invoking the parser lambda, and S3.
@@ -64,21 +78,20 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3):
     s3.create_bucket(Bucket=retrieval.OUTPUT_BUCKET)
 
     # Set up mock request values used in multiple requests.
-    source_api_url = "http://foo.bar"
-    os.environ["SOURCE_API_URL"] = source_api_url
+    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL  # Still needed for now.
     source_id = valid_event['sourceId']
     upload_id = "012345678901234567890123"
     origin_url = "http://bar.baz/"
 
     # Mock the request to create the upload.
-    create_upload_url = f"{source_api_url}/sources/{source_id}/uploads"
+    create_upload_url = f"{_SOURCE_API_URL}/sources/{source_id}/uploads"
     requests_mock.post(
         create_upload_url, json={"_id": upload_id},
         status_code=201)
 
     # Mock the request to retrieval source details (e.g. format).
     date_filter = {"numDaysBeforeToday": 2, "op": "EQ"}
-    full_source_url = f"{source_api_url}/sources/{source_id}"
+    full_source_url = f"{_SOURCE_API_URL}/sources/{source_id}"
     lambda_arn = "arn"
     requests_mock.get(
         full_source_url,
@@ -93,6 +106,7 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3):
 
     common_lib.obtain_api_credentials.assert_called_once()
     retrieval.invoke_parser.assert_called_once_with(
+        valid_event["env"],
         lambda_arn, source_id, upload_id, {},
         response["key"],
         origin_url, date_filter)
@@ -104,59 +118,65 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3):
     assert response["upload_id"] == upload_id
 
 
-def test_extract_source_id_returns_id_field(valid_event):
+def test_extract_event_fields_returns_env_and_source_id(valid_event):
     from retrieval import retrieval
-    assert retrieval.extract_source_id(valid_event) == valid_event["sourceId"]
+    env, source_id = retrieval.extract_event_fields(valid_event)
+    assert env == valid_event["env"]
+    assert source_id == valid_event["sourceId"]
 
 
-def test_extract_source_id_raises_error_if_event_lacks_id(invalid_event):
+def test_extract_event_fields_raises_error_if_event_lacks_env():
+    from retrieval import retrieval  # Import locally to avoid superseding mock
+    with pytest.raises(ValueError, match=retrieval.ENV_FIELD):
+        retrieval.extract_event_fields({"sourceId": "sourceId"})
+
+
+def test_extract_event_fields_raises_error_if_event_lacks_source_id():
     from retrieval import retrieval  # Import locally to avoid superseding mock
     with pytest.raises(ValueError, match=retrieval.SOURCE_ID_FIELD):
-        retrieval.extract_source_id(invalid_event)
+        retrieval.extract_event_fields({"env": "env"})
 
 
-def test_get_source_details_returns_url_and_format(requests_mock):
+def test_get_source_details_returns_url_and_format(
+        requests_mock, mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    source_api_url = "http://foo.bar"
     source_id = "id"
     content_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url
-    requests_mock.get(f"{source_api_url}/sources/{source_id}",
+    requests_mock.get(f"{_SOURCE_API_URL}/sources/{source_id}",
                       json={"format": "CSV", "origin": {"url": content_url}})
-    result = retrieval.get_source_details(source_id, "upload_id", {})
+    result = retrieval.get_source_details("env", source_id, "upload_id", {})
     assert result[0] == content_url
     assert result[1] == "CSV"
     assert result[2] == ""
 
 
-def test_get_source_details_returns_parser_arn_if_present(requests_mock):
+def test_get_source_details_returns_parser_arn_if_present(
+        requests_mock, mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    source_api_url = "http://foo.bar"
     source_id = "id"
     content_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url
     lambda_arn = "lambdaArn"
     requests_mock.get(
-        f"{source_api_url}/sources/{source_id}",
+        f"{_SOURCE_API_URL}/sources/{source_id}",
         json={"origin": {"url": content_url}, "format": "JSON",
               "automation": {"parser": {"awsLambdaArn": lambda_arn}}})
-    result = retrieval.get_source_details(source_id, "upload_id", {})
+    result = retrieval.get_source_details("env", source_id, "upload_id", {})
     assert result[2] == lambda_arn
 
 
-def test_get_source_details_raises_error_if_source_not_found(requests_mock):
+def test_get_source_details_raises_error_if_source_not_found(
+        requests_mock, mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    source_api_url = "http://foo.bar"
+    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL  # Still needed for now.
     source_id = "id"
-    os.environ["SOURCE_API_URL"] = source_api_url
-    get_source_url = f"{source_api_url}/sources/{source_id}"
+    get_source_url = f"{_SOURCE_API_URL}/sources/{source_id}"
     requests_mock.get(get_source_url, status_code=404)
     upload_id = "upload_id"
-    update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
+    update_upload_url = f"{_SOURCE_API_URL}/sources/{source_id}/uploads/{upload_id}"
     requests_mock.put(update_upload_url, json={})
 
     try:
-        retrieval.get_source_details(source_id, upload_id, {})
+        retrieval.get_source_details("env", source_id, upload_id, {})
     except Exception:
         assert requests_mock.request_history[0].url == get_source_url
         assert requests_mock.request_history[1].url == update_upload_url
@@ -169,19 +189,18 @@ def test_get_source_details_raises_error_if_source_not_found(requests_mock):
 
 
 def test_get_source_details_raises_error_if_other_errors_getting_source(
-        requests_mock):
+        requests_mock, mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
-    source_api_url = "http://foo.bar"
-    source_id = "id"
-    os.environ["SOURCE_API_URL"] = source_api_url
-    get_source_url = f"{source_api_url}/sources/{source_id}"
+    os.environ["SOURCE_API_URL"] = _SOURCE_API_URL  # Still needed for now.
+    source_id = "sourceId"
+    get_source_url = f"{_SOURCE_API_URL}/sources/{source_id}"
     requests_mock.get(get_source_url, status_code=500)
     upload_id = "upload_id"
-    update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
+    update_upload_url = f"{_SOURCE_API_URL}/sources/{source_id}/uploads/{upload_id}"
     requests_mock.put(update_upload_url, json={})
 
     try:
-        retrieval.get_source_details(source_id, upload_id, {})
+        retrieval.get_source_details("env", source_id, upload_id, {})
     except Exception:
         assert requests_mock.request_history[0].url == get_source_url
         assert requests_mock.request_history[1].url == update_upload_url
@@ -235,7 +254,7 @@ def test_retrieve_content_raises_error_for_non_supported_format(requests_mock):
     content_url = "http://foo.bar/"
     requests_mock.get(content_url)
     source_api_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url
+    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
     source_id = "source_id"
     upload_id = "123456789012345678901234"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
@@ -262,7 +281,7 @@ def test_retrieve_content_raises_error_for_source_content_not_found(
     content_url = "http://foo.bar/"
     requests_mock.get(content_url, status_code=404)
     source_api_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url
+    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
     source_id = "source_id"
     upload_id = "123456789012345678901234"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
@@ -288,7 +307,7 @@ def test_retrieve_content_raises_error_if_other_errors_getting_source_content(
     content_url = "http://foo.bar/"
     requests_mock.get(content_url, status_code=500)
     source_api_url = "http://bar.baz"
-    os.environ["SOURCE_API_URL"] = source_api_url
+    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
     source_id = "source_id"
     upload_id = "123456789012345678901234"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"
@@ -330,7 +349,7 @@ def test_upload_to_s3_writes_indicated_file_to_key(s3):
 def test_upload_to_s3_raises_error_on_s3_error(requests_mock, s3):
     from retrieval import retrieval  # Import locally to avoid superseding mock
     source_api_url = "http://foo.bar"
-    os.environ["SOURCE_API_URL"] = source_api_url
+    os.environ["SOURCE_API_URL"] = source_api_url  # Still needed for now.
     upload_id = "123456789012345678901234"
     source_id = "source_id"
     update_upload_url = f"{source_api_url}/sources/{source_id}/uploads/{upload_id}"

--- a/ingestion/functions/retrieval/valid_scheduled_event.json
+++ b/ingestion/functions/retrieval/valid_scheduled_event.json
@@ -1,3 +1,4 @@
 {
+    "env": "local",
     "sourceId": "5f32be3fe3f3ef002e849307"
 }

--- a/verification/curator-service/api/src/clients/aws-events-client.ts
+++ b/verification/curator-service/api/src/clients/aws-events-client.ts
@@ -17,6 +17,7 @@ export default class AwsEventsClient {
     constructor(
         awsRegion: string,
         private readonly lambdaClient: AwsLambdaClient,
+        private readonly serviceEnv: string,
     ) {
         AWS.config.update({ region: awsRegion });
         this.cloudWatchEventsClient = new AWS.CloudWatchEvents({
@@ -62,7 +63,10 @@ export default class AwsEventsClient {
                         {
                             Arn: targetArn,
                             Id: targetId,
-                            Input: JSON.stringify({ sourceId: sourceId }),
+                            Input: JSON.stringify({
+                                env: this.serviceEnv,
+                                sourceId: sourceId,
+                            }),
                         },
                     ],
                 };

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -119,6 +119,7 @@ const awsLambdaClient = new AwsLambdaClient(
 const awsEventsClient = new AwsEventsClient(
     env.AWS_SERVICE_REGION,
     awsLambdaClient,
+    env.SERVICE_ENV,
 );
 
 // API validation.

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -1,28 +1,33 @@
 import { CleanEnv, bool, cleanEnv, port, str, url } from 'envalid';
 
 export default function validateEnv(): Readonly<{
+    AFTER_LOGIN_REDIRECT_URL: string;
     AWS_ACCESS_KEY_ID: string;
     AWS_SECRET_ACCESS_KEY: string;
     AWS_SERVICE_REGION: string;
     DATASERVER_URL: string;
     DB_CONNECTION_STRING: string;
-    PORT: number;
+    ENABLE_FAKE_GEOCODER: boolean;
+    ENABLE_LOCAL_AUTH: boolean;
     GLOBAL_RETRIEVAL_FUNCTION_ARN: string;
     GOOGLE_OAUTH_CLIENT_ID: string;
     GOOGLE_OAUTH_CLIENT_SECRET: string;
-    SESSION_COOKIE_KEY: string;
-    AFTER_LOGIN_REDIRECT_URL: string;
-    STATIC_DIR: string;
-    ENABLE_LOCAL_AUTH: boolean;
-    MAPBOX_TOKEN: string;
     MAPBOX_PERMANENT_GEOCODE: boolean;
-    ENABLE_FAKE_GEOCODER: boolean;
+    MAPBOX_TOKEN: string;
+    PORT: number;
+    SERVICE_ENV: string;
+    SESSION_COOKIE_KEY: string;
+    STATIC_DIR: string;
 }> &
     CleanEnv & {
         readonly [varName: string]: string | undefined;
         // eslint-disable-next-line indent
     } {
     return cleanEnv(process.env, {
+        AFTER_LOGIN_REDIRECT_URL: str({
+            desc: 'URL to redirect to after the oauth consent screen',
+            devDefault: 'http://localhost:3002/',
+        }),
         AWS_ACCESS_KEY_ID: str({
             desc: 'ID for AWS access key credential',
             devDefault: 'fakeAccessKeyId',
@@ -47,7 +52,16 @@ export default function validateEnv(): Readonly<{
             desc: 'MongoDB URI provided to MongoClient.',
             devDefault: 'mongodb://localhost:27017/covid19',
         }),
-        PORT: port({ default: 3001 }),
+        ENABLE_FAKE_GEOCODER: bool({
+            desc: 'Whether to enable the fake seedable geocoder',
+            devDefault: true,
+            default: false,
+        }),
+        ENABLE_LOCAL_AUTH: bool({
+            desc: 'Whether to enable local auth strategy for testing',
+            devDefault: true,
+            default: false,
+        }),
         GLOBAL_RETRIEVAL_FUNCTION_ARN: str({
             desc: 'AWS ARN for the global source retrieval Lambda function',
             default:
@@ -61,36 +75,28 @@ export default function validateEnv(): Readonly<{
             desc: 'OAuth client secret from the Google developer console',
             devDefault: 'replace to enable auth',
         }),
-        SESSION_COOKIE_KEY: str({
-            desc: 'Secret key to sign cookies',
-            devDefault: 'default-dev-key',
-        }),
-        AFTER_LOGIN_REDIRECT_URL: str({
-            desc: 'URL to redirect to after the oauth consent screen',
-            devDefault: 'http://localhost:3002/',
-        }),
-        STATIC_DIR: str({
-            desc: 'Directory to serve static files from',
-            devDefault: '',
-        }),
-        ENABLE_LOCAL_AUTH: bool({
-            desc: 'Whether to enable local auth strategy for testing',
-            devDefault: true,
-            default: false,
-        }),
-        MAPBOX_TOKEN: str({
-            desc: 'Mapbox token to use for geocoding',
-            devDefault: '',
-        }),
         MAPBOX_PERMANENT_GEOCODE: bool({
             desc: 'Whether to use the permanent geocode endpoint',
             devDefault: false,
             default: true,
         }),
-        ENABLE_FAKE_GEOCODER: bool({
-            desc: 'Whether to enable the fake seedable geocoder',
-            devDefault: true,
-            default: false,
+        MAPBOX_TOKEN: str({
+            desc: 'Mapbox token to use for geocoding',
+            devDefault: '',
+        }),
+        PORT: port({ default: 3001 }),
+        SERVICE_ENV: str({
+            choices: ['local', 'dev', 'prod'],
+            desc: 'Environment in which the service is running',
+            devDefault: 'local',
+        }),
+        SESSION_COOKIE_KEY: str({
+            desc: 'Secret key to sign cookies',
+            devDefault: 'default-dev-key',
+        }),
+        STATIC_DIR: str({
+            desc: 'Directory to serve static files from',
+            devDefault: '',
         }),
     });
 }

--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -3,7 +3,7 @@ import AWSMock from 'aws-sdk-mock';
 import AwsEventsClient from '../../src/clients/aws-events-client';
 import AwsLambdaClient from '../../src/clients/aws-lambda-client';
 
-const ENV = 'test';
+const _ENV = 'test';
 
 let client: AwsEventsClient;
 const addInvokeFromEventPermissionSpy = jest.fn().mockResolvedValue({});
@@ -46,7 +46,7 @@ beforeEach(() => {
     client = new AwsEventsClient(
         'us-east-1',
         new AwsLambdaClient('some-arn', 'us-east-1'),
-        ENV,
+        _ENV,
     );
 });
 
@@ -90,7 +90,7 @@ describe('putRule', () => {
                         Arn: targetArn,
                         Id: targetId,
                         Input: JSON.stringify({
-                            env: ENV,
+                            env: _ENV,
                             sourceId: sourceId,
                         }),
                     },

--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -3,6 +3,8 @@ import AWSMock from 'aws-sdk-mock';
 import AwsEventsClient from '../../src/clients/aws-events-client';
 import AwsLambdaClient from '../../src/clients/aws-lambda-client';
 
+const ENV = 'test';
+
 let client: AwsEventsClient;
 const addInvokeFromEventPermissionSpy = jest.fn().mockResolvedValue({});
 const deleteRuleSpy = jest.fn().mockResolvedValueOnce({});
@@ -44,6 +46,7 @@ beforeEach(() => {
     client = new AwsEventsClient(
         'us-east-1',
         new AwsLambdaClient('some-arn', 'us-east-1'),
+        ENV,
     );
 });
 
@@ -65,16 +68,37 @@ describe('putRule', () => {
         expect(putRuleSpy).toHaveBeenCalledTimes(1);
     });
     it('creates a permissioned target for the rule if targetId and sourceId provided', async () => {
+        const ruleName = 'passingRule';
+        const targetArn = 'targetArn';
+        const targetId = 'targetId';
+        const sourceId = 'sourceId';
         await client.putRule(
-            'passingRule',
+            ruleName,
             'description',
             'rate(1 hour)',
-            'targetArn',
-            'targetId',
-            'sourceId',
+            targetArn,
+            targetId,
+            sourceId,
             'statementId',
         );
         expect(putTargetsSpy).toHaveBeenCalledTimes(1);
+        expect(putTargetsSpy).toHaveBeenCalledWith(
+            {
+                Rule: ruleName,
+                Targets: [
+                    {
+                        Arn: targetArn,
+                        Id: targetId,
+                        Input: JSON.stringify({
+                            env: ENV,
+                            sourceId: sourceId,
+                        }),
+                    },
+                ],
+            },
+            // There's a callback function added under-the-hood by aws-sdk.
+            expect.anything(),
+        );
         expect(addInvokeFromEventPermissionSpy).toHaveBeenCalledTimes(1);
     });
     it('does not mutate rule targets if target details not provided', async () => {


### PR DESCRIPTION
This covers:

- Creating the env var in our AWS deployment(s).
- Supplying it as JSON in our scheduled CloudWatch events.
- Using it to determine G.h API URL in retrieval.

Next step is using it in the parsing_lib, and removing references to the legacy os.environ param.

Handful of files impacted, but the commits should be nice logical chunks if you'd like to review that way.

To expand on the overall approach:

I'd considered doing full separation of serverless resources between environments. The "right" way to do that with AWS is to create separate CloudFormation stacks for each environment (using aliases to do it isn't recommended). It'd add a fair bit of cognitive overhead and complexity -- just didn't seem worth the payoff, given that there's no real resource separation advantage, since an "environment" for a Lambda is just a version of code to run.

So instead, G.h servers can include the environment in which a rule was configured in the input to ingestion, and our functions can determine which server to hit using that information. I'll talk this over with Chris/Spencer during handoffs; it won't be hard to simply templatize our SAM set up with some specific dev/prod params, and instead target the relevant environment's retrieval function from our servers, but to me it doesn't seem quite worth it for now.