### PR TITLE
Catch 409 errors adding invocation permissions to allow source editing.

### DIFF
--- a/verification/curator-service/api/test/clients/aws-events-client.test.ts
+++ b/verification/curator-service/api/test/clients/aws-events-client.test.ts
@@ -1,4 +1,5 @@
-import AWS from 'aws-sdk';
+import AWS, { AWSError } from 'aws-sdk';
+
 import AWSMock from 'aws-sdk-mock';
 import AwsEventsClient from '../../src/clients/aws-events-client';
 import AwsLambdaClient from '../../src/clients/aws-lambda-client';
@@ -144,6 +145,26 @@ describe('putRule', () => {
                 'statementId',
             ),
         ).rejects.toThrow(expectedError);
+    });
+    it('does not throw 409 errors from lambda client', async () => {
+        // AWSError isn't backed by an actual prototype.
+        // https://github.com/aws/aws-sdk-js/issues/2611
+        const expectedError = new Error() as AWSError;
+        expectedError.statusCode = 409;
+
+        addInvokeFromEventPermissionSpy.mockRejectedValueOnce(expectedError);
+
+        await client.putRule(
+            'ruleName',
+            'description',
+            'rate(1 hour)',
+            'targetArn',
+            'awsErrorTargetId',
+            'sourceId',
+            'statementId',
+        );
+
+        expect(addInvokeFromEventPermissionSpy).toHaveBeenCalledTimes(1);
     });
     it('throws error if PutRuleResponse somehow lacks RuleArn', async () => {
         putRuleSpy.mockResolvedValueOnce({});


### PR DESCRIPTION
Prior to this, editing a source in SourcesTable (one that was configured for automation) would fail with an exception from AWS. Because setting permissions for a Lambda function is a create operation (as opposed to say put, as in putTargets, which doesn't suffer from this problem), it throws an error if the requested permission exists.