### PR TITLE
make local runs of ingestion functions able to register a user and use it

### DIFF
--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -49,7 +49,23 @@ Serverless Application Model
 Python and executed on a version 3.8 runtime. See set up instructions and
 common commands, below.
 
-### One-time setup
+### Setup for folks without AWS access
+
+If you're a first-time contributor to the project and don't have access to the S3 bucket containing the service account keys, you can run the ingestion and parsing functions fully locally, in the `retrieval/valid_scheduled_event.json`, add this auth param to it:
+
+```json
+"auth": {
+   "email": "local@ingestion.function"
+}
+```
+
+This will make the functions log-in as a new user specified by this email and use the cookies generated for this user instead of the service account creds stored on S3.
+
+Note that this only works in a local environment as the handler to register a user isn't exposed in production for obvious reasons.
+
+TODO: #754 Add param to store and retrieve source content locally, not on S3.
+
+### One-time setup for people with AWS access
 
 #### Prerequisites
 

--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -37,12 +37,13 @@ class UploadError(Enum):
     VALIDATION_ERROR = 8
 
 
-def create_upload_record(env, source_id, headers):
+def create_upload_record(env, source_id, headers, cookies):
     """Creates an upload resource via the G.h Source API."""
     post_api_url = f"{get_source_api_url(env)}/sources/{source_id}/uploads"
     print(f"Creating upload via {post_api_url}")
     res = requests.post(post_api_url,
                         json={"status": "IN_PROGRESS", "summary": {}},
+                        cookies=cookies,
                         headers=headers)
     if res and res.status_code == 201:
         res_json = res.json()
@@ -54,7 +55,7 @@ def create_upload_record(env, source_id, headers):
 
 
 def finalize_upload(
-        env, source_id, upload_id, headers, count_created=None,
+        env, source_id, upload_id, headers, cookies, count_created=None,
         count_updated=None, error=None):
     """Records the results of an upload via the G.h Source API."""
     put_api_url = f"{get_source_api_url(env)}/sources/{source_id}/uploads/{upload_id}"
@@ -65,18 +66,21 @@ def finalize_upload(
         "summary": {"numCreated": count_created, "numUpdated": count_updated}}
     res = requests.put(put_api_url,
                        json=update,
-                       headers=headers)
+                       headers=headers,
+                       cookies=cookies)
     # TODO: Look for "errors" in res_json and handle them in some way.
+    # TODO: This can end up in a error-loop where we try to upload and fail
+    #       endlessly
     if not res or res.status_code != 200:
         e = RuntimeError(
             f'Error updating upload record, status={res.status_code}, response={res.text}')
         complete_with_error(e, env, UploadError.INTERNAL_ERROR,
-                            source_id, upload_id, headers)
+                            source_id, upload_id, headers, cookies)
 
 
 def complete_with_error(
         exception, env=None, upload_error=None, source_id=None, upload_id=None,
-        headers=None):
+        headers=None, cookies=None):
     """
     Logs and raises the provided exception.
 
@@ -85,9 +89,26 @@ def complete_with_error(
     """
     print(exception)
     if env and upload_error and source_id and upload_id:
-        finalize_upload(env, source_id, upload_id, headers,
+        finalize_upload(env, source_id, upload_id, headers, cookies,
                         error=upload_error)
     raise exception
+
+
+def login(email: str):
+    """Logs-in a local curator server instance for testing.
+
+    Returns the cookie of the now logged-in user.
+    """
+    print('Logging-in user', email)
+    endpoint = "http://localhost:3001/auth/register"
+    res = requests.post(endpoint, json={
+        "email": email,
+        "roles": ['curator', 'reader'],
+    })
+    if not res or res.status_code != 200:
+        raise RuntimeError(
+            f'Error registering local user, status={res.status_code}, response={res.text}')
+    return res.cookies
 
 
 def obtain_api_credentials(s3_client):

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -174,8 +174,10 @@ def run_lambda(event, context, parsing_function):
     env, source_url, source_id, upload_id, s3_bucket, s3_key, date_filter = extract_event_fields(
         event)
     api_creds = common_lib.obtain_api_credentials(s3_client)
+    # TODO: #754 Handle cookies as well.
     if not upload_id:
-        upload_id = common_lib.create_upload_record(env, source_id, api_creds)
+        upload_id = common_lib.create_upload_record(
+            env, source_id, api_creds, None)
     try:
         raw_data_file = retrieve_raw_data_file(s3_bucket, s3_key)
         case_data = parsing_function(
@@ -190,8 +192,9 @@ def run_lambda(event, context, parsing_function):
                 api_creds),
             env, source_id, upload_id,
             api_creds)
