### PR TITLE
Add a download option for selected rows

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -167,6 +167,7 @@ paths:
                   type: array
                   items:
                     type: string
+                    pattern: '^[a-f\d]{24}$'
                 query:
                   description: >
                     Cases matching this query will be deleted. Must contain
@@ -198,19 +199,33 @@ paths:
         "500":
           $ref: "#/components/responses/500"
   /cases/download:
-    get:
+    post:
       summary: >
-        Streams a CSV attachment of all cases. If parameter q is supplied the
-        CSV only contains cases matching the search query.
+        Streams a CSV attachment of all cases. If a query is supplied the
+        CSV only contains cases matching the search query. If caseIds are
+        supplied the CSV only contains cases with those ids. You cannot supply
+        both query and caseIds.
       tags: [Case]
       operationId: downloadCases
-      parameters:
-        - name: q
-          in: query
-          description: The search query
-          required: false
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              maxProperties: 1
+              properties:
+                caseIds:
+                  description: Cases corresponding to these ids will returned
+                  type: array
+                  items:
+                    type: string
+                    pattern: '^[a-f\d]{24}$'
+                query:
+                  description: >
+                    Cases matching this query will be returned. Must contain
+                    non-whitespace characters.
+                  type: string
+                  pattern: \S+
       responses:
         "200":
           $ref: "#/components/responses/200CasesDownload"

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -26,16 +26,18 @@ export const get = async (req: Request, res: Response): Promise<void> => {
 /**
  * Streams a CSV attachment of all cases.
  *
- * Handles HTTP GET /api/cases/download.
+ * Handles HTTP POST /api/cases/download.
  */
 export const download = async (req: Request, res: Response): Promise<void> => {
     let cases: any;
     try {
-        if (req.query.q) {
+        if (req.body.query) {
             cases = await casesMatchingSearchQuery({
-                searchQuery: req.query.q as string,
+                searchQuery: req.body.query as string,
                 count: false,
             });
+        } else if (req.body.caseIds) {
+            cases = await Case.find({ _id: { $in: req.body.caseIds } }).lean();
         } else {
             cases = await Case.find({}).lean();
         }

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -84,7 +84,6 @@ new OpenApiValidator({
         const apiRouter = express.Router();
         apiRouter.get('/cases/:id([a-z0-9]{24})', caseController.get);
         apiRouter.get('/cases', caseController.list);
-        apiRouter.get('/cases/download', caseController.download);
         apiRouter.get('/cases/symptoms', caseController.listSymptoms);
         apiRouter.get(
             '/cases/placesOfTransmission',
@@ -92,6 +91,7 @@ new OpenApiValidator({
         );
         apiRouter.get('/cases/occupations', caseController.listOccupations);
         apiRouter.post('/cases', setRevisionMetadata, caseController.create);
+        apiRouter.post('/cases/download', caseController.download);
         apiRouter.post('/cases/batchValidate', caseController.batchValidate);
         apiRouter.post(
             '/cases/batchUpsert',

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -52,83 +52,6 @@ describe('GET', () => {
             .get('/api/cases/53cb6b9b4f4ddef1ad47f943')
             .expect(404);
     });
-    describe('download', () => {
-        it('should return 200 OK', async () => {
-            const c = new Case(minimalCase);
-            await c.save();
-            const c2 = new Case(fullCase);
-            await c2.save();
-            const res = await request(app)
-                .get('/api/cases/download')
-                .expect('Content-Type', 'text/csv')
-                .expect(200);
-            expect(res.text).toContain(
-                '_id,caseReference.verificationStatus,caseReference.sourceId',
-            );
-            expect(res.text).toContain(c._id);
-            expect(res.text).toContain(c.caseReference.verificationStatus);
-            expect(res.text).toContain(c.caseReference.sourceId);
-            expect(res.text).toContain(c2._id);
-            expect(res.text).toContain(c2.caseReference.verificationStatus);
-            expect(res.text).toContain(c2.caseReference.sourceId);
-        });
-        it('rejects invalid searches', (done) => {
-            request(app)
-                .get('/api/cases/download?q=country%3A')
-                .expect(422, done);
-        });
-        it('should filter results with text query', async () => {
-            // Simulate index creation used in unit tests, in production they are
-            // setup by the setup-db script and such indexes are not present by
-            // default in the in memory mongo spawned by unit tests.
-            await mongoose.connection.collection('cases').createIndex({
-                notes: 'text',
-            });
-
-            const matchingCase = new Case(minimalCase);
-            const matchingNotes = 'matching';
-            matchingCase.notes = matchingNotes;
-            await matchingCase.save();
-
-            const unmatchedCase = new Case(minimalCase);
-            const unmatchedNotes = 'unmatched';
-            unmatchedCase.notes = unmatchedNotes;
-            await unmatchedCase.save();
-
-            const res = await request(app)
-                .get(`/api/cases/download?q=${matchingNotes}`)
-                .expect('Content-Type', 'text/csv')
-                .expect(200);
-            expect(res.text).toContain(
-                '_id,caseReference.verificationStatus,caseReference.sourceId',
-            );
-            expect(res.text).toContain(matchingNotes);
-            expect(res.text).toContain(matchingCase._id);
-            expect(res.text).toContain(matchingNotes);
-            expect(res.text).not.toContain(unmatchedCase._id);
-            expect(res.text).not.toContain(unmatchedNotes);
-        });
-        it('should filter results with keyword query', async () => {
-            const matchedCase = new Case(minimalCase);
-            matchedCase.location.country = 'Germany';
-            matchedCase.set('demographics.occupation', 'engineer');
-            await matchedCase.save();
-
-            const unmatchedCase = new Case(minimalCase);
-            await unmatchedCase.save();
-
-            const res = await request(app)
-                .get('/api/cases/download?q=country%3AGermany')
-                .expect('Content-Type', 'text/csv')
-                .expect(200);
-            expect(res.text).toContain(
-                '_id,caseReference.verificationStatus,caseReference.sourceId',
-            );
-            expect(res.text).toContain('Germany');
-            expect(res.text).toContain(matchedCase._id);
-            expect(res.text).not.toContain(unmatchedCase._id);
-        });
-    });
     describe('list', () => {
         it('should return 200 OK', () => {
             return request(app)
@@ -669,6 +592,129 @@ describe('POST', () => {
         expect(res.body.errors).toHaveLength(1);
         expect(res.body.errors[0].index).toBe(1);
         expect(res.body.errors[0].message).toMatch('Case validation failed');
+    });
+    describe('download', () => {
+        it('should return 200 OK', async () => {
+            const c = new Case(minimalCase);
+            await c.save();
+            const c2 = new Case(fullCase);
+            await c2.save();
+            const res = await request(app)
+                .post('/api/cases/download')
+                .send({})
+                .expect('Content-Type', 'text/csv')
+                .expect(200);
+            expect(res.text).toContain(
+                '_id,caseReference.verificationStatus,caseReference.sourceId',
+            );
+            expect(res.text).toContain(c._id);
+            expect(res.text).toContain(c.caseReference.verificationStatus);
+            expect(res.text).toContain(c.caseReference.sourceId);
+            expect(res.text).toContain(c2._id);
+            expect(res.text).toContain(c2.caseReference.verificationStatus);
+            expect(res.text).toContain(c2.caseReference.sourceId);
+        });
+        it('rejects invalid searches', (done) => {
+            request(app)
+                .post('/api/cases/download')
+                .send({
+                    query: 'country:',
+                })
+                .expect(422, done);
+        });
+        it('rejects request bodies with query and caseIds', async (done) => {
+            const c = new Case(minimalCase);
+            await c.save();
+
+            request(app)
+                .post('/api/cases/download')
+                .send({
+                    query: 'country:India',
+                    caseIds: [c._id],
+                })
+                .expect(400, done);
+        });
+        it('should filter results with caseIds', async () => {
+            const matchingCase = new Case(minimalCase);
+            await matchingCase.save();
+
+            const matchingCase2 = new Case(minimalCase);
+            await matchingCase2.save();
+
+            const unmatchedCase = new Case(minimalCase);
+            await unmatchedCase.save();
+
+            const res = await request(app)
+                .post('/api/cases/download')
+                .send({
+                    caseIds: [matchingCase._id, matchingCase2._id],
+                })
+                .expect('Content-Type', 'text/csv')
+                .expect(200);
+            expect(res.text).toContain(
+                '_id,caseReference.verificationStatus,caseReference.sourceId',
+            );
+            expect(res.text).toContain(matchingCase._id);
+            expect(res.text).toContain(matchingCase2._id);
+            expect(res.text).not.toContain(unmatchedCase._id);
+        });
+        it('should filter results with text query', async () => {
+            // Simulate index creation used in unit tests, in production they are
+            // setup by the setup-db script and such indexes are not present by
+            // default in the in memory mongo spawned by unit tests.
+            await mongoose.connection.collection('cases').createIndex({
+                notes: 'text',
+            });
+
+            const matchingCase = new Case(minimalCase);
+            const matchingNotes = 'matching';
+            matchingCase.notes = matchingNotes;
+            await matchingCase.save();
+
+            const unmatchedCase = new Case(minimalCase);
+            const unmatchedNotes = 'unmatched';
+            unmatchedCase.notes = unmatchedNotes;
+            await unmatchedCase.save();
+
+            const res = await request(app)
+                .post('/api/cases/download')
+                .send({
+                    query: matchingNotes,
+                })
+                .expect('Content-Type', 'text/csv')
+                .expect(200);
+            expect(res.text).toContain(
+                '_id,caseReference.verificationStatus,caseReference.sourceId',
+            );
+            expect(res.text).toContain(matchingNotes);
+            expect(res.text).toContain(matchingCase._id);
+            expect(res.text).toContain(matchingNotes);
+            expect(res.text).not.toContain(unmatchedCase._id);
+            expect(res.text).not.toContain(unmatchedNotes);
+        });
+        it('should filter results with keyword query', async () => {
+            const matchedCase = new Case(minimalCase);
+            matchedCase.location.country = 'Germany';
+            matchedCase.set('demographics.occupation', 'engineer');
+            await matchedCase.save();
+
+            const unmatchedCase = new Case(minimalCase);
+            await unmatchedCase.save();
+
+            const res = await request(app)
+                .post('/api/cases/download')
+                .send({
+                    query: 'country:Germany',
+                })
+                .expect('Content-Type', 'text/csv')
+                .expect(200);
+            expect(res.text).toContain(
+                '_id,caseReference.verificationStatus,caseReference.sourceId',
+            );
+            expect(res.text).toContain('Germany');
+            expect(res.text).toContain(matchedCase._id);
+            expect(res.text).not.toContain(unmatchedCase._id);
+        });
     });
 });
 

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -493,19 +493,33 @@ paths:
         "500":
           $ref: "#/components/responses/500"
   /cases/download:
-    get:
+    post:
       summary: >
-        Streams a CSV attachment of all cases. If parameter q is supplied the
-        CSV only contains cases matching the search query.
+        Streams a CSV attachment of all cases. If a query is supplied the
+        CSV only contains cases matching the search query. If caseIds are
+        supplied the CSV only contains cases with those ids. You cannot supply
+        both query and caseIds.
       tags: [Case]
       operationId: downloadCases
-      parameters:
-        - name: q
-          in: query
-          description: The search query
-          required: false
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              maxProperties: 1
+              properties:
+                caseIds:
+                  description: Cases corresponding to these ids will returned
+                  type: array
+                  items:
+                    type: string
+                    pattern: '^[a-f\d]{24}$'
+                query:
+                  description: >
+                    Cases matching this query will be returned. Must contain
+                    non-whitespace characters.
+                  type: string
+                  pattern: \S+
       responses:
         "200":
           $ref: "#/components/responses/200CasesDownload"

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -43,8 +43,9 @@ export default class CasesController {
     download = async (req: Request, res: Response): Promise<void> => {
         try {
             axios({
-                method: 'get',
+                method: 'post',
                 url: this.dataServerURL + '/api' + req.url,
+                data: req.body,
                 responseType: 'stream',
             }).then((response) => {
                 res.setHeader('Content-Type', 'text/csv');

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -1,7 +1,7 @@
 import * as usersController from './controllers/users';
 
 import { AuthController, mustHaveAnyRole } from './controllers/auth';
-import { Request, Response, NextFunction } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import session, { SessionOptions } from 'express-session';
 
 import AwsEventsClient from './clients/aws-events-client';
@@ -14,6 +14,7 @@ import MapboxGeocoder from './geocoding/mapbox';
 import { OpenApiValidator } from 'express-openapi-validator';
 import SourcesController from './controllers/sources';
 import UploadsController from './controllers/uploads';
+import { ValidationError } from 'express-openapi-validator/dist/framework/types';
 import YAML from 'yamljs';
 import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
@@ -26,7 +27,6 @@ import passport from 'passport';
 import path from 'path';
 import swaggerUi from 'swagger-ui-express';
 import validateEnv from './util/validate-env';
-import { ValidationError } from 'express-openapi-validator/dist/framework/types';
 
 const app = express();
 
@@ -227,11 +227,6 @@ new OpenApiValidator({
             casesController.list,
         );
         apiRouter.get(
-            '/cases/download',
-            mustHaveAnyRole(['reader', 'curator', 'admin']),
-            casesController.download,
-        );
-        apiRouter.get(
             '/cases/symptoms',
             mustHaveAnyRole(['reader', 'curator']),
             casesController.listSymptoms,
@@ -255,6 +250,11 @@ new OpenApiValidator({
             '/cases',
             mustHaveAnyRole(['curator']),
             casesController.create,
+        );
+        apiRouter.post(
+            '/cases/download',
+            mustHaveAnyRole(['reader', 'curator', 'admin']),
+            casesController.download,
         );
         apiRouter.post(
             '/cases/batchUpsert',

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -263,7 +263,7 @@ describe('Linelist table', function () {
         });
         cy.visit('/cases');
         cy.server();
-        cy.route('GET', '/api/cases/download').as('downloadCases');
+        cy.route('POST', '/api/cases/download').as('downloadCases');
         cy.contains('Download').click();
         cy.wait('@downloadCases').then((xhr) => {
             const csv = xhr.response.body;
@@ -291,7 +291,7 @@ describe('Linelist table', function () {
         cy.get('input[id="search-field"]').type('France{enter}');
 
         cy.server();
-        cy.route('GET', '/api/cases/download*').as('downloadCases');
+        cy.route('POST', '/api/cases/download').as('downloadCases');
         cy.contains('Download').click();
         cy.wait('@downloadCases').then((xhr) => {
             const csv = xhr.response.body;
@@ -299,6 +299,35 @@ describe('Linelist table', function () {
             assert.include(csv, 'France');
             assert.notInclude(csv, 'Germany');
             assert.notInclude(csv, 'United Kingdom');
+        });
+    });
+
+    it('Can download selected cases', function () {
+        cy.addCase({
+            country: 'France',
+        });
+        cy.addCase({
+            country: 'Germany',
+        });
+        cy.addCase({
+            country: 'United Kingdom',
+        });
+        cy.server();
+        cy.route('GET', '/api/cases/*').as('getCases');
+        cy.visit('/cases');
+        cy.wait('@getCases');
+
+        cy.get('input[type="checkbox"]').eq(1).click();
+        cy.get('input[type="checkbox"]').eq(2).click();
+
+        cy.route('POST', '/api/cases/download').as('downloadCases');
+        cy.get('button[title="Download selected rows"]').click();
+        cy.wait('@downloadCases').then((xhr) => {
+            const csv = xhr.response.body;
+            assert.include(csv, 'location.country');
+            assert.notInclude(csv, 'France');
+            assert.include(csv, 'Germany');
+            assert.include(csv, 'United Kingdom');
         });
     });
 


### PR DESCRIPTION
Fixes #909

The download option for selected rows is in the table toolbar, whereas the download button next to the search bar will always download all cases matching the search result.

Changes download requests from GET to POST. This is to allow for a request body so that many caseIds can be sent in the request.

![Screen Shot 2020-09-09 at 6 24 21 PM](https://user-images.githubusercontent.com/30459667/92631920-cf63e480-f2c9-11ea-90a4-2a8b909dac2e.png)

