### PR TITLE
Don't set HTTP timeouts.

### DIFF
--- a/data-serving/data-service/src/server.ts
+++ b/data-serving/data-service/src/server.ts
@@ -6,4 +6,7 @@ const server = app.listen(app.get('port'), async () => {
     console.log('  Press CTRL-C to stop\n');
 });
 
+// Set global 1-hour timeout.
+server.setTimeout(60 * 60 * 1000);
+
 export default server;

--- a/data-serving/data-service/src/server.ts
+++ b/data-serving/data-service/src/server.ts
@@ -7,6 +7,8 @@ const server = app.listen(app.get('port'), async () => {
 });
 
 // Set global 1-hour timeout.
+// TODO: Make this more fine-grained once we fix
+//   https://github.com/globaldothealth/list/issues/961.
 server.setTimeout(60 * 60 * 1000);
 
 export default server;

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -5,6 +5,8 @@ import { UserDocument } from '../model/user';
 import axios from 'axios';
 
 // Don't set client-side timeouts for requests to the data service.
+// TODO: Make this more fine-grained once we fix
+//   https://github.com/globaldothealth/list/issues/961.
 axios.defaults.timeout = 0;
 
 class InvalidParamError extends Error {}

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -4,6 +4,9 @@ import { Request, Response } from 'express';
 import { UserDocument } from '../model/user';
 import axios from 'axios';
 
+// Don't set client-side timeouts for requests to the data service.
+axios.defaults.timeout = 0;
+
 class InvalidParamError extends Error {}
 
 /**

--- a/verification/curator-service/api/src/server.ts
+++ b/verification/curator-service/api/src/server.ts
@@ -6,4 +6,7 @@ const server = app.listen(app.get('port'), () => {
     console.log('  Press CTRL-C to stop\n');
 });
 
+// Set global 1-hour timeout.
+server.setTimeout(60 * 60 * 1000);
+
 export default server;

--- a/verification/curator-service/api/src/server.ts
+++ b/verification/curator-service/api/src/server.ts
@@ -7,6 +7,8 @@ const server = app.listen(app.get('port'), () => {
 });
 
 // Set global 1-hour timeout.
+// TODO: Make this more fine-grained once we fix
+//   https://github.com/globaldothealth/list/issues/961.
 server.setTimeout(60 * 60 * 1000);
 
 export default server;


### PR DESCRIPTION
This is a little heavy-handed, but I can dial it back to the right level if this works.

Trying to debug #961 (which I can't repro locally), so casting a wide net at first.