+        # TODO: #754 Handle cookies as well.
         common_lib.finalize_upload(
-            env, source_id, upload_id, api_creds, count_created, count_updated)
+            env, source_id, upload_id, api_creds, None, count_created, count_updated)
         return {"count_created": count_created, "count_updated": count_updated}
     except Exception as e:
         common_lib.complete_with_error(

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -80,15 +80,15 @@ def retrieve_content(
         env, source_id, upload_id, url, source_format, api_headers, cookies):
     """ Retrieves and locally persists the content at the provided URL. """
     try:
-        print(f"Downloading {source_format} content from {url}")
-        headers = {"user-agent": "GHDSI/1.0 (http://ghdsi.org)"}
-        r = requests.get(url, headers=headers)
-        r.raise_for_status()
         if source_format != "JSON" and source_format != "CSV":
             e = ValueError(f"Unsupported source format: {source_format}")
             common_lib.complete_with_error(
                 e, env, common_lib.UploadError.SOURCE_CONFIGURATION_ERROR,
                 source_id, upload_id, api_headers, cookies)
+        print(f"Downloading {source_format} content from {url}")
+        headers = {"user-agent": "GHDSI/1.0 (http://ghdsi.org)"}
+        r = requests.get(url, headers=headers)
+        r.raise_for_status()
         print('Download finished')
 
         key_filename_part = f"content.{source_format.lower()}"
@@ -124,7 +124,7 @@ def retrieve_content(
         # TODO: Handle 301.
         upload_error = (
             common_lib.UploadError.SOURCE_CONTENT_NOT_FOUND
-            if r.status_code == 404 else
+            if e.response.status_code == 404 else
             common_lib.UploadError.SOURCE_CONTENT_DOWNLOAD_ERROR)
         common_lib.complete_with_error(
             e, env, upload_error, source_id, upload_id,

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -42,17 +42,18 @@ def extract_event_fields(event):
             f"Required fields {ENV_FIELD}; {SOURCE_ID_FIELD} not found in input event json.")
         print(error_message)
         raise ValueError(error_message)
-    return event[ENV_FIELD], event[SOURCE_ID_FIELD]
+    return event[ENV_FIELD], event[SOURCE_ID_FIELD], event.get('auth', {})
 
 
-def get_source_details(env, source_id, upload_id, api_headers):
+def get_source_details(env, source_id, upload_id, api_headers, cookies):
     """
     Retrieves the content URL and format associated with the provided source ID.
     """
     try:
         source_api_endpoint = f"{common_lib.get_source_api_url(env)}/sources/{source_id}"
         print(f"Requesting source configuration from {source_api_endpoint}")
-        r = requests.get(source_api_endpoint, headers=api_headers)
+        r = requests.get(source_api_endpoint,
+                         headers=api_headers, cookies=cookies)
         if r and r.status_code == 200:
             api_json = r.json()
             print(f"Received source API response: {api_json}")
@@ -68,15 +69,15 @@ def get_source_details(env, source_id, upload_id, api_headers):
             f"Error retrieving source details, status={r.status_code}, response={r.text}")
         common_lib.complete_with_error(
             e, env, upload_error, source_id, upload_id,
-            api_headers)
+            api_headers, cookies)
     except ValueError as e:
         common_lib.complete_with_error(
             e, env, common_lib.UploadError.INTERNAL_ERROR, source_id, upload_id,
-            api_headers)
+            api_headers, cookies)
 
 
 def retrieve_content(
-        env, source_id, upload_id, url, source_format, api_headers):
+        env, source_id, upload_id, url, source_format, api_headers, cookies):
     """ Retrieves and locally persists the content at the provided URL. """
     try:
         print(f"Downloading {source_format} content from {url}")
@@ -87,7 +88,7 @@ def retrieve_content(
             e = ValueError(f"Unsupported source format: {source_format}")
             common_lib.complete_with_error(
                 e, env, common_lib.UploadError.SOURCE_CONFIGURATION_ERROR,
-                source_id, upload_id, api_headers)
+                source_id, upload_id, api_headers, cookies)
         print('Download finished')
 
         key_filename_part = f"content.{source_format.lower()}"
