### PR TITLE
faster cypress by not compressing videos

### DIFF
--- a/verification/curator-service/ui/cypress.json
+++ b/verification/curator-service/ui/cypress.json
@@ -1,5 +1,7 @@
 {
     "baseUrl": "http://localhost:3002",
     "pluginsFile": "cypress/plugins/index.ts",
-    "supportFile": "cypress/support/index.ts"
+    "supportFile": "cypress/support/index.ts",
+    "videoCompression": false,
+    "videoUploadOnPasses": false
 }


### PR DESCRIPTION
https://docs.cypress.io/guides/guides/screenshots-and-videos.html#Video-encoding

Also not saving videos when test passes.

Apparently now taking around 11 min instead of 15 that I used to see.