### PR TITLE
do not loop endlessly on error-writing failure

### DIFF
--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -47,9 +47,6 @@ def create_upload_record(env, source_id, headers, cookies):
                         headers=headers)
     if res and res.status_code == 201:
         res_json = res.json()
-        # Upload POST API doesn't provide 'errors' json in response body, all
-        # we have is the response body itself which is enough to describe the
-        # error.
         return res_json["_id"]
     e = RuntimeError(
         f'Error creating upload record, status={res.status_code}, response={res.text}')
@@ -70,8 +67,6 @@ def finalize_upload(
                        json=update,
                        headers=headers,
                        cookies=cookies)
-    # Upload PUT API doesn't provide 'errors' json in response body, all we have
-    # is the response body itself which is enough to describe the error.
     if not res or res.status_code != 200:
         raise RuntimeError(
             f'Error updating upload record, status={res.status_code}, response={res.text}')

--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -47,7 +47,9 @@ def create_upload_record(env, source_id, headers, cookies):
                         headers=headers)
     if res and res.status_code == 201:
         res_json = res.json()
-        # TODO: Look for "errors" in res_json and handle them in some way.
+        # Upload POST API doesn't provide 'errors' json in response body, all
+        # we have is the response body itself which is enough to describe the
+        # error.
         return res_json["_id"]
     e = RuntimeError(
         f'Error creating upload record, status={res.status_code}, response={res.text}')
@@ -68,14 +70,11 @@ def finalize_upload(
                        json=update,
                        headers=headers,
                        cookies=cookies)
-    # TODO: Look for "errors" in res_json and handle them in some way.
-    # TODO: This can end up in a error-loop where we try to upload and fail
-    #       endlessly
+    # Upload PUT API doesn't provide 'errors' json in response body, all we have
+    # is the response body itself which is enough to describe the error.
     if not res or res.status_code != 200:
-        e = RuntimeError(
+        raise RuntimeError(
             f'Error updating upload record, status={res.status_code}, response={res.text}')
-        complete_with_error(e, env, UploadError.INTERNAL_ERROR,
-                            source_id, upload_id, headers, cookies)
 
 
 def complete_with_error(

--- a/ingestion/functions/common/common_lib_test.py
+++ b/ingestion/functions/common/common_lib_test.py
@@ -91,15 +91,13 @@ def test_finalize_upload_raises_error_for_failed_request(
     requests_mock.register_uri(
         "PUT",
         update_upload_url,
-        [{"json": {}, "status_code": 500}, {"json": {}}])
+        [{"status_code": 500}])
 
     try:
         common_lib.finalize_upload("env", _SOURCE_ID, upload_id, {}, {}, 42, 0)
     except RuntimeError:
+        assert len(requests_mock.request_history) == 1
         assert requests_mock.request_history[0].url == update_upload_url
-        assert requests_mock.request_history[1].url == update_upload_url
-        assert requests_mock.request_history[-1].json(
-        ) == {"status": "ERROR", "summary": {"error": common_lib.UploadError.INTERNAL_ERROR.name}}
         return
 
     # We got the wrong exception or no exception, fail the test.

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -86,8 +86,9 @@ def write_to_server(cases, env, source_id, upload_id, headers):
                         headers=headers)
     if res and res.status_code == 200:
         res_json = res.json()
-        # TODO: Look for "errors" in res_json and handle them in some way.
         return len(res_json["createdCaseIds"]), len(res_json["updatedCaseIds"])
+    # Response can contain an 'error' field which describe each error that
+    # occurred, it will be contained in the res.text here below.
     e = RuntimeError(
         f'Error sending cases to server, status={res.status_code}, response={res.text}')
     # 207 encompasses both geocoding and case schema validation errors.


### PR DESCRIPTION
`finalize_upload` was calling `finalize_upload` if it failed to finalize the upload. nope.

Also removes TODO handling of `res.json().errors` field as well as the text is contained in the runtime exception we throw in each case or the API just doesn't provide fine grained errors like this (uploads API for example).