@@ -102,18 +103,23 @@ def retrieve_content(
         detected_enc = detect(bytesio.read(2048))
         print(f'Source encoding is presumably {detected_enc}')
         bytesio.seek(0)
-        with codecs.open(f"/tmp/{key_filename_part}", "wb", 'utf-8') as f:
-            # Write the output file as utf-8 in chunks because decoding the
-            # whole data in one shot becomes really slow with big files.
-            content = bytesio.read(2048)
-            while content:
-                f.write(codecs.decode(content, detected_enc['encoding']))
+        source_encoding = detected_enc['encoding']
+        if source_encoding != "utf-8":
+            with codecs.open(f"/tmp/{key_filename_part}", "wb", 'utf-8') as f:
+                # Write the output file as utf-8 in chunks because decoding the
+                # whole data in one shot becomes really slow with big files.
                 content = bytesio.read(2048)
-            s3_object_key = (
-                f"{source_id}"
-                f"{datetime.now(timezone.utc).strftime(TIME_FILEPART_FORMAT)}"
-                f"{key_filename_part}")
-            return (f.name, s3_object_key)
+                while content:
+                    f.write(codecs.decode(content, source_encoding))
+                    content = bytesio.read(2048)
+        else:
+            with open(f"/tmp/{key_filename_part}", "wb") as f:
+                f.write(r.content)
+        s3_object_key = (
+            f"{source_id}"
+            f"{datetime.now(timezone.utc).strftime(TIME_FILEPART_FORMAT)}"
+            f"{key_filename_part}")
+        return (f.name, s3_object_key)
     except requests.exceptions.RequestException as e:
         # TODO: Handle 301.
         upload_error = (
@@ -122,11 +128,12 @@ def retrieve_content(
             common_lib.UploadError.SOURCE_CONTENT_DOWNLOAD_ERROR)
         common_lib.complete_with_error(
             e, env, upload_error, source_id, upload_id,
-            api_headers)
+            api_headers, cookies)
 
 
 def upload_to_s3(
-        file_name, s3_object_key, env, source_id, upload_id, api_headers):
+        file_name, s3_object_key, env, source_id, upload_id, api_headers,
+        cookies):
     try:
         s3_client.upload_file(
             file_name, OUTPUT_BUCKET, s3_object_key)
