### PR TITLE
Add env as required var when invoking lambda from ui

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -39,7 +39,7 @@ def extract_event_fields(event):
             for field
             in [ENV_FIELD, SOURCE_ID_FIELD]):
         error_message = (
-            f"Required fields {ENV_FIELD}; {SOURCE_ID_FIELD} not found in input event json.")
+            f"Required fields {ENV_FIELD}; {SOURCE_ID_FIELD} not found in input event: {event}")
         print(error_message)
         raise ValueError(error_message)
     return event[ENV_FIELD], event[SOURCE_ID_FIELD], event.get('auth', {})

--- a/verification/curator-service/api/src/clients/aws-lambda-client.ts
+++ b/verification/curator-service/api/src/clients/aws-lambda-client.ts
@@ -26,6 +26,7 @@ export default class AwsLambdaClient {
     private readonly lambdaClient: AWS.Lambda;
     constructor(
         private readonly retrievalFunctionArn: string,
+        private readonly serviceEnv: string,
         awsRegion: string,
     ) {
         AWS.config.update({ region: awsRegion });
@@ -84,6 +85,7 @@ export default class AwsLambdaClient {
                 .invoke({
                     FunctionName: this.retrievalFunctionArn,
                     Payload: JSON.stringify({
+                        env: this.serviceEnv,
                         sourceId: sourceId,
                     }),
                 })

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -114,6 +114,7 @@ app.use('/auth', authController.router);
 // Configure connection to AWS services.
 const awsLambdaClient = new AwsLambdaClient(
     env.GLOBAL_RETRIEVAL_FUNCTION_ARN,
+    env.SERVICE_ENV,
     env.AWS_SERVICE_REGION,
 );
 const awsEventsClient = new AwsEventsClient(

--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
     AWSMock.mock('CloudWatchEvents', 'removeTargets', removeTargetsSpy);
     client = new AwsEventsClient(
         'us-east-1',
-        new AwsLambdaClient('some-arn', 'us-east-1'),
+        new AwsLambdaClient('some-arn', 'test', 'us-east-1'),
         _ENV,
     );
 });

--- a/verification/curator-service/api/test/clients/aws-lambda-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-lambda-client.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
     AWSMock.mock('Lambda', 'addPermission', addPermissionSpy);
     AWSMock.mock('Lambda', 'removePermission', removePermissionSpy);
     AWSMock.mock('Lambda', 'invoke', invokeSpy);
-    client = new AwsLambdaClient('some-arn', 'us-east-1');
+    client = new AwsLambdaClient('some-arn', 'test', 'us-east-1');
 });
 
 afterEach(() => {


### PR DESCRIPTION
 Missed that during your PR review, the invoke() call that builds the event must also pass in an env key.
Also logging the whole event when we fail to get a required key to figure out what's going on more easily.