### PR TITLE
Don't populate source dateFilters unless we really want them

### DIFF
--- a/verification/curator-service/api/src/model/date-filter.ts
+++ b/verification/curator-service/api/src/model/date-filter.ts
@@ -1,17 +1,20 @@
 import mongoose from 'mongoose';
 
-export const dateFilterSchema = new mongoose.Schema({
-    numDaysBeforeToday: Number,
-    op: {
-        type: String,
-        enum: [
-            // Only import cases from a given day.
-            'EQ',
-            // Import all cases strictly prior to a given day.
-            'LT',
-        ],
+export const dateFilterSchema = new mongoose.Schema(
+    {
+        numDaysBeforeToday: Number,
+        op: {
+            type: String,
+            enum: [
+                // Only import cases from a given day.
+                'EQ',
+                // Import all cases strictly prior to a given day.
+                'LT',
+            ],
+        },
     },
-});
+    { _id: false },
+);
 
 export type DateFilterDocument = mongoose.Document & {
     numDaysBeforeToday: number;

--- a/verification/curator-service/api/test/model/date-filter.test.ts
+++ b/verification/curator-service/api/test/model/date-filter.test.ts
@@ -6,4 +6,8 @@ describe('DateFilter schema', () => {
         const errors = new DateFilter(fullModel).validateSync();
         expect(errors).toBeUndefined();
     });
+    it('should not include an _id field', () => {
+        const df = new DateFilter(fullModel);
+        expect(df['_id']).toBeUndefined();
+    });
 });

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -201,7 +201,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             dateFilter:
                 rowData.dateFilter?.numDaysBeforeToday || rowData.dateFilter?.op
                     ? rowData.dateFilter
-                    : {},
+                    : undefined,
         };
     }
 


### PR DESCRIPTION
This chokes up parsing, since dateFilter [isn't falsey](https://github.com/globaldothealth/list/blob/main/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py#L116), but it also doesn't contain necessary fields.