@@ -135,11 +142,11 @@ def upload_to_s3(
     except Exception as e:
         common_lib.complete_with_error(
             e, env, common_lib.UploadError.INTERNAL_ERROR, source_id, upload_id,
-            api_headers)
+            api_headers, cookies)
 
 
 def invoke_parser(
-    env, parser_arn, source_id, upload_id, api_headers, s3_object_key,
+    env, parser_arn, source_id, upload_id, api_headers, cookies, s3_object_key,
         source_url, date_filter):
     payload = {
         "env": env,
@@ -161,7 +168,7 @@ def invoke_parser(
         e = Exception(f"Parser invocation unsuccessful. Response: {response}")
         common_lib.complete_with_error(
             e, env, common_lib.UploadError.INTERNAL_ERROR, source_id, upload_id,
-            api_headers)
+            api_headers, cookies)
 
 
 def get_today():
@@ -216,19 +223,25 @@ def lambda_handler(event, context):
       https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
     """
 
-    env, source_id = extract_event_fields(event)
-    auth_headers = common_lib.obtain_api_credentials(s3_client)
-    upload_id = common_lib.create_upload_record(env, source_id, auth_headers)
+    env, source_id, local_auth = extract_event_fields(event)
+    auth_headers = None
+    cookies = None
+    if local_auth and env == 'local':
+        cookies = common_lib.login(local_auth['email'])
+    else:
+        auth_headers = common_lib.obtain_api_credentials(s3_client)
+    upload_id = common_lib.create_upload_record(
+        env, source_id, auth_headers, cookies)
     url, source_format, parser_arn, date_filter = get_source_details(
-        env, source_id, upload_id, auth_headers)
+        env, source_id, upload_id, auth_headers, cookies)
     url = format_source_url(url)
     file_name, s3_object_key = retrieve_content(
-        env, source_id, upload_id, url, source_format, auth_headers)
+        env, source_id, upload_id, url, source_format, auth_headers, cookies)
     upload_to_s3(file_name, s3_object_key, env,
-                 source_id, upload_id, auth_headers)
+                 source_id, upload_id, auth_headers, cookies)
     if parser_arn:
         invoke_parser(env, parser_arn, source_id, upload_id,
-                      auth_headers, s3_object_key, url, date_filter)
+                      auth_headers, cookies, s3_object_key, url, date_filter)
     return {
         "bucket": OUTPUT_BUCKET,
         "key": s3_object_key,

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -266,7 +266,6 @@ def test_retrieve_content_raises_error_for_non_supported_format(
         requests_mock, mock_source_api_url_fixture):
     from retrieval import retrieval  # Import locally to avoid superseding mock
     content_url = "http://foo.bar/"
-    requests_mock.get(content_url)
     source_id = "source_id"
     upload_id = "123456789012345678901234"
     update_upload_url = f"{_SOURCE_API_URL}/sources/{source_id}/uploads/{upload_id}"
@@ -277,8 +276,7 @@ def test_retrieve_content_raises_error_for_non_supported_format(
         retrieval.retrieve_content(
             "env", source_id, upload_id, content_url, bad_format, {}, {})
     except ValueError:
-        assert requests_mock.request_history[0].url == content_url
-        assert requests_mock.request_history[1].url == update_upload_url
+        assert requests_mock.request_history[0].url == update_upload_url
         assert requests_mock.request_history[-1].json(
         ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.SOURCE_CONFIGURATION_ERROR.name}}
         return

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -116,7 +116,7 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3,
     common_lib.obtain_api_credentials.assert_called_once()
     retrieval.invoke_parser.assert_called_once_with(
         valid_event["env"],
-        lambda_arn, source_id, upload_id, {},
+        lambda_arn, source_id, upload_id, {}, None,
         response["key"],
         origin_url, date_filter)
     assert requests_mock.request_history[0].url == create_upload_url
@@ -129,7 +129,7 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3,
 
 def test_extract_event_fields_returns_env_and_source_id(valid_event):
     from retrieval import retrieval
-    env, source_id = retrieval.extract_event_fields(valid_event)
+    env, source_id, auth = retrieval.extract_event_fields(valid_event)
     assert env == valid_event["env"]
     assert source_id == valid_event["sourceId"]
 
@@ -153,7 +153,7 @@ def test_get_source_details_returns_url_and_format(
     content_url = "http://bar.baz"
     requests_mock.get(f"{_SOURCE_API_URL}/sources/{source_id}",
                       json={"format": "CSV", "origin": {"url": content_url}})
-    result = retrieval.get_source_details("env", source_id, "upload_id", {})
+    result = retrieval.get_source_details("env", source_id, "upload_id", {}, {})
     assert result[0] == content_url
     assert result[1] == "CSV"
     assert result[2] == ""
@@ -169,7 +169,7 @@ def test_get_source_details_returns_parser_arn_if_present(
         f"{_SOURCE_API_URL}/sources/{source_id}",
         json={"origin": {"url": content_url}, "format": "JSON",
               "automation": {"parser": {"awsLambdaArn": lambda_arn}}})
-    result = retrieval.get_source_details("env", source_id, "upload_id", {})
+    result = retrieval.get_source_details("env", source_id, "upload_id", {}, {})
     assert result[2] == lambda_arn
 
 
@@ -186,7 +186,7 @@ def test_get_source_details_raises_error_if_source_not_found(
     requests_mock.put(update_upload_url, json={})
 
     try:
-        retrieval.get_source_details("env", source_id, upload_id, {})
+        retrieval.get_source_details("env", source_id, upload_id, {}, {})
     except Exception:
         assert requests_mock.request_history[0].url == get_source_url
         assert requests_mock.request_history[1].url == update_upload_url
@@ -211,7 +211,7 @@ def test_get_source_details_raises_error_if_other_errors_getting_source(
     requests_mock.put(update_upload_url, json={})
 
     try:
-        retrieval.get_source_details("env", source_id, upload_id, {})
+        retrieval.get_source_details("env", source_id, upload_id, {}, {})
     except Exception:
         assert requests_mock.request_history[0].url == get_source_url
         assert requests_mock.request_history[1].url == update_upload_url
@@ -230,7 +230,7 @@ def test_retrieve_content_persists_downloaded_json_locally(requests_mock):
     format = "JSON"
     requests_mock.get(content_url, json={"data": "yes"})
     retrieval.retrieve_content(
-        "env", source_id, "upload_id", content_url, format, {})
+        "env", source_id, "upload_id", content_url, format, {}, {})
     assert requests_mock.request_history[0].url == content_url
     assert "GHDSI" in requests_mock.request_history[0].headers["user-agent"]
     with open("/tmp/content.json", "r") as f:
@@ -244,7 +244,7 @@ def test_retrieve_content_persists_downloaded_csv_locally(requests_mock):
     format = "CSV"
     requests_mock.get(content_url, content=b"foo,bar")
     retrieval.retrieve_content(
-        "env", source_id, "upload_id", content_url, format, {})
+        "env", source_id, "upload_id", content_url, format, {}, {})
     assert requests_mock.request_history[0].url == content_url
     assert "GHDSI" in requests_mock.request_history[0].headers["user-agent"]
     with open("/tmp/content.csv", "r") as f:
@@ -257,7 +257,7 @@ def test_retrieve_content_returns_local_and_s3_object_names(requests_mock):
     content_url = "http://foo.bar/"
     requests_mock.get(content_url, json={"data": "yes"})
     result = retrieval.retrieve_content(
-        "env", source_id, "upload_id", content_url, "JSON", {})
+        "env", source_id, "upload_id", content_url, "JSON", {}, {})
     assert "/tmp/" in result[0]
     assert source_id in result[1]
 
@@ -275,7 +275,7 @@ def test_retrieve_content_raises_error_for_non_supported_format(
 
     try:
         retrieval.retrieve_content(
-            "env", source_id, upload_id, content_url, bad_format, {})
+            "env", source_id, upload_id, content_url, bad_format, {}, {})
     except ValueError:
         assert requests_mock.request_history[0].url == content_url
         assert requests_mock.request_history[1].url == update_upload_url
@@ -299,7 +299,7 @@ def test_retrieve_content_raises_error_for_source_content_not_found(
 
     try:
         retrieval.retrieve_content(
-            "env", source_id, upload_id, content_url, "JSON", {})
+            "env", source_id, upload_id, content_url, "JSON", {}, {})
     except Exception:
         assert requests_mock.request_history[0].url == content_url
         assert requests_mock.request_history[1].url == update_upload_url
@@ -323,7 +323,7 @@ def test_retrieve_content_raises_error_if_other_errors_getting_source_content(
 
     try:
         retrieval.retrieve_content(
-            "env", source_id, upload_id, content_url, "JSON", {})
+            "env", source_id, upload_id, content_url, "JSON", {}, {})
     except Exception:
         assert requests_mock.request_history[0].url == content_url
         assert requests_mock.request_history[1].url == update_upload_url
@@ -345,7 +345,7 @@ def test_upload_to_s3_writes_indicated_file_to_key(s3):
     s3.create_bucket(Bucket=expected_s3_bucket)
     expected_s3_key = "objectkey"
     retrieval.upload_to_s3(local_file, expected_s3_key,
-                           "", "", "", {})  # api creds
+                           "", "", "", {}, {})  # api creds
     actual_object = s3.get_object(
         Bucket=expected_s3_bucket, Key=expected_s3_key)
     s3_data = actual_object['Body'].read().decode("utf-8")
@@ -362,7 +362,7 @@ def test_upload_to_s3_raises_error_on_s3_error(
 
     try:
         retrieval.upload_to_s3("not a file name", "not an s3 key",
-                               "env", source_id, upload_id, {})  # api creds
+                               "env", source_id, upload_id, {}, {})  # api creds
     except Exception:
         assert requests_mock.request_history[0].url == update_upload_url
         assert requests_mock.request_history[-1].json(

--- a/ingestion/functions/retrieval/valid_scheduled_event.json
+++ b/ingestion/functions/retrieval/valid_scheduled_event.json
@@ -1,4 +1,4 @@
 {
     "env": "local",
-    "sourceId": "5f4626eee8aeac002eb7dab4"
+    "sourceId": "5f4cbc1585d64403a986b1b4"
 }

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -34,10 +34,16 @@ paths:
       tags:
         - Auth
         - User
-      summary: Authorize a user for the given roles
+      summary: >
+        Creates a local user for testing.The user can have any specified roles
+        in the request and the returned cookies can be used for subsequent
+        requests acting as this new user.
+        Note that this endpoint is only exposed in a local environment.
+      servers:
+        - url: http://localhost:3001/api
       operationId: registerAuth
       requestBody:
-        description: User to authorize
+        description: User to register
         required: true
         content:
           application/json:


### PR DESCRIPTION
First step for #754, will tackle the parsing functions next.

This also includes a quick fix for the utf-8 encoding of sources, turns out one cannot just "decode" utf-8 into a utf-8 file if there are surrogates already present, instead if the source is already utf-8 I just dump it as is, no need to do the decoding/reencoding step that's simpler and faster and we just get the raw source as is this way. (Noticed the issue when trying on Estonian data source).