### PR TITLE
create all indexes with default collation set for case insensitivity

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -32,8 +32,15 @@ export const casesMatchingSearchQuery = (opts: {
           }
         : {};
 
-    const casesQuery = Case.find(queryOpts);
-    const countQuery = Case.countDocuments(queryOpts);
+    // Always search with case-insensitivity.
+    const casesQuery = Case.find(queryOpts).collation({
+        locale: 'en_US',
+        strength: 2,
+    });
+    const countQuery = Case.countDocuments(queryOpts).collation({
+        locale: 'en_US',
+        strength: 2,
+    });
     // Fill in keyword filters.
     parsedSearch.filters.forEach((f) => {
         if (f.values.length == 1) {

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -144,9 +144,15 @@ describe('GET', () => {
                 expect(res.body.cases).toHaveLength(0);
                 expect(res.body.total).toEqual(0);
             });
-            it('returns the case if keyword matches', async () => {
+            it('returns the case if matches', async () => {
                 await request(app)
                     .get('/api/cases?page=1&limit=1&q=country%3AGermany')
+                    .expect(200, /Germany/)
+                    .expect('Content-Type', /json/);
+            });
+            it('returns the case if non case sensitive matches', async () => {
+                await request(app)
+                    .get('/api/cases?page=1&limit=1&q=country%3Agermany')
                     .expect(200, /Germany/)
                     .expect('Content-Type', /json/);
             });

--- a/data-serving/scripts/setup-db/src/index.ts
+++ b/data-serving/scripts/setup-db/src/index.ts
@@ -62,6 +62,8 @@ const setupDatabase = async ({
         } else {
             await database.createCollection(collectionName, {
                 validator: schema,
+                // Create default indexes with case-insensitivity.
+                collation: { locale: 'en_US', strength: 2 },
             });
             print(`Created collection "${collectionName}" with schema 📑`);
             collection = await database.getCollection(collectionName);

--- a/data-serving/scripts/setup-db/src/types/mongo-cli.d.ts
+++ b/data-serving/scripts/setup-db/src/types/mongo-cli.d.ts
@@ -71,6 +71,12 @@ interface IndexSpec {
 /** Options to pass with the command to create a collection. */
 interface CreateCollectionOptions {
     validator: JSON;
+    collation?: Collation;
+}
+
+interface Collation {
+    locale: string;
+    strength: number;
 }
 
 /** The result of a call to `runCommand.` */

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -206,7 +206,7 @@ describe('Linelist table', function () {
         cy.contains('France');
         cy.get('input[id="search-field"]').click();
         cy.get('li').contains('country:').click();
-        cy.get('input[id="search-field"]').type('Uruguay{enter}');
+        cy.get('input[id="search-field"]').type('uruguay{enter}');
         cy.contains('France').should('not.exist');
         cy.get('input[id="search-field"]').clear().type('France{enter}');
         cy.get('td[value="France"]');


### PR DESCRIPTION
Mongo docs about collation: https://docs.mongodb.com/manual/reference/collation/

+ simple
- mongoose doesn't allow to set collation when creating indexes, we do not use mongoose to create collections so we can't set the default collation that way either.
- no way to do case-sensitive matches (but did we want that really? I don't think so)
- we have to run the setup-db which drops indexes created by mongoose when server starts so it requires a restart of the prod/dev jobs once done.

For #925