### PR TITLE
remove todo about 301 in retrieval func

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -115,7 +115,6 @@ def retrieve_content(
                 f"{key_filename_part}")
             return (f.name, s3_object_key)
     except requests.exceptions.RequestException as e:
-        # TODO: Handle 301.
         upload_error = (
             common_lib.UploadError.SOURCE_CONTENT_NOT_FOUND
             if r.status_code == 404 else


### PR DESCRIPTION
Requests follows the redirects by default https://requests.readthedocs.io/en/master/user/quickstart/#redirection-and-history so we shouldn't get a 301 explicitely unless I missed something?