### PR TITLE
Move common parsing template values into Globals.

### DIFF
--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -2,6 +2,13 @@ AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: AWS Lambda functions for Global Health ingestion
 
+Globals:
+  Function:
+    Runtime: python3.8
+    Timeout: 900
+    Layers:
+      - !Ref CommonLibLayer
+
 Resources:
   RawSourcesBucket:
     Type: AWS::S3::Bucket
@@ -12,16 +19,12 @@ Resources:
     Properties:
       CodeUri: retrieval/
       Handler: retrieval.lambda_handler
-      Runtime: python3.8
       Description: Retrieve raw source content
       # Function's execution role
       Policies:
         - AWSLambdaFullAccess
         - S3WritePolicy:
             BucketName: !Ref RawSourcesBucket
-      Timeout: 300
-      Layers:
-        - !Ref CommonLibLayer
   ParsingLibLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:
@@ -55,62 +58,50 @@ Resources:
     Properties:
       CodeUri: parsing/india/
       Handler: india.lambda_handler
-      Runtime: python3.8
       Description: Parse case data for India
       # Function's execution role
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
-      Timeout: 300
       Layers:
         - !Ref ParsingLibLayer
-        - !Ref CommonLibLayer
   HongKongParsingFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       CodeUri: parsing/hongkong/
       Handler: hongkong.lambda_handler
-      Runtime: python3.8
       Description: Parse case data for HongKong
       # Function's execution role
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
-      Timeout: 300
       Layers:
         - !Ref ParsingLibLayer
-        - !Ref CommonLibLayer
   JapanParsingFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       CodeUri: parsing/japan/
       Handler: japan.lambda_handler
-      Runtime: python3.8
       Description: Parse case data for Japan
       # Function's execution role
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
-      Timeout: 300
       MemorySize: 512
       Layers:
         - !Ref ParsingLibLayer
-        - !Ref CommonLibLayer
   CHZurichParsingFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       CodeUri: parsing/ch_zurich/
       Handler: zurich.lambda_handler
-      Runtime: python3.8
       Description: Parse case data for the Zurich Canton of Switzerland
       # Function's execution role
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
-      Timeout: 300
       Layers:
         - !Ref ParsingLibLayer
-        - !Ref CommonLibLayer
 # Declare values that can be imported to other CloudFormation stacks, or should
 # be made easily visible on the console.
 # For more information:


### PR DESCRIPTION
A timeout of 900 is the "default" (in that Lambdas are terminated after 900 seconds). It's probably worthwhile to declare it, so that our behavior doesn't implicitly change if AWS defaults are tweaked in the future.