### PR TITLE
Move pagination bar to the top of the tables

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -220,9 +220,14 @@ describe('Linelist table', function () {
                 sourceUrl: 'foo.bar',
             });
         }
+        cy.server();
+        cy.route('GET', '/api/cases/*').as('getCases');
         cy.visit('/cases');
+        cy.wait('@getCases');
         cy.contains('rows').click();
+        cy.route('GET', '/api/cases/?limit=5&page=1').as('get5Cases');
         cy.get('li').contains('5').click();
+        cy.wait('@get5Cases');
         cy.get('input[type="checkbox"]').should('have.length', 6);
         cy.contains('1 row selected').should('not.exist');
         cy.get('input[type="checkbox"]').eq(1).click();
@@ -258,7 +263,10 @@ describe('Linelist table', function () {
         cy.addCase({
             country: 'United Kingdom',
         });
+        cy.server();
+        cy.route('GET', '/api/cases/*').as('getCases');
         cy.visit('/cases');
+        cy.wait('@getCases');
         cy.contains('rows').click();
         cy.get('li').contains('5').click();
         cy.get('input[id="search-field"]').click();

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -52,6 +52,7 @@ describe('Manage users page', function () {
         cy.get('li[data-value="admin"]').click();
         cy.wait('@updateUser');
         cy.wait('@getUsers');
+        cy.get('div[data-testid="Bob-select-roles"]').click();
         cy.get('li[data-value="reader"]').click();
         cy.wait('@updateUser');
         cy.wait('@getUsers');

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -8,8 +8,11 @@ import {
     IconButton,
     Menu,
     MenuItem,
+    Paper,
+    TablePagination,
     Theme,
     Tooltip,
+    Typography,
     makeStyles,
     withStyles,
 } from '@material-ui/core';
@@ -100,6 +103,14 @@ const styles = (theme: Theme) =>
         centeredContent: {
             display: 'flex',
             justifyContent: 'center',
+        },
+        spacer: { flex: 1 },
+        paginationRoot: { border: 'unset' },
+        tablePaginationBar: {
+            alignItems: 'center',
+            backgroundColor: '#ECF3F0',
+            display: 'flex',
+            height: '64px',
         },
         tableToolbar: {
             backgroundColor: '#31A497',
@@ -734,6 +745,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                     }
                                     this.setState({
                                         totalNumRows: result.data.total,
+                                        selectedRowsCurrentPage: [],
+                                        numSelectedRows: 0,
                                     });
                                     resolve({
                                         data: flattenedCases,
@@ -757,19 +770,34 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 });
                         })
                     }
-                    title="COVID-19 cases"
                     components={{
+                        Container: (props): JSX.Element => (
+                            <Paper elevation={0} {...props}></Paper>
+                        ),
+                        Pagination: (props): JSX.Element => {
+                            return this.state.numSelectedRows === 0 ? (
+                                <div className={classes.tablePaginationBar}>
+                                    <Typography>Linelist</Typography>
+                                    <span className={classes.spacer}></span>
+                                    <TablePagination
+                                        {...props}
+                                        classes={{
+                                            ...props.classes,
+                                            root: classes.paginationRoot,
+                                        }}
+                                    ></TablePagination>
+                                </div>
+                            ) : (
+                                <></>
+                            );
+                        },
                         Toolbar: (props): JSX.Element => (
                             <MTableToolbar
                                 {...props}
-                                classes={
-                                    this.state.numSelectedRows > 0
-                                        ? {
-                                              highlight: classes.tableToolbar,
-                                              title: classes.toolbarItems,
-                                          }
-                                        : {}
-                                }
+                                classes={{
+                                    highlight: classes.tableToolbar,
+                                    title: classes.toolbarItems,
+                                }}
                                 toolbarButtonAlignment="left"
                             />
                         ),
@@ -800,6 +828,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             this.props.user.roles.includes('admin'),
                         pageSize: this.state.pageSize,
                         pageSizeOptions: [5, 10, 20, 50, 100],
+                        paginationPosition: 'top',
+                        toolbar: this.state.numSelectedRows > 0,
                         maxBodyHeight: 'calc(100vh - 20em)',
                         headerStyle: {
                             zIndex: 1,

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -2,7 +2,9 @@ import {
     Button,
     Divider,
     MenuItem,
+    TablePagination,
     Theme,
+    Typography,
     WithStyles,
     createStyles,
     withStyles,
@@ -12,12 +14,12 @@ import React, { RefObject } from 'react';
 
 import MuiAlert from '@material-ui/lab/Alert';
 import Paper from '@material-ui/core/Paper';
+import ParsersAutocomplete from './ParsersAutocomplete';
+import SourceRetrievalButton from './SourceRetrievalButton';
 import TextField from '@material-ui/core/TextField';
+import User from './User';
 import axios from 'axios';
 import { isUndefined } from 'util';
-import User from './User';
-import SourceRetrievalButton from './SourceRetrievalButton';
-import ParsersAutocomplete from './ParsersAutocomplete';
 
 interface ListResponse {
     sources: Source[];
@@ -106,6 +108,14 @@ const styles = (theme: Theme) =>
         divider: {
             marginTop: theme.spacing(1),
             marginBottom: theme.spacing(1),
+        },
+        spacer: { flex: 1 },
+        paginationRoot: { border: 'unset' },
+        tablePaginationBar: {
+            alignItems: 'center',
+            backgroundColor: '#ECF3F0',
+            display: 'flex',
+            height: '64px',
         },
     });
 
@@ -480,7 +490,28 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                     });
                             })
                         }
