### PR TITLE
Send parsed cases in batches to avoid OOMs and ease lambda memory usage

### DIFF
--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -170,8 +170,10 @@ is run on pull requests.
 
 ### Writing a parser
 
-At minima, a parser must output a list of cases that conform to the openAPI
+At minima, a parser must generate a list of cases that conform to the openAPI
 specifications.
+
+Its main function must yield cases one by one using [python generators](https://wiki.python.org/moin/Generators). A common library will take care of sending those cases to the server for you.
 
 If you have a local stack running, go to the [OpenAPI UI](http://localhost:3001/api-docs) to check the structure of a `Case` object. Otherwise you can always [check it online](https://curator.ghdsi.org/api-docs/) as well.
 

--- a/ingestion/functions/parsing/ch_zurich/input_event.json
+++ b/ingestion/functions/parsing/ch_zurich/input_event.json
@@ -1,7 +1,7 @@
 {
     "env": "local",
     "s3Bucket": "epid-sources-raw",
-    "s3Key": "5f32be3fe3f3ef002e849307/2020/08/12/0815/content.csv",
+    "s3Key": "5f589b22d9a72c0028ec668b/2020/09/09/0908/content.csv",
     "sourceUrl": "https://github.com/openZH/covid_19/blob/master/fallzahlen_kanton_alter_geschlecht_csv/COVID19_Fallzahlen_Kanton_ZH_alter_geschlecht.csv",
-    "sourceId": "5f32be3fe3f3ef002e849307"
+    "sourceId": "5f589b22d9a72c0028ec668b"
 }

--- a/ingestion/functions/parsing/ch_zurich/zurich.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich.py
@@ -78,7 +78,6 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
     with open(raw_data_file, "r") as f:
         reader = csv.reader(f)
         next(reader)  # Skip the header.
-        cases = []
         for row in reader:
             num_confirmed_cases = int(row[_CONFIRMED_INDEX])
             if not num_confirmed_cases:
@@ -103,10 +102,10 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                     "demographics": convert_demographics(
                         row[_GENDER_INDEX], row[_AGE_INDEX]),
                 }
-                cases.extend([case] * num_confirmed_cases)
+                for _ in range(num_confirmed_cases):
+                    yield case
             except ValueError as ve:
                 print(ve)
-        return cases
 
 
 def lambda_handler(event, context):

--- a/ingestion/functions/parsing/ch_zurich/zurich_test.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich_test.py
@@ -55,4 +55,4 @@ class CHZurichTest(unittest.TestCase):
         sample_data_file = os.path.join(current_dir, "sample_data.csv")
 
         result = zurich.parse_cases(sample_data_file, _SOURCE_ID, _SOURCE_URL)
-        self.assertCountEqual(result, [_PARSED_CASE, _PARSED_CASE])
+        self.assertCountEqual(list(result), [_PARSED_CASE, _PARSED_CASE])

--- a/ingestion/functions/parsing/common/python/parsing_lib/input_event.json
+++ b/ingestion/functions/parsing/common/python/parsing_lib/input_event.json
@@ -7,7 +7,7 @@
     "uploadIds": ["123456789012345678901234"],
     "dateFilter": {
         "numDaysBeforeToday": 3,
-        "op": "EQ"
+        "op": "LT"
     },
     "auth": {
         "email": "test@fixture.com"

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -97,7 +97,6 @@ def batch_of(cases, max_items):
         return batch
     except StopIteration:
         return batch
-    
 
 def write_to_server(cases, env, source_id, upload_id, headers, cookies):
     """Upserts the provided cases via the G.h Case API."""

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -69,7 +69,7 @@ def parse_cases(raw_data_file, source_id, source_url):
     """
     with open(raw_data_file, "r") as f:
         cases = json.load(f)
-        return [
+        return (
             {
                 "caseReference": {
                     "sourceId": source_id,
@@ -95,7 +95,7 @@ def parse_cases(raw_data_file, source_id, source_url):
                     "gender": convert_gender(entry["gender"])
                 },
                 "notes": entry["notes"] or None
-            } for entry in cases["raw_data"] if entry["agebracket"]]
+            } for entry in cases["raw_data"] if entry["agebracket"])
 
 
 def lambda_handler(event, context):

--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -58,5 +58,5 @@ def test_parse_cases_converts_fields_to_ghdsi_schema(sample_data):
         json.dump(sample_data, f)
         f.flush()
 
-        result, = india.parse_cases(f.name, _SOURCE_ID, _SOURCE_URL)
+        result = next(india.parse_cases(f.name, _SOURCE_ID, _SOURCE_URL))
         assert result == _PARSED_CASE

--- a/ingestion/functions/parsing/japan/japan.py
+++ b/ingestion/functions/parsing/japan/japan.py
@@ -52,7 +52,7 @@ def parse_cases(raw_data_file, source_id, source_url):
     """
     with open(raw_data_file, "r") as f:
         cases = json.load(f)
-        return [
+        return (
             {
                 "caseReference": {
                     "sourceId": source_id,
@@ -75,7 +75,7 @@ def parse_cases(raw_data_file, source_id, source_url):
                     "gender": convert_gender(entry)
                 },
                 "notes": detect_notes(entry)
-            } for entry in cases if entry["patientId"] != "-1"]
+            } for entry in cases if entry["patientId"] != "-1")
 
 
 def lambda_handler(event, context):

--- a/ingestion/functions/parsing/japan/japan_test.py
+++ b/ingestion/functions/parsing/japan/japan_test.py
@@ -54,6 +54,6 @@ def test_parse_cases_converts_fields_to_ghdsi_schema(sample_data):
         json.dump(sample_data, f)
         f.flush()
 
-        result, = japan.parse_cases(f.name, _SOURCE_ID, _SOURCE_URL)
+        result = next(japan.parse_cases(f.name, _SOURCE_ID, _SOURCE_URL))
         assert result == _PARSED_CASE
 

--- a/ingestion/functions/retrieval/valid_scheduled_event.json
+++ b/ingestion/functions/retrieval/valid_scheduled_event.json
@@ -1,4 +1,4 @@
 {
     "env": "local",
-    "sourceId": "5f4cbc1585d64403a986b1b4"
+    "sourceId": "5f589b22d9a72c0028ec668b"
 }


### PR DESCRIPTION
For #961 

Overall feels much efficient than storing the whole list in memory in multiple places.