### PR TITLE
Limit num of deletable cases to 10K for curators with no limit for admins

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -173,6 +173,14 @@ paths:
                     non-whitespace characters.
                   type: string
                   pattern: \S+
+                maxCasesThreshold:
+                  type: number
+                  description: >
+                    An optional safeguard against deletion of too many cases.
+                    If you want to delete based on a query for example but fail
+                    if the number of cases that's going to be deleted is more
+                    than a given number, set this field to that desired number.
+                    Failure will be indicated by a 422 error status code.
               oneOf:
                 - required: [caseIds]
                 - required: [query]
@@ -185,6 +193,8 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+        "422":
+          $ref: "#/components/responses/422"
         "500":
           $ref: "#/components/responses/500"
   /cases/batchValidate:

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -425,6 +425,20 @@ export const batchDel = async (req: Request, res: Response): Promise<void> => {
         return;
     }
 
+    // If we have a limit set, check that we do not go over it first.
+    const maxCasesThreshold = req.body['maxCasesThreshold'];
+    if (maxCasesThreshold) {
+        const total = await casesMatchingSearchQuery({
+            searchQuery: req.body.query,
+            count: true,
+        });
+        if (total > Number(maxCasesThreshold)) {
+            res.status(422).json(
+                `query ${req.body.query} will delete ${total} cases which is more than the maximum allowed of ${maxCasesThreshold}, only admins are not subject to the maximum number of cases restriction. Please contact one if you wish to move forward with the deletion.`,
+            );
+        }
+    }
+
     const casesQuery = casesMatchingSearchQuery({
         searchQuery: req.body.query,
         count: false,

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -436,6 +436,7 @@ export const batchDel = async (req: Request, res: Response): Promise<void> => {
             res.status(422).json(
                 `query ${req.body.query} will delete ${total} cases which is more than the maximum allowed of ${maxCasesThreshold}, only admins are not subject to the maximum number of cases restriction. Please contact one if you wish to move forward with the deletion.`,
             );
+            return;
         }
     }
 

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -963,4 +963,23 @@ describe('DELETE', () => {
             .expect(204);
         expect(await Case.collection.countDocuments()).toEqual(1);
     });
+    it('delete multiple cases cannot go over threshold', async () => {
+        // Simulate index creation used in unit tests, in production they are
+        // setup by the setup-db script and such indexes are not present by
+        // default in the in memory mongo spawned by unit tests.
+        await mongoose.connection.collection('cases').createIndex({
+            notes: 'text',
+        });
+
+        await Promise.all([
+            new Case(minimalCase).set('notes', 'foo').save(),
+            new Case(minimalCase).set('notes', 'foo').save(),
+            new Case(minimalCase).set('notes', 'foo').save(),
+        ]);
+        expect(await Case.collection.countDocuments()).toEqual(3);
+        await request(app)
+            .delete('/api/cases')
+            .send({ query: 'foo', maxCasesThreshold: 2 })
+            .expect(422, /more than the maximum allowed/);
+    });
 });

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -488,6 +488,8 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
+        "422":
+          $ref: "#/components/responses/422"
         "500":
           $ref: "#/components/responses/500"
   /cases/symptoms:

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -1,7 +1,7 @@
 import { GeocodeOptions, Geocoder, Resolution } from '../geocoding/geocoder';
 import { Request, Response } from 'express';
 
-import { UserDocument, User } from '../model/user';
+import { UserDocument } from '../model/user';
 import axios from 'axios';
 
 class InvalidParamError extends Error {}

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -1,7 +1,7 @@
 import { GeocodeOptions, Geocoder, Resolution } from '../geocoding/geocoder';
 import { Request, Response } from 'express';
 
-import { UserDocument } from '../model/user';
+import { UserDocument, User } from '../model/user';
 import axios from 'axios';
 
 class InvalidParamError extends Error {}
