### PR TITLE
increase memory of japan parsing func

### DIFF
--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -92,6 +92,7 @@ Resources:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
       Timeout: 300
+      MemorySize: 512
       Layers:
         - !Ref ParsingLibLayer
         - !Ref CommonLibLayer


### PR DESCRIPTION
Note: the json input file is 30Mb (as of today, still growing of course), there is no way to stream this in unfortuantely as the object that it contains is an array of cases :(

They do not have a csv as an alternative format.

When ran locally the function was just timing out on json.load(f) with no logs.
After increasing the memory to 512Mb it worked.

https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-memorysize

#961 