### PR TITLE
fix prod export by pointing to case_fields.yaml file

### DIFF
--- a/.github/workflows/case-data-export-prod.yml
+++ b/.github/workflows/case-data-export-prod.yml
@@ -37,8 +37,8 @@ jobs:
           pip install -r data-serving/scripts/export-data/requirements.txt
       - name: Create gzip of CSV and JSON prod case data
         run: |
-          python3 data-serving/scripts/export-data/export.py -mongodb_connection_string "${{ secrets.DB_CONNECTION_URL_PROD }}" --format csv
-          python3 data-serving/scripts/export-data/export.py -mongodb_connection_string "${{ secrets.DB_CONNECTION_URL_PROD }}" --format json
+          python3 data-serving/scripts/export-data/export.py -mongodb_connection_string "${{ secrets.DB_CONNECTION_URL_PROD }}" --format csv --fields data-serving/scripts/export-data/case_fields.yaml
+          python3 data-serving/scripts/export-data/export.py -mongodb_connection_string "${{ secrets.DB_CONNECTION_URL_PROD }}" --format json --fields data-serving/scripts/export-data/case_fields.yaml
           tar -cvzf data/cases.tar.gz cases.csv cases.json
 
       - name: Commit files


### PR DESCRIPTION
We were seeing errors like:

```
 Create gzip of CSV and JSON prod case data0s
##[error]Process completed with exit code 2.
Run python3 data-serving/scripts/export-data/export.py -mongodb_connection_string "***" --format csv
usage: export.py [-h] [--mongodb_connection_string MONGODB_CONNECTION_STRING]
                 [--collection COLLECTION] [--fields FIELDS]
                 [--format {csv,json}]
export.py: error: argument --fields: can't open 'case_fields.yaml': [Errno 2] No such file or directory: 'case_fields.yaml'
##[error]Process completed with exit code 2.
```