### PR TITLE
zero pad month and day when rendering dates

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -74,18 +74,18 @@ describe('Bulk upload form', function () {
 
         // Events
         // Confirmation
-        cy.contains('2020-6-23');
+        cy.contains('2020-06-23');
         cy.contains('PCR test');
         // Symptom onset
-        cy.contains('2020-6-19');
+        cy.contains('2020-06-19');
         // Hospital admission
         cy.contains('Yes');
-        cy.contains('2020-6-21');
+        cy.contains('2020-06-21');
         // ICU admission
-        cy.contains('2020-6-22');
+        cy.contains('2020-06-22');
         // Outcome
         cy.contains('Recovered');
-        cy.contains('2020-6-24');
+        cy.contains('2020-06-24');
 
         // Symptoms
         cy.contains('Symptomatic');
@@ -118,7 +118,7 @@ describe('Bulk upload form', function () {
         cy.contains('No records to display').should('not.exist');
         cy.contains('bulk_data.csv uploaded. 2 new cases added.');
         cy.contains('www.bulksource.com');
-        cy.contains('2020-6-23');
+        cy.contains('2020-06-23');
         cy.contains('Canada');
         cy.contains('Alberta');
         cy.contains('Banff');
@@ -149,7 +149,7 @@ describe('Bulk upload form', function () {
         cy.contains('No records to display').should('not.exist');
         cy.contains('bulk_data.csv uploaded. 2 new cases added.');
         cy.contains('www.new-source.com');
-        cy.contains('2020-6-23');
+        cy.contains('2020-06-23');
         cy.contains('Canada');
         cy.contains('Alberta');
         cy.contains('Banff');

--- a/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
@@ -169,7 +169,7 @@ describe('Curator', function () {
             cy.contains('Female');
             cy.contains('21');
             cy.contains('Frankreich');
-            cy.contains('2020-1-1');
+            cy.contains('2020-01-01');
             cy.contains('Recovered');
 
             // View the case from the message bar.
@@ -318,12 +318,12 @@ describe('Curator', function () {
             cy.contains('45.7589');
             cy.contains('4.8414');
             // Events.
-            cy.contains('2020-1-1');
-            cy.contains('2020-1-2');
-            cy.contains('2020-1-3');
-            cy.contains('2020-1-4');
-            cy.contains('2020-1-5');
-            cy.contains('2020-1-6');
+            cy.contains('2020-01-01');
+            cy.contains('2020-01-02');
+            cy.contains('2020-01-03');
+            cy.contains('2020-01-04');
+            cy.contains('2020-01-05');
+            cy.contains('2020-01-06');
             cy.contains('PCR test');
             cy.contains('Recovered');
             cy.contains('Yes');

--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -38,7 +38,7 @@ describe('New case form', function () {
             cy.contains('No records to display').should('not.exist');
             cy.contains('www.example.com');
             cy.contains('France');
-            cy.contains('2020-1-1');
+            cy.contains('2020-01-01');
         });
     });
 
@@ -69,7 +69,7 @@ describe('New case form', function () {
             cy.contains('No records to display').should('not.exist');
             cy.contains('www.new-source.com');
             cy.contains('France');
-            cy.contains('2020-1-1');
+            cy.contains('2020-01-01');
 
             cy.visit('/sources');
             cy.contains('www.new-source.com');
@@ -102,7 +102,7 @@ describe('New case form', function () {
         cy.contains('3 cases added');
         cy.contains('No records to display').should('not.exist');
         cy.get('td:contains("www.example.com")').should('have.length', 3);
-        cy.get('td:contains("2020-1-1")').should('have.length', 3);
+        cy.get('td:contains("2020-01-01")').should('have.length', 3);
     });
 
     it('Can submit events without dates', function () {
@@ -143,7 +143,7 @@ describe('New case form', function () {
             cy.contains('No records to display').should('not.exist');
             cy.contains('www.example.com');
             cy.contains('France');
-            cy.contains('2020-1-1');
+            cy.contains('2020-01-01');
             cy.contains('Recovered');
         });
     });
@@ -379,7 +379,7 @@ describe('New case form', function () {
             cy.contains('www.example.com');
             cy.contains('France');
             cy.contains('Paris');
-            cy.contains('2020-1-1');
+            cy.contains('2020-01-01');
         });
     });
 });

--- a/verification/curator-service/ui/cypress/integration/components/UploadsTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UploadsTableTest.spec.ts
@@ -28,7 +28,7 @@ describe('Uploads table', function () {
         cy.contains('5');
         cy.contains('3');
         cy.contains('5ef8e943dfe6e00030892d59');
-        cy.contains('2020-01-2');
+        cy.contains('2020-01-02');
         cy.contains('SUCCESS');
         cy.contains('2');
         cy.contains('0');

--- a/verification/curator-service/ui/cypress/integration/components/UploadsTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UploadsTableTest.spec.ts
@@ -23,12 +23,12 @@ describe('Uploads table', function () {
         cy.visit('/uploads');
         cy.contains('www.example.com');
         cy.contains('5ef8e943dfe6e00030892d58');
-        cy.contains('2020-1-1');
+        cy.contains('2020-01-01');
         cy.contains('IN_PROGRESS');
         cy.contains('5');
         cy.contains('3');
         cy.contains('5ef8e943dfe6e00030892d59');
-        cy.contains('2020-1-2');
+        cy.contains('2020-01-2');
         cy.contains('SUCCESS');
         cy.contains('2');
         cy.contains('0');

--- a/verification/curator-service/ui/src/components/ViewCase.test.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.test.tsx
@@ -55,9 +55,9 @@ it('loads and displays case', async () => {
     );
     expect(getByText('entryId')).toBeInTheDocument();
     expect(getByText('abc123')).toBeInTheDocument();
-    expect(getByText('2020-1-20')).toBeInTheDocument();
+    expect(getByText('2020-01-20')).toBeInTheDocument();
     expect(getByText('xyz789')).toBeInTheDocument();
-    expect(getByText('2020-4-13')).toBeInTheDocument();
+    expect(getByText('2020-04-13')).toBeInTheDocument();
     expect(
         getByText('Contact of a confirmed case at work.'),
     ).toBeInTheDocument();
@@ -76,11 +76,11 @@ it('loads and displays case', async () => {
     expect(getByText(/2.3522/)).toBeInTheDocument();
     expect(getByText(/48.85/)).toBeInTheDocument();
     // Events.
-    expect(getByText('2020-1-1')).toBeInTheDocument();
-    expect(getByText('2020-1-2')).toBeInTheDocument();
-    expect(getByText('2020-1-3')).toBeInTheDocument();
-    expect(getByText('2020-1-4 - 2020-1-5')).toBeInTheDocument();
-    expect(getByText('2020-1-6')).toBeInTheDocument();
+    expect(getByText('2020-01-01')).toBeInTheDocument();
+    expect(getByText('2020-01-02')).toBeInTheDocument();
+    expect(getByText('2020-01-03')).toBeInTheDocument();
+    expect(getByText('2020-01-04 - 2020-01-05')).toBeInTheDocument();
+    expect(getByText('2020-01-06')).toBeInTheDocument();
     expect(getByText('Recovered')).toBeInTheDocument();
     expect(getByText('PCR test')).toBeInTheDocument();
     // Symptoms.
@@ -106,7 +106,7 @@ it('loads and displays case', async () => {
     );
 
     // Travel history.
-    expect(getByText('2020-2-10 - 2020-2-17')).toBeInTheDocument();
+    expect(getByText('2020-02-10 - 2020-02-17')).toBeInTheDocument();
     expect(getByText('United States')).toBeInTheDocument();
     expect(getByText('New York')).toBeInTheDocument();
     expect(getByText('Kings County')).toBeInTheDocument();

--- a/verification/curator-service/ui/src/components/util/date.test.tsx
+++ b/verification/curator-service/ui/src/components/util/date.test.tsx
@@ -1,0 +1,9 @@
+import renderDate from './date';
+
+describe('Dates', () => {
+    it('are padded', () => {
+        expect(renderDate(new Date(Date.UTC(2020, 6, 9)))).toEqual(
+            '2020-07-09',
+        );
+    });
+});

--- a/verification/curator-service/ui/src/components/util/date.tsx
+++ b/verification/curator-service/ui/src/components/util/date.tsx
@@ -3,9 +3,10 @@ export default function renderDate(date: string | Date | null): string {
     if (typeof date === 'string') {
         date = new Date(date);
     }
-    return `${date.getUTCFullYear()}-${
-        date.getUTCMonth() + 1
-    }-${date.getUTCDate()}`;
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(
+        2,
+        '0',
+    )}-${String(date.getUTCDate()).padStart(2, '0')}`;
 }
 
 // Changes the date to be in UTC while maintaining the current date values


### PR DESCRIPTION
Don't know about you but single digit day or months look incomplete to me.

Notice how I am *not* using any leftpad library to do that, pure magic.

https://en.wikipedia.org/wiki/Npm_(software)#Notable_breakages