### PR TITLE
fix URL mangling due to date directives being incorrectly applied

### DIFF
--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -188,9 +188,15 @@ That parser will now import a day worth of data with a lag of 3 days, this delay
 
 ### Handling sources with unstable URLs
 
-If a source has a time-based URL scheme you can use standard Python [date formatting parameters](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) in the source URL and those will be automatically applied when retrieving the source content.
+If a source has a time-based URL scheme you can use the following date formatting directives in the source URL and those will be automatically applied when retrieving the source content:
 
-For example if a source publishes its data every day at a URL like `https://source.com/data/year-month-day.json` you can set the source URL to `https://source.com/data/%Y-%m-%d.json` and it will fetch the URL `https://source.com/data/2020-04-20.json` on the 4th of April 2020.
+- `$FULLYEAR` is replaced with the 4 digits current year.
+- `$FULLMONTH` is replaced with the 2 digits current month.
+- `$FULLDAY` is replaced with the 2 digits current day of the month.
+- `$MONTH` is replaced with the 1 or 2 digits current month.
+- `$DAY` is replaced with the 1 or 2 digits current day of the month.
+
+For example if a source publishes its data every day at a URL like `https://source.com/data/year-month-day.json` you can set the source URL to `https://source.com/data/$FULLYEAR-$FULLMONTH-$FULLDAY.json` and it will fetch the URL `https://source.com/data/2020-04-20.json` on the 4th of April 2020.
 
 ## Parsers
 

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -157,9 +157,24 @@ def get_today():
 def format_source_url(url: str) -> str:
     """
     Formats the given url with the date formatting params contained in it if any.
-    Cf. https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+    - $FULLYEAR is replaced with the 4 digits current year.
+    - $FULLMONTH is replaced with the 2 digits current month.
+    - $FULLDAY is replaced with the 2 digits current day of the month.
+    - $MONTH is replaced with the 1 or 2 digits current month.
+    - $DAY is replaced with the 1 or 2 digits current day of the month.
     """
-    return get_today().strftime(url)
+    today = get_today()
+    mappings = {
+        "$FULLYEAR": str(today.year),
+        "$FULLMONTH": str(today.month).zfill(2),
+        "$MONTH": str(today.month),
+        "$FULLDAY": str(today.day).zfill(2),
+        "$DAY": str(today.day),
+    }
+    for key in mappings:
+        if key in url:
+            url = url.replace(key, mappings[key], -1)
+    return url
 
 
 def lambda_handler(event, context):

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -59,8 +59,9 @@ def test_format_url_leaves_unchanged_if_no_format_params():
 def test_format_url(mock_today):
     from retrieval import retrieval  # Import locally to avoid superseding mock
     mock_today.return_value = datetime.datetime(2020, 6, 8)
-    url = "http://foo.bar/%Y-%m-%d.json"
-    assert retrieval.format_source_url(url) == "http://foo.bar/2020-06-08.json"
+    url = "http://foo.bar/$FULLYEAR-$FULLMONTH-$FULLDAY/$MONTH/$DAY.json"
+    assert retrieval.format_source_url(
+        url) == "http://foo.bar/2020-06-08/6/8.json"
 
 
 def test_lambda_handler_e2e(valid_event, requests_mock, s3,

--- a/ingestion/functions/retrieval/valid_scheduled_event.json
+++ b/ingestion/functions/retrieval/valid_scheduled_event.json
@@ -1,4 +1,4 @@
 {
     "env": "local",
-    "sourceId": "5f46eda6a6a7a5002834c2a3"
+    "sourceId": "5f4626eee8aeac002eb7dab4"
 }


### PR DESCRIPTION
Fixes #880

Bonus points: this makes us independent of python date formatting directives in our sources URL so if we ever switch to a different language for our retrieval lambda the source URLs will still work.