### PR TITLE
Return counts, with true modification numbers, from batchUpsert

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -473,7 +473,11 @@ components:
           description: The number of cases created by the request.
         numUpdated:
           type: number
-          description: The number of cases modified by the request.
+          description: >
+            The number of cases modified by the request. Note that this only
+            includes cases that are actually modified by the batch upsert. If a
+            case is included in the batch upsert request, but contains no
+            changes compared to the currently stored case, it won't be counted.
       required:
         - numCreated
         - numUpdated

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -468,17 +468,15 @@ components:
     BatchUpsertCaseResponse:
       description: Response to batch upsert case API requests
       properties:
-        createdCaseIds:
-          type: array
-          items:
-            type: string
-        updatedCaseIds:
-          type: array
-          items:
-            type: string
+        numCreated:
+          type: number
+          description: The number of cases created by the request.
+        numUpdated:
+          type: number
+          description: The number of cases modified by the request.
       required:
-        - createdCaseIds
-        - updatedCaseIds
+        - numCreated
+        - numUpdated
     Case:
       description: A single line-list case.
       properties:

--- a/data-serving/data-service/src/controllers/preprocessor.ts
+++ b/data-serving/data-service/src/controllers/preprocessor.ts
@@ -126,6 +126,9 @@ export const setBatchUpsertRevisionMetadata = async (
 
     // Store the unchanged IDs for future middleware.
     response.locals.unchangedCaseIdSet = unchangedCaseIdSet;
+    // Store modification details for response handler.
+    response.locals.numModified =
+        existingCasesByCaseRefCombo.size - unchangedCaseIdSet.size;
 
     // For existing cases, compute the revision metadata that should be saved
     // to the database. If the case is unmodified, per the above set, the

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -382,14 +382,19 @@ describe('POST', () => {
     it('batch upsert with no cases should return 400', () => {
         return request(app).post('/api/cases/batchUpsert').send({}).expect(400);
     });
-    it('batch upsert with only valid cases should return 207 with IDs', async () => {
+    it('batch upsert with only valid cases should return 207 with counts', async () => {
         const newCaseWithoutEntryId = new Case(minimalCase);
         const newCaseWithEntryId = new Case(fullCase);
         newCaseWithEntryId.caseReference.sourceEntryId = 'newId';
 
-        const existingCaseWithEntryId = new Case(fullCase);
-        await existingCaseWithEntryId.save();
-        existingCaseWithEntryId.notes = 'new notes';
+        const changedCaseWithEntryId = new Case(fullCase);
+        await changedCaseWithEntryId.save();
+        changedCaseWithEntryId.notes = 'new notes';
+
+        const unchangedCaseWithEntryId = new Case(fullCase);
+        unchangedCaseWithEntryId.caseReference.sourceEntryId =
+            'unchangedEntryId';
+        await unchangedCaseWithEntryId.save();
 
         const res = await request(app)
             .post('/api/cases/batchUpsert')
@@ -397,15 +402,24 @@ describe('POST', () => {
                 cases: [
                     newCaseWithoutEntryId,
                     newCaseWithEntryId,
-                    existingCaseWithEntryId,
+                    changedCaseWithEntryId,
+                    unchangedCaseWithEntryId,
                 ],
                 ...curatorMetadata,
             })
             .expect(207);
-        expect(res.body.createdCaseIds).toHaveLength(2);
-        expect(res.body.updatedCaseIds).toHaveLength(1);
-        const updatedCaseInDb = await Case.findById(res.body.updatedCaseIds[0]);
-        expect(updatedCaseInDb?.notes).toEqual(existingCaseWithEntryId.notes);
+
+        const unchangedDbCase = await Case.findById(
+            unchangedCaseWithEntryId._id,
+        );
+        expect(unchangedDbCase?.toJSON()).toEqual(
+            unchangedCaseWithEntryId.toJSON(),
+        );
+        expect(res.body.numCreated).toBe(2); // Both new cases were created.
+        expect(res.body.numUpdated).toBe(1); // Only changed case was updated.
+
+        const updatedCaseInDb = await Case.findById(changedCaseWithEntryId._id);
+        expect(updatedCaseInDb?.notes).toEqual(changedCaseWithEntryId.notes);
     });
     it('batch upsert should result in create and update metadata', async () => {
         const existingCase = new Case(fullCase);
@@ -419,14 +433,16 @@ describe('POST', () => {
                 ...curatorMetadata,
             });
 
-        const newCaseInDb = await Case.findById(res.body.createdCaseIds[0]);
-        expect(newCaseInDb?.revisionMetadata.revisionNumber).toEqual(0);
+        const newCaseInDb = await Case.findOne({
+            'revisionMetadata.revisionNumber': 0,
+        });
         expect(newCaseInDb?.revisionMetadata.creationMetadata.curator).toEqual(
             curatorMetadata.curator.email,
         );
 
-        const updatedCaseInDb = await Case.findById(res.body.updatedCaseIds[0]);
-        expect(updatedCaseInDb?.revisionMetadata.revisionNumber).toEqual(1);
+        const updatedCaseInDb = await Case.findOne({
+            'revisionMetadata.revisionNumber': 1,
+        });
         expect(
             updatedCaseInDb?.revisionMetadata.updateMetadata?.curator,
         ).toEqual(curatorMetadata.curator.email);
@@ -454,14 +470,14 @@ describe('POST', () => {
         const existingCase = new Case(fullCase);
         await existingCase.save();
 
-        const res = await request(app)
+        await request(app)
             .post('/api/cases/batchUpsert')
             .send({
                 cases: [existingCase],
                 ...curatorMetadata,
             });
 
-        const caseInDb = await Case.findById(res.body.updatedCaseIds[0]);
+        const caseInDb = await Case.findById(existingCase._id);
         expect(caseInDb?.revisionMetadata.revisionNumber).toEqual(0);
         expect(caseInDb?.revisionMetadata.creationMetadata.curator).toEqual(
             minimalCase.revisionMetadata.creationMetadata.curator,

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -86,7 +86,7 @@ def write_to_server(cases, env, source_id, upload_id, headers):
                         headers=headers)
     if res and res.status_code == 200:
         res_json = res.json()
-        return len(res_json["createdCaseIds"]), len(res_json["updatedCaseIds"])
+        return res_json["numCreated"], res_json["numUpdated"]
     # Response can contain an 'error' field which describe each error that
     # occurred, it will be contained in the res.text here below.
     e = RuntimeError(
@@ -195,7 +195,8 @@ def run_lambda(event, context, parsing_function):
             api_creds)
         # TODO: #754 Handle cookies as well.
         common_lib.finalize_upload(
-            env, source_id, upload_id, api_creds, None, count_created, count_updated)
+            env, source_id, upload_id, api_creds, None, count_created,
+            count_updated)
         return {"count_created": count_created, "count_updated": count_updated}
     except Exception as e:
         common_lib.complete_with_error(

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -162,8 +162,8 @@ def test_run_lambda_e2e(
     num_updated = 5
     requests_mock.post(
         full_source_url,
-        json={"createdCaseIds": list(range(num_created)),
-              "updatedCaseIds": list(range(num_updated))})
+        json={"numCreated": num_created,
+              "numUpdated": num_updated})
 
     # Delete the provided upload ID to force parsing_lib to create a new upload.
     # Mock the create and update upload calls.
@@ -254,16 +254,18 @@ def test_write_to_server_returns_created_and_updated_count(
         requests_mock, mock_source_api_url_fixture):
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
     full_source_url = f"{_SOURCE_API_URL}/cases/batchUpsert"
+    num_created = 10
+    num_updated = 5
     requests_mock.post(
         full_source_url,
-        json={"createdCaseIds": list(range(10)),
-              "updatedCaseIds": list(range(5))})
+        json={"numCreated": num_created,
+              "numUpdated": num_updated})
 
     count_created, count_updated = parsing_lib.write_to_server(
         [_PARSED_CASE], "env", _SOURCE_ID, "upload_id", {})
     assert requests_mock.request_history[0].url == full_source_url
-    assert count_created == 10
-    assert count_updated == 5
+    assert count_created == num_created
+    assert count_updated == num_updated
 
 
 def test_write_to_server_raises_error_for_failed_batch_upsert(

--- a/ingestion/functions/parsing/hongkong/input_event.json
+++ b/ingestion/functions/parsing/hongkong/input_event.json
@@ -1,11 +1,7 @@
 {
     "env": "local",
     "s3Bucket": "epid-sources-raw",
-    "s3Key": "5f311a9795e338003016593a/2020/08/10/1009/content.csv",
+    "s3Key": "5f46eda6a6a7a5002834c2a3/2020/08/26/2318/content.csv",
     "sourceUrl": "http://www.chp.gov.hk/files/misc/enhanced_sur_covid_19_eng.csv",
-    "sourceId": "5f311a9795e338003016593a",
-    "dateFilter": {
-        "numDaysBeforeToday": 3,
-        "op": "EQ"
-    }
+    "sourceId": "5f46eda6a6a7a5002834c2a3"
 }

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1440,7 +1440,11 @@ components:
           description: The number of cases created by the request.
         numUpdated:
           type: number
-          description: The number of cases modified by the request.
+          description: >
+            The number of cases modified by the request. Note that this only
+            includes cases that are actually modified by the batch upsert. If a
+            case is included in the batch upsert request, but contains no
+            changes compared to the currently stored case, it won't be counted.
         errors:
           type: array
           items:

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1435,18 +1435,12 @@ components:
             - GEOCODE
             - VALIDATE
             - UPSERT
-        createdCaseIds:
-          type: array
-          description: UUIDs of cases created by the batch upsert
-          items:
-            type: string
-            example: 5f204ed6b986091d868a6ae4
-        updatedCaseIds:
-          type: array
-          description: UUIDs of cases updated by the batch upsert
-          items:
-            type: string
-            example: 5f204ed6b986091d868a6ae4
+        numCreated:
+          type: number
+          description: The number of cases created by the request.
+        numUpdated:
+          type: number
+          description: The number of cases modified by the request.
         errors:
           type: array
           items:
@@ -1464,8 +1458,8 @@ components:
               - message
       required:
         - phase
-        - createdCaseIds
-        - updatedCaseIds
+        - numCreated
+        - numUpdated
         - errors
   responses:
     "200Auth":

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -216,8 +216,8 @@ export default class CasesController {
             if (geocodeErrors.length > 0) {
                 res.status(207).send({
                     phase: 'GEOCODE',
-                    createdCaseIds: [],
-                    updatedCaseIds: [],
+                    numCreated: 0,
+                    numUpdated: 0,
                     errors: geocodeErrors,
                 });
                 return;
@@ -232,8 +232,8 @@ export default class CasesController {
             if (validationResponse.data.errors.length > 0) {
                 res.status(207).send({
                     phase: 'VALIDATE',
-                    createdCaseIds: [],
-                    updatedCaseIds: [],
+                    numCreated: 0,
+                    numUpdated: 0,
                     errors: validationResponse.data.errors,
                 });
                 return;
@@ -250,8 +250,8 @@ export default class CasesController {
             );
             res.status(200).send({
                 phase: 'UPSERT',
-                createdCaseIds: upsertResponse.data.createdCaseIds,
-                updatedCaseIds: upsertResponse.data.updatedCaseIds,
+                numCreated: upsertResponse.data.numCreated,
+                numUpdated: upsertResponse.data.numUpdated,
                 errors: [],
             });
             return;

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -358,8 +358,8 @@ describe('Cases', () => {
             .mockResolvedValueOnce({
                 status: 207,
                 data: {
-                    createdCaseIds: ['abc', 'def'],
-                    updatedCaseIds: [],
+                    numCreated: 2,
+                    numUpdated: 0,
                 },
             });
         const res = await curatorRequest
@@ -380,8 +380,8 @@ describe('Cases', () => {
             .expect('Content-Type', /json/);
         expect(mockedAxios.post).toHaveBeenCalledTimes(2);
         expect(res.body.phase).toBe('UPSERT');
-        expect(res.body.createdCaseIds).toHaveLength(2);
-        expect(res.body.updatedCaseIds).toHaveLength(0);
+        expect(res.body.numCreated).toBe(2);
+        expect(res.body.numUpdated).toBe(0);
         expect(res.body.errors).toHaveLength(0);
     });
 
@@ -420,8 +420,8 @@ describe('Cases', () => {
         expect(mockedAxios.post).not.toHaveBeenCalled();
         expect(mockedAxios.put).not.toHaveBeenCalled();
         expect(res.body.phase).toBe('GEOCODE');
-        expect(res.body.createdCaseIds).toHaveLength(0);
-        expect(res.body.updatedCaseIds).toHaveLength(0);
+        expect(res.body.numCreated).toBe(0);
+        expect(res.body.numUpdated).toBe(0);
         expect(res.body.errors).toEqual([
             {
                 index: 1,
@@ -475,8 +475,8 @@ describe('Cases', () => {
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
         expect(mockedAxios.put).not.toHaveBeenCalled();
         expect(res.body.phase).toBe('VALIDATE');
-        expect(res.body.createdCaseIds).toHaveLength(0);
-        expect(res.body.updatedCaseIds).toHaveLength(0);
+        expect(res.body.numCreated).toBe(0);
+        expect(res.body.numUpdated).toBe(0);
         expect(res.body.errors).toEqual(validationErrors);
     });
 

--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -196,8 +196,9 @@ describe('Bulk upload form', function () {
         cy.get('button[data-testid="submit"]').click();
         cy.wait('@batchUpsert');
 
-        // The updated case now has a gender of Female.
-        cy.contains('bulk_data.csv uploaded. 2 cases updated.');
+        // One case was updated to have a gender of Female.
+        // The other case, while present, wasn't modified.
+        cy.contains('bulk_data.csv uploaded. 1 case updated.');
         cy.contains('Female');
     });
 

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -172,8 +172,8 @@ interface BatchUpsertError {
 
 interface BatchUpsertResponse {
     phase: string;
-    createdCaseIds: string[];
-    updatedCaseIds: string[];
+    numCreated: number;
+    numUpdated: number;
     errors: BatchUpsertError[];
 }
 
@@ -523,30 +523,27 @@ class BulkCaseForm extends React.Component<
             );
             return;
         }
-        const createdIds = upsertResponse.createdCaseIds;
-        const updatedIds = upsertResponse.updatedCaseIds;
         await this.finalizeUpload(caseReference.sourceId, uploadId, 'SUCCESS', {
-            numCreated: createdIds.length,
-            numUpdated: updatedIds.length,
+            numCreated: upsertResponse.numCreated,
+            numUpdated: upsertResponse.numUpdated,
         });
         const createdMessage =
-            createdIds.length === 0
+            upsertResponse.numCreated === 0
                 ? ''
-                : createdIds.length === 1
+                : upsertResponse.numCreated === 1
                 ? '1 new case added. '
-                : `${createdIds.length} new cases added. `;
+                : `${upsertResponse.numCreated} new cases added. `;
         const updatedMessage =
-            updatedIds.length === 0
+            upsertResponse.numUpdated === 0
                 ? ''
-                : updatedIds.length === 1
+                : upsertResponse.numUpdated === 1
                 ? '1 case updated. '
-                : `${updatedIds.length} cases updated. `;
+                : `${upsertResponse.numUpdated} cases updated. `;
         this.props.history.push({
             pathname: '/cases',
             state: {
                 bulkMessage: `${filename} uploaded. ${createdMessage} ${updatedMessage}`,
-                newCaseIds: createdIds,
-                editedCaseIds: updatedIds,
+                searchQuery: `uploadid:${uploadId}`,
             },
         });
     }

--- a/verification/curator-service/ui/src/components/UploadsTable.tsx
+++ b/verification/curator-service/ui/src/components/UploadsTable.tsx
@@ -156,8 +156,21 @@ class UploadsTable extends React.Component<Props, UploadsTableState> {
                                 );
                                 response
                                     .then((result) => {
-                                        const flattenedSources = result.data.uploads.map(
-                                            (u) => {
+                                        const flattenedSources = result.data.uploads
+                                            .filter((u) => {
+                                                const numCreated =
+                                                    u.upload?.summary
+                                                        ?.numCreated;
+                                                const numUpdated =
+                                                    u.upload?.summary
+                                                        ?.numUpdated;
+                                                return numCreated
+                                                    ? numCreated > 0
+                                                    : false || numUpdated
+                                                    ? numUpdated > 0
+                                                    : false;
+                                            })
+                                            .map((u) => {
                                                 return {
                                                     id: u.upload._id,
                                                     created: u.upload.created,
@@ -170,12 +183,12 @@ class UploadsTable extends React.Component<Props, UploadsTableState> {
                                                         u.upload.summary
                                                             .numUpdated ?? 0,
                                                 };
-                                            },
-                                        );
+                                            });
                                         resolve({
                                             data: flattenedSources,
                                             page: query.page,
-                                            totalCount: result.data.total ?? 0,
+                                            totalCount:
+                                                flattenedSources.length ?? 0,
                                         });
                                     })
                                     .catch((e) => {

--- a/verification/curator-service/ui/src/components/UploadsTable.tsx
+++ b/verification/curator-service/ui/src/components/UploadsTable.tsx
@@ -156,21 +156,8 @@ class UploadsTable extends React.Component<Props, UploadsTableState> {
                                 );
                                 response
                                     .then((result) => {
-                                        const flattenedSources = result.data.uploads
-                                            .filter((u) => {
-                                                const numCreated =
-                                                    u.upload?.summary
-                                                        ?.numCreated;
-                                                const numUpdated =
-                                                    u.upload?.summary
-                                                        ?.numUpdated;
-                                                return numCreated
-                                                    ? numCreated > 0
-                                                    : false || numUpdated
-                                                    ? numUpdated > 0
-                                                    : false;
-                                            })
-                                            .map((u) => {
+                                        const flattenedSources = result.data.uploads.map(
+                                            (u) => {
                                                 return {
                                                     id: u.upload._id,
                                                     created: u.upload.created,
@@ -183,12 +170,12 @@ class UploadsTable extends React.Component<Props, UploadsTableState> {
                                                         u.upload.summary
                                                             .numUpdated ?? 0,
                                                 };
-                                            });
+                                            },
+                                        );
                                         resolve({
                                             data: flattenedSources,
                                             page: query.page,
-                                            totalCount:
-                                                flattenedSources.length ?? 0,
+                                            totalCount: result.data.total ?? 0,
                                         });
                                     })
                                     .catch((e) => {


### PR DESCRIPTION
Slight change in behavior for post-bulk-upload, which I broached with Aaron/Shroo.

On a minor note, we're saving one query in the nominal case for ADI (batchUpsert with many existing cases), which seems to shave off about 10-15% of the total time.