### PR TITLE
read more data to guess encoding

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -100,9 +100,10 @@ def retrieve_content(
         # parsers as per https://github.com/globaldothealth/list/issues/867.
         bytesio = io.BytesIO(r.content)
         print('detecting encoding of retrieved content.')
-        detected_enc = detect(bytesio.read(2048))
-        print(f'Source encoding is presumably {detected_enc}')
+        # Read 2MB to be quite sure about the encoding.
+        detected_enc = detect(bytesio.read(2<<20))
         bytesio.seek(0)
+        print(f'Source encoding is presumably {detected_enc}')
         source_encoding = detected_enc['encoding']
         if source_encoding != "utf-8":
             with codecs.open(f"/tmp/{key_filename_part}", "wb", 'utf-8') as f:


### PR DESCRIPTION
Otherwise Japan source would be guessed as ascii while it is utf-8 really.

Before: `Source encoding is presumably {'encoding': 'ascii', 'confidence': 1.0, 'language': ''}`
After: `Source encoding is presumably {'encoding': 'utf-8', 'confidence': 0.99, 'language': ''}`