### PR TITLE
Make verificationStatus default to UNVERIFIED.

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -429,7 +429,8 @@ components:
             verificationStatus:
               description: >
                 Whether the case document has been manually verified for
-                correctness.
+                correctness. For new cases, if this field isn't provided, a
+                default value of UNVERIFIED will be used.
               type: string
               enum:
                 - UNVERIFIED

--- a/data-serving/data-service/src/model/case-reference.ts
+++ b/data-serving/data-service/src/model/case-reference.ts
@@ -12,7 +12,10 @@ export const caseReferenceSchema = new mongoose.Schema(
             required: true,
         },
         uploadId: String,
-        verificationStatus: String,
+        verificationStatus: {
+            type: String,
+            default: 'UNVERIFIED',
+        },
         additionalSources: [
             {
                 sourceUrl: String,

--- a/data-serving/data-service/test/model/case-reference.test.ts
+++ b/data-serving/data-service/test/model/case-reference.test.ts
@@ -40,3 +40,11 @@ describe('validate', () => {
         return new CaseReference(fullModel).validate();
     });
 });
+
+describe('default', () => {
+    it('verificationStatus is UNVERIFIED', () => {
+        expect(new CaseReference(minimalModel).verificationStatus).toBe(
+            'UNVERIFIED',
+        );
+    });
+});

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -20,7 +20,6 @@ S3_KEY_FIELD = "s3Key"
 SOURCE_ID_FIELD = "sourceId"
 UPLOAD_ID_FIELD = "uploadId"
 DATE_FILTER_FIELD = "dateFilter"
-UNVERIFIED_STATUS = "UNVERIFIED"
 
 s3_client = boto3.client("s3")
 
@@ -75,7 +74,6 @@ def prepare_cases(cases, upload_id):
     """
     for case in cases:
         case["caseReference"]["uploadId"] = upload_id
-        case["caseReference"]["verificationStatus"] = UNVERIFIED_STATUS
     return cases
 
 

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -228,14 +228,13 @@ def test_extract_event_fields_errors_if_missing_env_field(input_event):
         parsing_lib.extract_event_fields(input_event)
 
 
-def test_prepare_cases_adds_upload_id_and_verification_status(requests_mock):
+def test_prepare_cases_adds_upload_id_and(requests_mock):
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
     upload_id = "123456789012345678901234"
     result = parsing_lib.prepare_cases(
         [_PARSED_CASE],
         upload_id)
     assert result[0]["caseReference"]["uploadId"] == upload_id
-    assert result[0]["caseReference"]["verificationStatus"] == parsing_lib.UNVERIFIED_STATUS
 
 
 def test_write_to_server_returns_created_and_updated_count(

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -933,7 +933,8 @@ components:
             verificationStatus:
               description: >
                 Whether the case document has been manually verified for
-                correctness.
+                correctness. For new cases, if this field isn't provided, a
+                default value of UNVERIFIED will be used.
               type: string
               enum:
                 - UNVERIFIED


### PR DESCRIPTION
Required for #891. This prevents a case from appearing modified if it's been previously verified by a curator, and no new data is found in the ADI run.

This unfortunately won't set a case to `UNVERIFIED` if new information is found in an update, which might be nice, but I'd reckon that the vast majority of upserts of existing cases will _not_ contain new information (so this behavior is desirable), and that searching for verified cases within an upload is a reasonable workaround.