-                        title="Ingestion sources"
+                        components={{
+                            Container: (props): JSX.Element => (
+                                <Paper elevation={0} {...props}></Paper>
+                            ),
+                            Pagination: (props): JSX.Element => {
+                                return (
+                                    <div className={classes.tablePaginationBar}>
+                                        <Typography>
+                                            Ingestion sources
+                                        </Typography>
+                                        <span className={classes.spacer}></span>
+                                        <TablePagination
+                                            {...props}
+                                            classes={{
+                                                ...props.classes,
+                                                root: classes.paginationRoot,
+                                            }}
+                                        ></TablePagination>
+                                    </div>
+                                );
+                            },
+                        }}
                         options={{
                             // TODO: Create text indexes and support search queries.
                             // https://docs.mongodb.com/manual/text-search/
@@ -492,6 +523,8 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                             draggable: false, // No need to be able to drag and drop headers.
                             pageSize: this.state.pageSize,
                             pageSizeOptions: [5, 10, 20, 50, 100],
+                            paginationPosition: 'top',
+                            toolbar: false,
                             maxBodyHeight: 'calc(100vh - 15em)',
                             headerStyle: {
                                 zIndex: 1,

--- a/verification/curator-service/ui/src/components/UploadsTable.tsx
+++ b/verification/curator-service/ui/src/components/UploadsTable.tsx
@@ -1,4 +1,5 @@
 import MaterialTable, { QueryResult } from 'material-table';
+import { Paper, TablePagination, Typography } from '@material-ui/core';
 import React, { RefObject } from 'react';
 import {
     Theme,
@@ -9,7 +10,6 @@ import {
 
 import { Link } from 'react-router-dom';
 import MuiAlert from '@material-ui/lab/Alert';
-import { Paper } from '@material-ui/core';
 import axios from 'axios';
 import renderDate from './util/date';
 
@@ -20,6 +20,14 @@ const styles = (theme: Theme) =>
         alert: {
             borderRadius: theme.spacing(1),
             marginTop: theme.spacing(2),
+        },
+        spacer: { flex: 1 },
+        paginationRoot: { border: 'unset' },
+        tablePaginationBar: {
+            alignItems: 'center',
+            backgroundColor: '#ECF3F0',
+            display: 'flex',
+            height: '64px',
         },
     });
 
@@ -184,7 +192,26 @@ class UploadsTable extends React.Component<Props, UploadsTableState> {
                                     });
                             })
                         }
