### PR TITLE
fix environment label reference

### DIFF
--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -33,7 +33,7 @@ spec:
             - name: SERVICE_ENV
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.labels.environment
+                  fieldPath: metadata.labels['environment']
             - name: DATASERVER_URL
               value: "http://data-dev"
             - name: DB_CONNECTION_STRING
@@ -110,6 +110,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
           env:
+            - name: SERVICE_ENV
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['environment']
             - name: DATASERVER_URL
               value: "http://data-prod"
             - name: DB_CONNECTION_STRING


### PR DESCRIPTION
WIthout this kind of access we get:

```
The Deployment "curator-dev" is invalid: spec.template.spec.containers[0].env[0].valueFrom.fieldRef.fieldPath: Invalid value: "metadata.labels.environment": error converting fieldPath: field label not supported: metadata.labels.environment
```

when trying to apply the change