### PR TITLE
try catch imports that need sys path to be changed locally

### DIFF
--- a/ingestion/functions/parsing/ch_zurich/zurich.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich.py
@@ -6,12 +6,14 @@ import csv
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.
 # pylint: disable=import-error
-if ('lambda' not in sys.argv[0]):
+try:
+    import parsing_lib
+except ImportError:
     sys.path.append(
         os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             'common/python'))
-import parsing_lib
+    import parsing_lib
 
 # Fixed location, all cases are for the canton of Zurich in Switzerland.
 _LOCATION = {
@@ -31,6 +33,7 @@ _GENDER_INDEX = 3
 _CONFIRMED_INDEX = 4
 _SOURCE_INDEX = 6
 
+
 def convert_date(raw_date):
     """
     Convert raw date field into a value interpretable by the dataserver.
@@ -41,12 +44,14 @@ def convert_date(raw_date):
     date = datetime.strptime(raw_date, "%Y-%m-%d")
     return date.strftime("%m/%d/%YZ")
 
+
 def convert_gender(raw_gender: str):
     if raw_gender.upper() == "M":
         return "Male"
     elif raw_gender.upper() == "F":
         return "Female"
     return None
+
 
 def convert_demographics(gender: str, age: str):
     demo = {}
@@ -58,6 +63,7 @@ def convert_demographics(gender: str, age: str):
             "end": float(age),
         }
     return demo
+
 
 def parse_cases(raw_data_file: str, source_id: str, source_url: str):
     """
@@ -71,7 +77,7 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
     """
     with open(raw_data_file, "r") as f:
         reader = csv.reader(f)
-        next(reader) # Skip the header.
+        next(reader)  # Skip the header.
         cases = []
         for row in reader:
             num_confirmed_cases = int(row[_CONFIRMED_INDEX])
@@ -101,6 +107,7 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
             except ValueError as ve:
                 print(ve)
         return cases
+
 
 def lambda_handler(event, context):
     return parsing_lib.run_lambda(event, context, parse_cases)

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -13,6 +13,19 @@ import datetime
 from mock import MagicMock, patch
 from moto import mock_s3
 
+try:
+    import common_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,
+            os.pardir,
+            os.pardir,
+            os.pardir,
+            'common'))
+    import common_lib
+
 _SOURCE_API_URL = "http://bar.baz"
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "https://foo.bar"
@@ -274,7 +287,7 @@ def test_write_to_server_raises_error_for_failed_batch_upsert(
         assert requests_mock.request_history[0].url == full_source_url
         assert requests_mock.request_history[1].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": parsing_lib.UploadError.DATA_UPLOAD_ERROR.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.DATA_UPLOAD_ERROR.name}}
         return
     # We got the wrong exception or no exception, fail the test.
     assert False
@@ -300,7 +313,7 @@ def test_write_to_server_raises_error_for_failed_batch_upsert_with_validation_er
         assert requests_mock.request_history[0].url == full_source_url
         assert requests_mock.request_history[1].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": parsing_lib.UploadError.VALIDATION_ERROR.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.VALIDATION_ERROR.name}}
         return
     # We got the wrong exception or no exception, fail the test.
     assert False

--- a/ingestion/functions/parsing/hongkong/hongkong.py
+++ b/ingestion/functions/parsing/hongkong/hongkong.py
@@ -6,12 +6,14 @@ import csv
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.
 # pylint: disable=import-error
-if ('lambda' not in sys.argv[0]):
+try:
+    import parsing_lib
+except ImportError:
     sys.path.append(
         os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             'common/python'))
-import parsing_lib
+    import parsing_lib
 
 # Fixed location, all cases are for Hong Kong.
 _LOCATION = {

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -6,12 +6,14 @@ from datetime import date, datetime
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.
 # pylint: disable=import-error
-if ('lambda' not in sys.argv[0]):
+try:
+    import parsing_lib
+except ImportError:
     sys.path.append(
         os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             'common/python'))
-import parsing_lib
+    import parsing_lib
 
 
 def convert_date(raw_date):

--- a/ingestion/functions/parsing/japan/japan.py
+++ b/ingestion/functions/parsing/japan/japan.py
@@ -6,12 +6,14 @@ from datetime import date, datetime
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.
 # pylint: disable=import-error
-if ('lambda' not in sys.argv[0]):
+try:
+    import parsing_lib
+except ImportError:
     sys.path.append(
         os.path.join(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             'common/python'))
-import parsing_lib
+    import parsing_lib
 
 def convert_gender(raw_gender):
     if "gender" in raw_gender:

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -3,11 +3,21 @@ import datetime
 import json
 import os
 import pytest
+import sys
 
 from moto import mock_s3
 from unittest.mock import MagicMock, patch
 
 _SOURCE_API_URL = "http://foo.bar"
+
+try:
+    import common_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir, 'common'))
+    import common_lib
 
 
 @pytest.fixture()
@@ -180,7 +190,7 @@ def test_get_source_details_raises_error_if_source_not_found(
         assert requests_mock.request_history[0].url == get_source_url
         assert requests_mock.request_history[1].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": retrieval.UploadError.SOURCE_CONFIGURATION_NOT_FOUND.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.SOURCE_CONFIGURATION_NOT_FOUND.name}}
         return
 
     # We got the wrong exception or no exception, fail the test.
@@ -205,7 +215,7 @@ def test_get_source_details_raises_error_if_other_errors_getting_source(
         assert requests_mock.request_history[0].url == get_source_url
         assert requests_mock.request_history[1].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": retrieval.UploadError.INTERNAL_ERROR.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.INTERNAL_ERROR.name}}
         return
 
     # We got the wrong exception or no exception, fail the test.
@@ -269,7 +279,7 @@ def test_retrieve_content_raises_error_for_non_supported_format(
         assert requests_mock.request_history[0].url == content_url
         assert requests_mock.request_history[1].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": retrieval.UploadError.SOURCE_CONFIGURATION_ERROR.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.SOURCE_CONFIGURATION_ERROR.name}}
         return
 
     # We got the wrong exception or no exception, fail the test.
@@ -293,7 +303,7 @@ def test_retrieve_content_raises_error_for_source_content_not_found(
         assert requests_mock.request_history[0].url == content_url
         assert requests_mock.request_history[1].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": retrieval.UploadError.SOURCE_CONTENT_NOT_FOUND.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.SOURCE_CONTENT_NOT_FOUND.name}}
         return
 
     # We got the wrong exception or no exception, fail the test.
@@ -317,7 +327,7 @@ def test_retrieve_content_raises_error_if_other_errors_getting_source_content(
         assert requests_mock.request_history[0].url == content_url
         assert requests_mock.request_history[1].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": retrieval.UploadError.SOURCE_CONTENT_DOWNLOAD_ERROR.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.SOURCE_CONTENT_DOWNLOAD_ERROR.name}}
         return
 
     # We got the wrong exception or no exception, fail the test.
@@ -355,7 +365,7 @@ def test_upload_to_s3_raises_error_on_s3_error(
     except Exception:
         assert requests_mock.request_history[0].url == update_upload_url
         assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": retrieval.UploadError.INTERNAL_ERROR.name}}
+        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.INTERNAL_ERROR.name}}
         return
 
     # We got the wrong exception or no exception, fail the test.


### PR DESCRIPTION
Instead of checking for a magic string that can break anytime, that also makes it feasible with the new indent to ran autopep8 formatter automatically and it won't mistakenly move the failing imports above the others.