-                        title="Uploads"
+                        components={{
+                            Container: (props): JSX.Element => (
+                                <Paper elevation={0} {...props}></Paper>
+                            ),
+                            Pagination: (props): JSX.Element => {
+                                return (
+                                    <div className={classes.tablePaginationBar}>
+                                        <Typography>Uploads</Typography>
+                                        <span className={classes.spacer}></span>
+                                        <TablePagination
+                                            {...props}
+                                            classes={{
+                                                ...props.classes,
+                                                root: classes.paginationRoot,
+                                            }}
+                                        ></TablePagination>
+                                    </div>
+                                );
+                            },
+                        }}
                         options={{
                             // TODO: Create text indexes and support search queries.
                             // https://docs.mongodb.com/manual/text-search/
@@ -196,6 +223,8 @@ class UploadsTable extends React.Component<Props, UploadsTableState> {
                             draggable: false, // No need to be able to drag and drop headers.
                             pageSize: this.state.pageSize,
                             pageSizeOptions: [5, 10, 20, 50, 100],
+                            paginationPosition: 'top',
+                            toolbar: false,
                             maxBodyHeight: 'calc(100vh - 15em)',
                             headerStyle: {
                                 zIndex: 1,

--- a/verification/curator-service/ui/src/components/Users.test.tsx
+++ b/verification/curator-service/ui/src/components/Users.test.tsx
@@ -186,7 +186,7 @@ test('calls callback when user is changed', async () => {
     fireEvent.click(listbox.getByText(/curator/i));
     fireEvent.keyDown(getByRole('listbox'), { key: 'Escape' });
     // Awaiting this text gives time for the async functions to complete.
-    expect(await findByText('Alice Smith')).toBeInTheDocument();
+    expect(await findByText('Alice Smith')).toBeInTheDOM();
 
     // Check callback has been called
     expect(mockCallback).toHaveBeenCalledTimes(1);
@@ -246,7 +246,7 @@ test('callback not called when other users are changed', async () => {
     fireEvent.click(listbox.getByText(/curator/i));
     fireEvent.keyDown(getByRole('listbox'), { key: 'Escape' });
     // Awaiting this text gives time for the async functions to complete.
-    expect(await findByText('Alice Smith')).toBeInTheDocument();
+    expect(await findByText('Alice Smith')).toBeInTheDOM();
 
     // Check callback has not been called
     expect(functionCalledCounter).toBe(0);

--- a/verification/curator-service/ui/src/components/Users.tsx
+++ b/verification/curator-service/ui/src/components/Users.tsx
@@ -1,10 +1,16 @@
 import MaterialTable, { QueryResult } from 'material-table';
+import { Paper, TablePagination, Typography } from '@material-ui/core';
 import React, { RefObject } from 'react';
+import {
+    Theme,
+    WithStyles,
+    createStyles,
+    withStyles,
+} from '@material-ui/core/styles';
 
 import FormControl from '@material-ui/core/FormControl';
 import MenuItem from '@material-ui/core/MenuItem';
 import MuiAlert from '@material-ui/lab/Alert';
-import { Paper } from '@material-ui/core';
 import Select from '@material-ui/core/Select';
 import User from './User';
 import axios from 'axios';
@@ -29,7 +35,7 @@ interface TableRow {
     roles: string[];
 }
 
-interface Props {
+interface Props extends WithStyles<typeof styles> {
     user: User;
     onUserChange: () => void;
 }
@@ -38,7 +44,25 @@ interface UsersSelectDisplayProps extends React.HTMLAttributes<HTMLDivElement> {
     'data-testid'?: string;
 }
 
-export default class Users extends React.Component<Props, UsersState> {
+// Return type isn't meaningful.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const styles = (theme: Theme) =>
+    createStyles({
+        alert: {
+            borderRadius: theme.spacing(1),
+            marginTop: theme.spacing(2),
+        },
+        spacer: { flex: 1 },
+        paginationRoot: { border: 'unset' },
+        tablePaginationBar: {
+            alignItems: 'center',
+            backgroundColor: '#ECF3F0',
+            display: 'flex',
+            height: '64px',
+        },
+    });
+
+class Users extends React.Component<Props, UsersState> {
     // We could use a proper type here but then we wouldn't be able to call
     // onQueryChange() to refresh the table as we want.
     // https://github.com/mbrn/material-table/issues/1752
@@ -66,10 +90,15 @@ export default class Users extends React.Component<Props, UsersState> {
     }
 
     render(): JSX.Element {
+        const { classes } = this.props;
         return (
             <Paper>
                 {this.state.error && (
-                    <MuiAlert elevation={6} variant="filled" severity="error">
+                    <MuiAlert
+                        classes={{ root: classes.alert }}
+                        variant="filled"
+                        severity="error"
+                    >
                         {this.state.error}
                     </MuiAlert>
                 )}
@@ -129,7 +158,26 @@ export default class Users extends React.Component<Props, UsersState> {
                                 });
                         })
                     }
-                    title="Users"
+                    components={{
+                        Container: (props): JSX.Element => (
+                            <Paper elevation={0} {...props}></Paper>
+                        ),
+                        Pagination: (props): JSX.Element => {
+                            return (
+                                <div className={classes.tablePaginationBar}>
+                                    <Typography>Users</Typography>
+                                    <span className={classes.spacer}></span>
+                                    <TablePagination
+                                        {...props}
+                                        classes={{
+                                            ...props.classes,
+                                            root: classes.paginationRoot,
+                                        }}
+                                    ></TablePagination>
+                                </div>
+                            );
+                        },
+                    }}
                     options={{
                         search: false,
                         filtering: false,
@@ -138,6 +186,8 @@ export default class Users extends React.Component<Props, UsersState> {
                         draggable: false, // No need to be able to drag and drop headers.
                         pageSize: this.state.pageSize,
                         pageSizeOptions: [5, 10, 20, 50, 100],
+                        paginationPosition: 'top',
+                        toolbar: false,
                         headerStyle: {
                             zIndex: 1,
                         },
@@ -207,3 +257,5 @@ export default class Users extends React.Component<Props, UsersState> {
         );
     }
 }
+
+export default withStyles(styles, { withTheme: true })(Users);


### PR DESCRIPTION
For #948

![Screen Shot 2020-09-07 at 3 14 23 PM](https://user-images.githubusercontent.com/30459667/92400696-3c3d7a00-f124-11ea-95c3-d8674a3807da.png)
![Screen Shot 2020-09-07 at 3 14 32 PM](https://user-images.githubusercontent.com/30459667/92400692-3b0c4d00-f124-11ea-9bf9-037f1cf571a9.png)
![Screen Shot 2020-09-07 at 4 00 08 PM](https://user-images.githubusercontent.com/30459667/92400699-3d6ea700-f124-11ea-981c-9737ea87dff0.png)
![Screen Shot 2020-09-07 at 4 01 49 PM](https://user-images.githubusercontent.com/30459667/92400740-4fe8e080-f124-11ea-8a8c-221f765261a4.png)
