### PR TITLE
Testability changes to EmailClient.

### DIFF
--- a/verification/curator-service/api/src/clients/email-client.ts
+++ b/verification/curator-service/api/src/clients/email-client.ts
@@ -53,6 +53,7 @@ export default class EmailClient {
             });
         }
 
+        this.initialized = true;
         return this;
     }
 

--- a/verification/curator-service/api/src/clients/email-client.ts
+++ b/verification/curator-service/api/src/clients/email-client.ts
@@ -77,7 +77,7 @@ export default class EmailClient {
     /**
      * Getter returning the configured SMTP service.
      */
-    getService = (): EmailService | undefined => {
+    getService(): EmailService | undefined {
         return this.service;
-    };
+    }
 }

--- a/verification/curator-service/api/test/clients/email-client.test.ts
+++ b/verification/curator-service/api/test/clients/email-client.test.ts
@@ -1,19 +1,22 @@
 import EmailClient, { EmailService } from '../../src/clients/email-client';
 
-describe('create', () => {
-    it('can send ethereal emails without user or pass', async () => {
-        const client = await EmailClient.create();
+describe('initialize', () => {
+    it('uses ethereal without user or pass', async () => {
+        const client = await new EmailClient().initialize();
         expect(client.getService()).toBe(EmailService.Ethereal);
     });
     it('uses gmail if given user and pass', async () => {
-        const client = await EmailClient.create('user@gmail.com', 'hunter2');
+        const client = await new EmailClient(
+            'user@gmail.com',
+            'hunter2',
+        ).initialize();
         expect(client.getService()).toBe(EmailService.Gmail);
     });
 });
 
 describe('send', () => {
     it('sends specified properties via email', async () => {
-        const client = await EmailClient.create();
+        const client = await new EmailClient().initialize();
         const address = 'foo@bar.com';
         const result = await client.send(
             [address],
@@ -22,5 +25,11 @@ describe('send', () => {
         );
 
         expect(result.accepted).toContain(address);
+    });
+    it('throws error if client uninitialized', async () => {
+        const client = new EmailClient();
+        expect(() => {
+            client.send(['addressee'], 'subject', 'text');
+        }).toThrow();
     });
 });


### PR DESCRIPTION
I liked the static factory pattern better, but it was a nightmare to test with Jest, given our relatively high fidelity app/controller tests. Because we don't await app async set up in our superagent controller tests, I needed to mock the `email-client` module (reaching the test SMTP server was too slow, and our unit tests ran before the source controller finished installation). And mocking an ES6 class (via the module mocker, because we can't touch the actual client prototype in the unit test) with a static factory method proved difficult.