### PR TITLE
encode all downloaded sources as utf-8

### DIFF
--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -192,6 +192,11 @@ If a source has a time-based URL scheme you can use standard Python [date format
 
 For example if a source publishes its data every day at a URL like `https://source.com/data/year-month-day.json` you can set the source URL to `https://source.com/data/%Y-%m-%d.json` and it will fetch the URL `https://source.com/data/2020-04-20.json` on the 4th of April 2020.
 
+### Encoding of sources
+
+When the retrieval function stores the contents of a source in S3, the data is automatically encoded in utf-8 so that parsers do not have to care about which
+encoding to use when reading the files.
+
 ## Parsers
 
 You can find a list of issues/FR for parsers using the [importer tag](https://github.com/globaldothealth/list/issues?q=is%3Aopen+is%3Aissue+label%3AImporter).

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -27,8 +27,8 @@ if ('lambda' not in sys.argv[0]):
         os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             os.pardir, 'common'))
-from common_lib import UploadError
 import common_lib
+from common_lib import UploadError
 
 
 def extract_event_fields(event):

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -1,6 +1,9 @@
+import codecs
 import json
 import os
 import sys
+import io
+from chardet import detect
 
 import boto3
 import google.auth.transport.requests
@@ -24,8 +27,8 @@ if ('lambda' not in sys.argv[0]):
         os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             os.pardir, 'common'))
-import common_lib
 from common_lib import UploadError
+import common_lib
 
 
 def extract_event_fields(event):
@@ -75,26 +78,36 @@ def retrieve_content(
         env, source_id, upload_id, url, source_format, api_headers):
     """ Retrieves and locally persists the content at the provided URL. """
     try:
-        data = None
-        extension = None
         print(f"Downloading {source_format} content from {url}")
         headers = {"user-agent": "GHDSI/1.0 (http://ghdsi.org)"}
         r = requests.get(url, headers=headers)
         r.raise_for_status()
-        data = r.content
-        if source_format == "JSON":
-            extension = "json"
-        elif source_format == "CSV":
-            extension = "csv"
-        else:
+        if source_format != "JSON" and source_format != "CSV":
             e = ValueError(f"Unsupported source format: {source_format}")
             common_lib.complete_with_error(
                 e, env, UploadError.SOURCE_CONFIGURATION_ERROR, source_id,
                 upload_id, api_headers)
+        print('Download finished')
 
-        key_filename_part = f"content.{extension}"
-        with open(f"/tmp/{key_filename_part}", "wb") as f:
-            f.write(data)
+        key_filename_part = f"content.{source_format.lower()}"
+        # Lambda limitations: 512MB ephemeral disk space.
+        # Memory range is from 128 to 3008 MB so we could switch to
+        # https://docs.python.org/3/library/io.html#io.StringIO for bigger
+        # sources.
+        # Make the encoding of retrieved content consistent (UTF-8) for all
+        # parsers as per https://github.com/globaldothealth/list/issues/867.
+        bytesio = io.BytesIO(r.content)
+        print('detecting encoding of retrieved content.')
+        detected_enc = detect(bytesio.read(2048))
+        print(f'Source encoding is presumably {detected_enc}')
+        bytesio.seek(0)
+        with codecs.open(f"/tmp/{key_filename_part}", "wb", 'utf-8') as f:
+            # Write the output file as utf-8 in chunks because decoding the
+            # whole data in one shot becomes really slow with big files.
+            content = bytesio.read(2048)
+            while content:
+                f.write(codecs.decode(content, detected_enc['encoding']))
+                content = bytesio.read(2048)
             s3_object_key = (
                 f"{source_id}"
                 f"{datetime.now(timezone.utc).strftime(TIME_FILEPART_FORMAT)}"


### PR DESCRIPTION
Fixes #867 

FYI the code could be _slightly_ simpler if we didn't write the output file in chunks, but if we don't the lambda times out because decoding takes too long.

Test methodology:
- pytest passes (encoding is "ascii" in tests)
- downloaded the Peru csv:

```
file -I positivos_covid.csv
positivos_covid.csv:                         text/plain; charset=iso-8859-1
```

Ran the retrieval function locally with the changes in this PR built-in:

```
...
Requesting source configuration from http://localhost:3001/api/sources/5f48e71090ac8000280d2d9d
Received source API response: {'_id': '5f48e71090ac8000280d2d9d', 'name': 'Peru', 'origin': {'_id': '5f48e71090ac8000280d2d9e', 'url': 'https://cloud.minsa.gob.pe/s/Y8w3wHsEdYQSZRp/download'}, 'format': 'CSV', 'uploads': [{'created': '2020-08-28T11:15:08.696Z', '_id': '5f48e73c90ac8000280d2da3', 'status': 'IN_PROGRESS', 'summary': {}}, {'created': '2020-08-28T11:27:01.549Z', '_id': '5f48ea0590ac8000280d2da6', 'status': 'IN_PROGRESS', 'summary': {}}, {'created': '2020-08-28T11:36:43.192Z', '_id': '5f48ec4b90ac8000280d2da9', 'status': 'IN_PROGRESS', 'summary': {}}], '__v': 3}
Downloading CSV content from https://cloud.minsa.gob.pe/s/Y8w3wHsEdYQSZRp/download
Download finished
detecting encoding of retrieved content.
Source encoding is presumably {'encoding': 'ISO-8859-1', 'confidence': 0.73, 'language': ''}
Uploaded source content to s3://epid-sources-raw/5f48e71090ac8000280d2d9d/2020/08/28/1137/content.csv
END RequestId: 7501be09-6012-1a5d-515b-a2070061a09a
REPORT RequestId: 7501be09-6012-1a5d-515b-a2070061a09a	Init Duration: 2109.54 ms	Duration: 54113.99 ms	Billed Duration: 54200 ms	Memory Size: 128 MB	Max Memory Used: 58 MB

{"bucket":"epid-sources-raw","key":"5f48e71090ac8000280d2d9d/2020/08/28/1137/content.csv","upload_id":"5f48ec4b90ac8000280d2da9"}
```

Downloaded the s3 file locally:

```
aws s3 cp s3://epid-sources-raw/5f48e71090ac8000280d2d9d/2020/08/28/1137/content.csv source.csv
download: s3://epid-sources-raw/5f48e71090ac8000280d2d9d/2020/08/28/1137/content.csv to ./source.csv
```

Checked new encoding:

```
file -I source.csv
source.csv: text/plain; charset=utf-8
```

Eyed-checked that the data was not garbage in the file:

`6ae8311b8bd08b6226d29965860ed194,LIMA,EN INVESTIGACIÓN,EN INVESTIGACIÓN,PCR,30,MASCULINO,20200615`

Having those `Ó` in there make me confident that we're good.