### PR TITLE
Define all case insensitive text keyword indexes in index schema instead of relying on mongoose

### DIFF
--- a/data-serving/data-service/schemas/cases.indexes.json
+++ b/data-serving/data-service/schemas/cases.indexes.json
@@ -45,18 +45,130 @@
         "name": "eventNamesIdx",
         "key": {
             "events.name": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
         }
     },
     {
         "name": "countriesIdx",
         "key": {
             "location.country": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
         }
     },
     {
         "name": "travelHistoryCountriesIdx",
         "key": {
             "travelHistory.travel.location.country": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "demographicsGenderIdx",
+        "key": {
+            "demographics.gender": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "demographicsOccupationIdx",
+        "key": {
+            "demographics.occupation": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "demographicsNationalitiesIdx",
+        "key": {
+            "demographics.nationalities": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "demographicsEthnicityIdx",
+        "key": {
+            "demographics.ethnicity": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "locationAdmin1Idx",
+        "key": {
+            "location.administrativeAreaLevel1": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "locationAdmin2Idx",
+        "key": {
+            "location.administrativeAreaLevel2": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "locationAdmin3Idx",
+        "key": {
+            "location.administrativeAreaLevel3": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "pathogenIdx",
+        "key": {
+            "pathogen.name": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "caseReferenceCreationMetadataCuratorIdx",
+        "key": {
+            "caseReference.creationMetadata.curator": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
+        "name": "caseReferenceUpdateMetadataCuratorIdx",
+        "key": {
+            "caseReference.updateMetadata.curator": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
         }
     }
 ]

--- a/data-serving/data-service/src/model/demographics.ts
+++ b/data-serving/data-service/src/model/demographics.ts
@@ -16,22 +16,10 @@ export const demographicsSchema = new mongoose.Schema(
             },
             _id: false,
         },
-        gender: {
-            type: String,
-            index: true,
-        },
-        occupation: {
-            type: String,
-            index: true,
-        },
-        nationalities: {
-            type: [String],
-            index: true,
-        },
-        ethnicity: {
-            type: String,
-            index: true,
-        },
+        gender: String,
+        occupation: String,
+        nationalities: [String],
+        ethnicity: String,
     },
     { _id: false },
 );

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -23,20 +23,10 @@ export const locationSchema = new mongoose.Schema(
         country: {
             type: String,
             required: true,
-            index: true,
         },
-        administrativeAreaLevel1: {
-            type: String,
-            index: true,
-        },
-        administrativeAreaLevel2: {
-            type: String,
-            index: true,
-        },
-        administrativeAreaLevel3: {
-            type: String,
-            index: true,
-        },
+        administrativeAreaLevel1: String,
+        administrativeAreaLevel2: String,
+        administrativeAreaLevel3: String,
         // Place represents a precise location, such as an establishment or POI.
         place: String,
         // A human-readable name of the location.

--- a/data-serving/data-service/src/model/pathogen.ts
+++ b/data-serving/data-service/src/model/pathogen.ts
@@ -6,7 +6,6 @@ export const pathogenSchema = new mongoose.Schema(
         name: {
             type: String,
             required: true,
-            index: true,
         },
         id: {
             ...positiveIntFieldInfo,

--- a/data-serving/data-service/src/model/revision-metadata.ts
+++ b/data-serving/data-service/src/model/revision-metadata.ts
@@ -7,7 +7,6 @@ const editMetadataSchema = new mongoose.Schema(
         curator: {
             type: String,
             required: true,
-            index: true,
         },
         date: {
             ...dateFieldInfo,

--- a/data-serving/scripts/setup-db/src/index.ts
+++ b/data-serving/scripts/setup-db/src/index.ts
@@ -62,8 +62,6 @@ const setupDatabase = async ({
         } else {
             await database.createCollection(collectionName, {
                 validator: schema,
-                // Create default indexes with case-insensitivity.
-                collation: { locale: 'en_US', strength: 2 },
             });
             print(`Created collection "${collectionName}" with schema 📑`);
             collection = await database.getCollection(collectionName);


### PR DESCRIPTION
Had to revert to this because there is no way to update an existing collection after it's created to properly setup the default collation as I attempted in my previous PR.
This way we can drop the indexes and recreate them as does the setup-db script and we don't have to touch the collection itself.

For #925 