@@ -107,6 +107,11 @@ export default class CasesController {
     /** batchDel simply forwards the request to the data service */
     batchDel = async (req: Request, res: Response): Promise<void> => {
         try {
+            // Limit number of deletes a non-admin can do.
+            // Cf. https://github.com/globaldothealth/list/issues/937.
+            if (!(req.user as UserDocument)?.roles?.includes('admin')) {
+                req.body['maxCasesThreshold'] = 10000;
+            }
             const response = await axios.delete(
                 this.dataServerURL + '/api' + req.url,
                 { data: req.body },

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -222,7 +222,7 @@ new OpenApiValidator({
         );
         apiRouter.get(
             '/cases',
-            mustHaveAnyRole(['reader', 'curator']),
+            mustHaveAnyRole(['reader', 'curator', 'admin']),
             casesController.list,
         );
         apiRouter.get(
@@ -242,7 +242,7 @@ new OpenApiValidator({
         );
         apiRouter.get(
             '/cases/:id([a-z0-9]{24})',
-            mustHaveAnyRole(['reader', 'curator']),
+            mustHaveAnyRole(['reader', 'curator', 'admin']),
             casesController.get,
         );
         apiRouter.post(
@@ -277,7 +277,7 @@ new OpenApiValidator({
         );
         apiRouter.delete(
             '/cases',
-            mustHaveAnyRole(['curator']),
+            mustHaveAnyRole(['curator', 'admin']),
             casesController.batchDel,
         );
         apiRouter.delete(

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -260,7 +260,35 @@ describe('Cases', () => {
         expect(mockedAxios.delete).toHaveBeenCalledWith(
             'http://localhost:3000/api/cases',
             {
-                data: { caseIds: ['5e99f21a1c9d440000ceb088'] },
+                data: {
+                    caseIds: ['5e99f21a1c9d440000ceb088'],
+                    maxCasesThreshold: 10000,
+                },
+            },
+        );
+    });
+
+    it('does not set maxCasesThreshold for admins', async () => {
+        mockedAxios.delete.mockResolvedValueOnce({
+            status: 204,
+            statusText: 'Cases deleted',
+        });
+        const adminRequest = supertest.agent(app);
+        await adminRequest
+            .post('/auth/register')
+            .send({ ...baseUser, ...{ roles: ['reader', 'curator', 'admin'] } })
+            .expect(200);
+        await adminRequest
+            .delete('/api/cases')
+            .send({ caseIds: ['5e99f21a1c9d440000ceb088'] })
+            .expect(204);
+        expect(mockedAxios.delete).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.delete).toHaveBeenCalledWith(
+            'http://localhost:3000/api/cases',
+            {
+                data: {
+                    caseIds: ['5e99f21a1c9d440000ceb088'],
+                },
             },
         );
     });

--- a/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
@@ -66,7 +66,7 @@ describe('App', function () {
 
         cy.contains('Create new').should('not.exist');
         cy.contains('Home');
-        cy.contains('Linelist').should('not.exist');
+        cy.contains('Linelist');
         cy.contains('Sources').should('not.exist');
         cy.contains('Uploads').should('not.exist');
         cy.contains('Profile');

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -253,7 +253,8 @@ export default function App(): JSX.Element {
             text: 'Linelist',
             icon: <ListIcon />,
             to: '/cases',
-            displayCheck: (): boolean => hasAnyRole(['reader', 'curator']),
+            displayCheck: (): boolean =>
+                hasAnyRole(['reader', 'curator', 'admin']),
         },
         {
             text: 'Sources',
@@ -477,7 +478,7 @@ export default function App(): JSX.Element {
                 >
                     <div className={classes.drawerHeader} />
                     <Switch>
-                        {hasAnyRole(['curator', 'reader']) && (
+                        {hasAnyRole(['curator', 'reader', 'admin']) && (
                             <Route exact path="/cases">
                                 <LinelistTable user={user} />
                             </Route>

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -579,7 +579,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 <MaterialTable
                     tableRef={this.tableRef}
                     columns={[
-                        ...(this.props.user.roles.includes('curator')
+                        ...(this.props.user.roles.includes('curator') ||
+                        this.props.user.roles.includes('admin')
                             ? [
                                   // TODO: move to the left of selection checkboxes when possible
                                   // https://github.com/mbrn/material-table/issues/2317
@@ -785,7 +786,9 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                         sorting: false, // Would be nice but has to wait on indexes to properly query the DB.
                         padding: 'dense',
                         draggable: false, // No need to be able to drag and drop headers.
-                        selection: this.props.user.roles.includes('curator'),
+                        selection:
+                            this.props.user.roles.includes('curator') ||
+                            this.props.user.roles.includes('admin'),
                         pageSize: this.state.pageSize,
                         pageSizeOptions: [5, 10, 20, 50, 100],
                         maxBodyHeight: 'calc(100vh - 20em)',
@@ -813,7 +816,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                         }
                     }}
                     actions={
-                        this.props.user.roles.includes('curator')
+                        this.props.user.roles.includes('curator') ||
+                        this.props.user.roles.includes('admin')
                             ? [
                                   // Only allow selecting rows across pages if
                                   // there is a search query.

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -579,8 +579,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                 <MaterialTable
                     tableRef={this.tableRef}
                     columns={[
-                        ...(this.props.user.roles.includes('curator') ||
-                        this.props.user.roles.includes('admin')
+                        ...(this.props.user.roles.includes('curator')
                             ? [
                                   // TODO: move to the left of selection checkboxes when possible
                                   // https://github.com/mbrn/material-table/issues/2317
@@ -879,6 +878,9 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                       icon: (): JSX.Element => (
                                           <VerifiedIcon data-testid="verify-action" />
                                       ),
+                                      hidden: !this.props.user.roles.includes(
+                                          'curator',
+                                      ),
                                       tooltip: 'Verify selected rows',
                                       // eslint-disable-next-line @typescript-eslint/no-explicit-any
                                       onClick: async (
@@ -903,6 +905,9 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                   {
                                       icon: (): JSX.Element => (
                                           <UnverifiedIcon data-testid="unverify-action" />
+                                      ),
+                                      hidden: !this.props.user.roles.includes(
+                                          'curator',
                                       ),
                                       tooltip: 'Unverify selected rows',
                                       // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #937

This also makes the linelist visible to admins so that they can issue the delete call from there.
I did not give them more permissions other than delete (for example edit/verify is not granted).