### PR TITLE
Make specifying a license mandatory for automatic ingestion sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ This repository contains the servers and scripts that support its data curation 
 - [Local curator service](http://localhost:3001/api-docs)
 - [Local data service](http://localhost:3000/api-docs)
 
+## Sources licenses and terms of use
+
+This repository and daily data exports are published under the MIT license.
+
+Each automatically ingested data source used has a required license and terms of use attachment, forcing curators to look-up the sources they are setting-up for ingestion.
+
+If you are the owner of a data source included here and would like us to remove data, add or alter an attribution, or add or alter license information, please open an issue on this repository and we will happily consider your request.
+
 ## Stats
 
 ![code size](https://img.shields.io/github/languages/code-size/globaldothealth/list) ![repo size](https://img.shields.io/github/repo-size/globaldothealth/list)

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -104,7 +104,7 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3,
     lambda_arn = "arn"
     requests_mock.get(
         full_source_url,
-        json={"origin": {"url": origin_url}, "format": "JSON",
+        json={"origin": {"url": origin_url, "license": "MIT"}, "format": "JSON",
               "automation": {"parser": {"awsLambdaArn": lambda_arn}},
               "dateFilter": date_filter})
 
@@ -152,7 +152,8 @@ def test_get_source_details_returns_url_and_format(
     source_id = "id"
     content_url = "http://bar.baz"
     requests_mock.get(f"{_SOURCE_API_URL}/sources/{source_id}",
-                      json={"format": "CSV", "origin": {"url": content_url}})
+                      json={"format": "CSV",
+                            "origin": {"url": content_url, "license": "MIT"}})
     result = retrieval.get_source_details("env", source_id, "upload_id", {}, {})
     assert result[0] == content_url
     assert result[1] == "CSV"
@@ -167,7 +168,8 @@ def test_get_source_details_returns_parser_arn_if_present(
     lambda_arn = "lambdaArn"
     requests_mock.get(
         f"{_SOURCE_API_URL}/sources/{source_id}",
-        json={"origin": {"url": content_url}, "format": "JSON",
+        json={"origin": {"url": content_url, "license": "MIT"},
+              "format": "JSON",
               "automation": {"parser": {"awsLambdaArn": lambda_arn}}})
     result = retrieval.get_source_details("env", source_id, "upload_id", {}, {})
     assert result[2] == lambda_arn

--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -41,7 +41,8 @@ export default class SourcesController {
             const [docs, total] = await Promise.all([
                 Source.find(filter)
                     .skip(limit * (page - 1))
-                    .limit(limit + 1),
+                    .limit(limit + 1)
+                    .lean(),
                 Source.countDocuments({}),
             ]);
             // If we have more items than limit, add a response param

--- a/verification/curator-service/api/src/controllers/users.ts
+++ b/verification/curator-service/api/src/controllers/users.ts
@@ -23,7 +23,8 @@ export const list = async (req: Request, res: Response): Promise<void> => {
         const [docs, total] = await Promise.all([
             User.find({})
                 .skip(limit * (page - 1))
-                .limit(limit + 1),
+                .limit(limit + 1)
+                .lean(),
             User.countDocuments({}),
         ]);
         // If we have more items than limit, add a response param

--- a/verification/curator-service/api/src/model/origin.ts
+++ b/verification/curator-service/api/src/model/origin.ts
@@ -5,9 +5,7 @@ export const originSchema = new mongoose.Schema({
         type: String,
         required: 'Enter an origin URL',
     },
-    license: {
-        type: String,
-    },
+    license: String,
 });
 
 export type OriginDocument = mongoose.Document & {

--- a/verification/curator-service/api/test/model/data/source.minimal.json
+++ b/verification/curator-service/api/test/model/data/source.minimal.json
@@ -1,6 +1,7 @@
 {
     "name": "source name",
     "origin": {
-        "url": "foo.bar"
+        "url": "foo.bar",
+        "license": "MIT"
     }
 }

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -67,7 +67,7 @@ describe('GET', () => {
     it('list should return 200', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         const res = await curatorRequest
@@ -82,12 +82,12 @@ describe('GET', () => {
     it('list should filter by url if supplied', async () => {
         const relevantSource = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         await new Source({
             name: 'test-source',
-            origin: { url: 'http://bar.baz' },
+            origin: { url: 'http://bar.baz', license: 'MIT' },
             format: 'JSON',
         }).save();
 
@@ -104,7 +104,7 @@ describe('GET', () => {
         for (const i of Array.from(Array(15).keys())) {
             await new Source({
                 name: `test-source-${i}`,
-                origin: { url: 'http://foo.bar' },
+                origin: { url: 'http://foo.bar', license: 'MIT' },
                 format: 'JSON',
             }).save();
         }
@@ -146,7 +146,7 @@ describe('GET', () => {
     it('one existing item should return 200', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         const res = await curatorRequest
@@ -161,7 +161,7 @@ describe('PUT', () => {
     it('should update a source', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         const res = await curatorRequest
@@ -178,7 +178,7 @@ describe('PUT', () => {
     it('should create an AWS rule with target if provided schedule expression', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         const scheduleExpression = 'rate(1 hour)';
@@ -205,7 +205,7 @@ describe('PUT', () => {
     it('should update AWS rule description on source rename', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
             automation: {
                 schedule: {
@@ -232,14 +232,14 @@ describe('PUT', () => {
             .put('/api/sources/5ea86423bae6982635d2e1f8')
             .send({
                 name: 'test-source',
-                origin: { url: 'http://foo.bar' },
+                origin: { url: 'http://foo.bar', license: 'MIT' },
             })
             .expect(404, done);
     });
     it('should not update to an invalid source', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         return curatorRequest
@@ -250,7 +250,7 @@ describe('PUT', () => {
     it('should be able to set a parser without schedule', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         await curatorRequest
@@ -271,7 +271,7 @@ describe('POST', () => {
     it('should return the created source', async () => {
         const source = {
             name: 'some_name',
-            origin: { url: 'http://what.ever' },
+            origin: { url: 'http://what.ever', license: 'MIT' },
             format: 'JSON',
         };
         const res = await curatorRequest
@@ -286,7 +286,7 @@ describe('POST', () => {
         const scheduleExpression = 'rate(1 hour)';
         const source = {
             name: 'some_name',
-            origin: { url: 'http://what.ever' },
+            origin: { url: 'http://what.ever', license: 'MIT' },
             format: 'JSON',
             automation: {
                 schedule: { awsScheduleExpression: scheduleExpression },
@@ -324,7 +324,7 @@ describe('DELETE', () => {
     it('should delete a source', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
         }).save();
         await curatorRequest.delete(`/api/sources/${source.id}`).expect(204);
@@ -333,7 +333,7 @@ describe('DELETE', () => {
     it('should delete corresponding AWS rule (et al.) if source contains ruleArn', async () => {
         const source = await new Source({
             name: 'test-source',
-            origin: { url: 'http://foo.bar' },
+            origin: { url: 'http://foo.bar', license: 'MIT' },
             format: 'JSON',
             automation: {
                 schedule: {

--- a/verification/curator-service/ui/cypress/integration/components/AutomatedSourceForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/AutomatedSourceForm.spec.ts
@@ -12,12 +12,14 @@ describe('Automated source form', function () {
         const url = 'www.newsource.com';
         const name = 'New source name';
         const format = 'JSON';
+        const license = 'WTFPL';
 
         cy.visit('/');
         cy.get('button[data-testid="create-new-button"]').click();
         cy.contains('li', 'New automated source').click();
         cy.get('div[data-testid="url"]').type(url);
         cy.get('div[data-testid="name"]').type(name);
+        cy.get('div[data-testid="license"]').type(license);
         cy.get('div[data-testid="format"]').click();
         cy.get(`li[data-value=${format}`).click();
         cy.server();
@@ -31,6 +33,7 @@ describe('Automated source form', function () {
         cy.contains(url);
         cy.contains(name);
         cy.contains(format);
+        cy.contains(license);
     });
 
     it('Does not add source on submission error', function () {
@@ -40,6 +43,7 @@ describe('Automated source form', function () {
         cy.visit('/sources/automated');
         cy.get('div[data-testid="url"]').type('www.newsource.com');
         cy.get('div[data-testid="name"]').type('New source name');
+        cy.get('div[data-testid="license"]').type('WTFPL');
         cy.get('div[data-testid="format"]').click();
         cy.get('li[data-value="JSON"').click();
 

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -123,6 +123,7 @@ export function addSource(name: string, url: string, uploads?: []): void {
             name: name,
             origin: {
                 url: url,
+                license: 'MIT',
             },
             uploads: uploads,
             format: 'JSON',

--- a/verification/curator-service/ui/src/components/AutomatedSourceForm.tsx
+++ b/verification/curator-service/ui/src/components/AutomatedSourceForm.tsx
@@ -69,6 +69,7 @@ interface Props {
 
 export interface AutomatedSourceFormValues {
     url: string;
+    license: string;
     name: string;
     format: string;
 }
@@ -77,6 +78,7 @@ const AutomatedSourceFormSchema = Yup.object().shape({
     url: Yup.string().required('Required'),
     name: Yup.string().required('Required'),
     format: Yup.string().required('Required'),
+    license: Yup.string().required('Required'),
 });
 
 export default function AutomatedSourceForm(props: Props): JSX.Element {
@@ -89,7 +91,7 @@ export default function AutomatedSourceForm(props: Props): JSX.Element {
     ): Promise<void> => {
         const newSource = {
             name: values.name,
-            origin: { url: values.url },
+            origin: { url: values.url, license: values.license },
             format: values.format,
         };
         try {
@@ -113,7 +115,7 @@ export default function AutomatedSourceForm(props: Props): JSX.Element {
             <Formik
                 validationSchema={AutomatedSourceFormSchema}
                 validateOnChange={false}
-                initialValues={{ url: '', name: '', format: '' }}
+                initialValues={{ url: '', name: '', format: '', license: '' }}
                 onSubmit={async (values): Promise<void> => {
                     await createSource(values);
                 }}
@@ -130,8 +132,7 @@ export default function AutomatedSourceForm(props: Props): JSX.Element {
                                 variant="body2"
                             >
                                 Add new cases through automated ingestion from a
-                                data source. G.h List will check for updates
-                                every 15 minutes from this new source.
+                                data source.
                             </Typography>
                         </div>
                         <Form>
@@ -157,6 +158,17 @@ export default function AutomatedSourceForm(props: Props): JSX.Element {
                                         name="name"
                                         type="text"
                                         data-testid="name"
+                                        component={TextField}
+                                        fullWidth
+                                    />
+                                </div>
+                                <div className={classes.formSection}>
+                                    <FastField
+                                        helperText="Required (MIT, Apache V2, ...)"
+                                        label="License"
+                                        name="license"
+                                        type="text"
+                                        data-testid="license"
                                         component={TextField}
                                         fullWidth
                                     />

--- a/verification/curator-service/ui/src/components/SourceTable.test.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.test.tsx
@@ -29,6 +29,7 @@ it('loads and displays sources', async () => {
     const sourceName = 'source_name';
     const originUrl = 'origin url';
     const format = 'JSON';
+    const license = 'MIT';
     const awsLambdaArn = 'arn:aws:lambda:a:b:functions:c';
     const awsRuleArn = 'arn:aws:events:a:b:rule/c';
     const awsScheduleExpression = 'rate(2 hours)';
@@ -39,7 +40,7 @@ it('loads and displays sources', async () => {
             format: format,
             origin: {
                 url: originUrl,
-                license: 'origin license',
+                license: license,
             },
             automation: {
                 parser: {
@@ -81,6 +82,7 @@ it('loads and displays sources', async () => {
     expect(await findByText(new RegExp(sourceName))).toBeInTheDocument();
     expect(await findByText(new RegExp(originUrl))).toBeInTheDocument();
     expect(await findByText(new RegExp(format))).toBeInTheDocument();
+    expect(await findByText(new RegExp(license))).toBeInTheDocument();
     expect(await findByText(new RegExp(awsLambdaArn))).toBeInTheDocument();
     expect(await findByText(new RegExp(awsRuleArn))).toBeInTheDocument();
     expect(

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -82,6 +82,8 @@ interface TableRow {
     name: string;
     // origin
     url: string;
+
+    license?: string;
     // automation.parser
 
     format?: string;
@@ -162,6 +164,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                 !(
                     this.validateRequired(newRowData.name) &&
                     this.validateRequired(newRowData.url) &&
+                    this.validateRequired(newRowData.license) &&
                     this.validateAutomationFields(newRowData)
                 )
             ) {
@@ -194,6 +197,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             name: rowData.name,
             origin: {
                 url: rowData.url,
+                license: rowData.license,
             },
             format: rowData.format,
             automation:
@@ -328,6 +332,31 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                             </MenuItem>
                                         ))}
                                     </TextField>
+                                ),
+                            },
+                            {
+                                title: 'License',
+                                field: 'license',
+                                tooltip: 'MIT, Apache V2, ...',
+                                editComponent: (props): JSX.Element => (
+                                    <TextField
+                                        type="text"
+                                        size="small"
+                                        fullWidth
+                                        placeholder="License"
+                                        error={
+                                            !this.validateRequired(props.value)
+                                        }
+                                        helperText={
+                                            this.validateRequired(props.value)
+                                                ? ''
+                                                : 'Required field'
+                                        }
+                                        onChange={(event): void =>
+                                            props.onChange(event.target.value)
+                                        }
+                                        defaultValue={props.value}
+                                    />
                                 ),
                             },
                             {
@@ -470,6 +499,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                                 name: s.name,
                                                 format: s.format,
                                                 url: s.origin.url,
+                                                license: s.origin.license,
                                                 awsLambdaArn:
                                                     s.automation?.parser
                                                         ?.awsLambdaArn,


### PR DESCRIPTION
Not making the origin.license field mandatory as it is not possible to specify it in the bulk/manual entry flow (yet).

This PR however includes the license in a few more tests just to be more realistic, also calls lean() on users and sources listing, somehow we forgot to do that but we do for cases.

For #972 