### PR TITLE
fix all flake8 issues

### DIFF
--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -7,7 +7,6 @@ API calls, and it's information that could be easily encoded as state in an
 object.
 """
 
-import os
 import tempfile
 import requests
 

--- a/ingestion/functions/common/common_lib_test.py
+++ b/ingestion/functions/common/common_lib_test.py
@@ -1,10 +1,8 @@
-import os
 import pytest
 import requests
-import sys
 
 from common import common_lib
-from mock import MagicMock, patch
+from mock import patch
 
 _SOURCE_API_URL = "https://foo.bar"
 _SOURCE_ID = "abc123"
@@ -34,6 +32,7 @@ def test_register_local_user(
     cookies = common_lib.login("foo@bar.baz")
 
     assert cookies == {"foo": "bar"}
+
 
 def test_create_upload_record_returns_upload_id(
         requests_mock, mock_source_api_url_fixture):
@@ -132,7 +131,7 @@ def test_complete_with_error_updates_upload_if_provided_data(
         ) == {"status": "ERROR", "summary": {"error": upload_error.name}}
         return
     # We got the wrong exception or no exception, fail the test.
-    assert "Should have raised a ValueError exception" == False
+    assert not "Should have raised a ValueError exception"
 
 
 def test_get_source_api_url_returns_mapped_value():
@@ -145,4 +144,4 @@ def test_get_source_api_url_raises_error_for_unmapped_env():
         common_lib.get_source_api_url('not-an-env')
     except ValueError:
         return
-    assert "Should have raised a ValueError exception" == False
+    assert not "Should have raised a ValueError exception"

--- a/ingestion/functions/parsing/brazil_amapa/amapa_test.py
+++ b/ingestion/functions/parsing/brazil_amapa/amapa_test.py
@@ -1,16 +1,11 @@
-import csv
-import json
 import os
-import tempfile
 import unittest
-from datetime import date
-
-import pytest
 
 from brazil_amapa import amapa
 
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "foo.bar"
+
 
 class AmapaTest(unittest.TestCase):
     def setUp(self):
@@ -30,10 +25,10 @@ class AmapaTest(unittest.TestCase):
                 },
                 "location": {
                     "query": "Laranjal do Jari, Amapá, Brazil"
-                    },
+                },
                 "demographics": {
                     "gender": "Female",
-                    "ageRange": 
+                    "ageRange":
                     {
                         "start": float(54),
                         "end": float(54)
@@ -55,7 +50,7 @@ class AmapaTest(unittest.TestCase):
                 "preexistingConditions": {
                     "hasPreexistingConditions": True,
                     "values": ["diabetes mellitus", "heart disease"]
-                    },
+                },
                 "notes": "Neighbourhood: AGRESTE"
             }
         ])

--- a/ingestion/functions/parsing/brazil_paraiba/paraiba.py
+++ b/ingestion/functions/parsing/brazil_paraiba/paraiba.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 import csv
 
 # Layer code, like parsing_lib, is added to the path by AWS.
@@ -24,19 +24,20 @@ _MUNICIPALITY_INDEX = 1
 _PREEXISTING_CONDITIONS_INDEX = 4
 
 commorbidities = {
-                  "Diabetes Mellitus": "diabetes mellitus", 
-                  "Cardiopatia": "heart disease",
-                  "Doença de Aparelho Digestivo": "gastrointestinal system disease",
-                  "Doença Hepática": "liver disease",
-                  "Doença Neurológica": "nervous system disease",
-                  "Doença Renal": "kidney disease",
-                  "Doença Respiratória": "respiratory system disease",
-                  "Neoplasia": "neoplasm",
-                  "Etilismo": "alcohol use disorder",
-                  "Obesidade": "obesity",
-                  "Transtorno mental": "mental or behavioural disorder",
-                  "Hipertensão": "hypertension"
-                 }
+    "Diabetes Mellitus": "diabetes mellitus",
+    "Cardiopatia": "heart disease",
+    "Doença de Aparelho Digestivo": "gastrointestinal system disease",
+    "Doença Hepática": "liver disease",
+    "Doença Neurológica": "nervous system disease",
+    "Doença Renal": "kidney disease",
+    "Doença Respiratória": "respiratory system disease",
+    "Neoplasia": "neoplasm",
+    "Etilismo": "alcohol use disorder",
+    "Obesidade": "obesity",
+    "Transtorno mental": "mental or behavioural disorder",
+    "Hipertensão": "hypertension"
+}
+
 
 def convert_date(raw_date):
     """
@@ -48,6 +49,7 @@ def convert_date(raw_date):
     date = datetime.strptime(raw_date, "%Y-%m-%d")
     return date.strftime("%m/%d/%YZ")
 
+
 def convert_gender(raw_gender: str):
     if raw_gender == "Masculino":
         return "Male"
@@ -55,10 +57,11 @@ def convert_gender(raw_gender: str):
         return "Female"
     return None
 
+
 def convert_age(age: str):
     if age.isdecimal():
-        #Ages are mostly reported in decimal years, but there are entries like '1 ano' ['1 year'] 
-        #and '1 m' ['1 month'] which need to be dealt with separately.
+        # Ages are mostly reported in decimal years, but there are entries like '1 ano' ['1 year']
+        # and '1 m' ['1 month'] which need to be dealt with separately.
         return {
             "start": float(age),
             "end": float(age)
@@ -67,14 +70,15 @@ def convert_age(age: str):
         only_age = float("".join([i for i in age if not i.isalpha()]))
         if "dia" in age:
             return {
-                "start": round(only_age/365.25,3), #Average number of days a year
-                "end": round(only_age/365.25,3)
+                # Average number of days a year
+                "start": round(only_age/365.25, 3),
+                "end": round(only_age/365.25, 3)
             }
         elif "m" in age:
-            #There is one case which is reported as 1 m; I am assuming here that this also means 'mes' (month)
+            # There is one case which is reported as 1 m; I am assuming here that this also means 'mes' (month)
             return {
-                "start": round(only_age/12,3),
-                "end": round(only_age/12,3)
+                "start": round(only_age/12, 3),
+                "end": round(only_age/12, 3)
             }
         elif "ano" in age:
             return {
@@ -82,28 +86,32 @@ def convert_age(age: str):
                 "end": only_age
             }
 
+
 def convert_confirmation_method(raw_test: str):
-    if "Clínico" in raw_test or "Clinico" in raw_test: #written both ways in dataset
+    if "Clínico" in raw_test or "Clinico" in raw_test:  # written both ways in dataset
         return "Clinical diagnosis"
     elif "C. Epid" in raw_test:
         return "Other"
     elif "Laboratorial" in raw_test:
         return "Other"
     elif "swab" in raw_test.lower():
-        #swabs are reported both as Swab and SWAB
+        # swabs are reported both as Swab and SWAB
         return "PCR test"
     elif "teste" in raw_test.lower():
-        #this is reported as both Teste Rapido and teste rapido
-        return "Serological test"  
+        # this is reported as both Teste Rapido and teste rapido
+        return "Serological test"
     else:
         print(f'unknown confirmation method: {raw_test}')
         return "Unknown"
 
+
 def convert_preexisting_conditions(raw_commorbidities: str):
     preexistingConditions = {}
-    if raw_commorbidities not in ["Sem comorbidades","Doença Hematológica","Tabagismo","Imunossupressão"]:
+    if raw_commorbidities not in [
+        "Sem comorbidades", "Doença Hematológica", "Tabagismo",
+            "Imunossupressão"]:
         preexistingConditions["hasPreexistingConditions"] = True
-        
+
         commorbidities_list = []
 
         for key in commorbidities:
@@ -113,11 +121,14 @@ def convert_preexisting_conditions(raw_commorbidities: str):
         preexistingConditions["values"] = commorbidities_list
         return preexistingConditions
     else:
-        return None         
+        return None
+
 
 def convert_location(raw_entry: str):
-    query = ", ".join(word for word in [raw_entry, "Paraíba", "Brazil"] if word)
+    query = ", ".join(word for word in [
+                      raw_entry, "Paraíba", "Brazil"] if word)
     return {"query": query}
+
 
 def convert_notes(raw_commorbidities: str):
     raw_notes = []
@@ -125,9 +136,9 @@ def convert_notes(raw_commorbidities: str):
         raw_notes.append("Patient with immunosupression")
     if "Tabagismo" in raw_commorbidities:
         raw_notes.append("Smoker")
-    if "Doença Hematológica" in raw_commorbidities: 
+    if "Doença Hematológica" in raw_commorbidities:
         raw_notes.append("Hematologic disease")
-    if "Outros" in raw_commorbidities: 
+    if "Outros" in raw_commorbidities:
         raw_notes.append("Unspecified pre-existing condition")
     notes = (', ').join(raw_notes)
     return notes
@@ -143,9 +154,11 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
     """
     with open(raw_data_file, "r") as f:
         reader = csv.reader(f)
-        next(reader) # Skip the header.
+        next(reader)  # Skip the header.
         for row in reader:
-            if datetime.strptime(row[_DATE_SYMPTOMS_INDEX], "%Y-%m-%d") < datetime.strptime("2019-11-01", "%Y-%m-%d"): #One date is recorded as year 2000
+            if datetime.strptime(row[_DATE_SYMPTOMS_INDEX],
+                                 "%Y-%m-%d") < datetime.strptime("2019-11-01",
+                                                                 "%Y-%m-%d"):  # One date is recorded as year 2000
                 print("date out of range:" + row[_DATE_SYMPTOMS_INDEX])
                 continue
             case = {
@@ -164,27 +177,28 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                         "value": convert_confirmation_method(row[_METHOD_CONFIRMATION_INDEX])
                     },
                     {
-                        "name" : "onsetSymptoms",
+                        "name": "onsetSymptoms",
                         "dateRange":
                         {
                             "start": convert_date(row[_DATE_SYMPTOMS_INDEX]),
                             "end": convert_date(row[_DATE_SYMPTOMS_INDEX])
-                        },                      
+                        },
                     },
                     {
-                        "name" : "outcome",
+                        "name": "outcome",
                         "dateRange":
                         {
                             "start": convert_date(row[_DATE_DEATH_INDEX]),
                             "end": convert_date(row[_DATE_DEATH_INDEX])
-                        }, 
-                        "value" : "Death"                       
+                        },
+                        "value": "Death"
                     }
                 ],
                 "preexistingConditions": convert_preexisting_conditions(row[_PREEXISTING_CONDITIONS_INDEX]),
                 "notes": convert_notes(row[_PREEXISTING_CONDITIONS_INDEX])
             }
             yield case
-        
+
+
 def lambda_handler(event, context):
     return parsing_lib.run_lambda(event, context, parse_cases)

--- a/ingestion/functions/parsing/brazil_paraiba/paraiba_test.py
+++ b/ingestion/functions/parsing/brazil_paraiba/paraiba_test.py
@@ -1,16 +1,11 @@
-import csv
-import json
 import os
-import tempfile
 import unittest
-from datetime import date
-
-import pytest
 
 from brazil_paraiba import paraiba
 
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "foo.bar"
+
 
 class ParaibaTest(unittest.TestCase):
     def setUp(self):
@@ -22,50 +17,26 @@ class ParaibaTest(unittest.TestCase):
         sample_data_file = os.path.join(current_dir, "sample_data.csv")
 
         result = paraiba.parse_cases(sample_data_file, _SOURCE_ID, _SOURCE_URL)
-        self.assertCountEqual(list(result), [
-            {
-                "caseReference": {
-                    "sourceId": _SOURCE_ID,
-                    "sourceUrl": _SOURCE_URL
-                },
-                "location": {
-                    "query": "Santa Rita, Paraíba, Brazil"
-                    },
-                "demographics": {
-                    "gender": "Male",
-                    "ageRange": {
-                                "start": 80.0,
-                                "end": 80.0
-                                },
-                },
-                "events": [
-                    {
-                        "name": "confirmed",
-                        "value": "PCR test"
-                    },
-                    {
-                        "name" : "onsetSymptoms",
-                        "dateRange":
-                        {
-                            "start": "04/27/2020Z",
-                            "end": "04/27/2020Z"
-                        },                      
-                    },
-                    {
-                        "name" : "outcome",
-                        "dateRange":
-                        {
-                            "start": "05/10/2020Z",
-                            "end": "05/10/2020Z"
-                        }, 
-                        "value" : "Death"                       
-                    }
-                ],
-                "preexistingConditions": {
-                                            "hasPreexistingConditions": True,
-                                            "values":
-                                            ["diabetes mellitus", "heart disease", "respiratory system disease"]
-                                        },
-                "notes": ''
-            }
-        ])
+        self.assertCountEqual(
+            list(result),
+            [{
+                "caseReference":
+                {"sourceId": _SOURCE_ID, "sourceUrl": _SOURCE_URL},
+                "location": {"query": "Santa Rita, Paraíba, Brazil"},
+                "demographics":
+                {"gender": "Male", "ageRange": {"start": 80.0, "end": 80.0}, },
+                "events":
+                [{"name": "confirmed", "value": "PCR test"},
+                    {"name": "onsetSymptoms",
+                     "dateRange":
+                     {"start": "04/27/2020Z", "end": "04/27/2020Z"}, },
+                    {"name": "outcome",
+                     "dateRange":
+                     {"start": "05/10/2020Z", "end": "05/10/2020Z"},
+                     "value": "Death"}],
+                "preexistingConditions":
+                {"hasPreexistingConditions": True,
+                    "values":
+                    ["diabetes mellitus", "heart disease",
+                     "respiratory system disease"]},
+                "notes": ''}])

--- a/ingestion/functions/parsing/ch_zurich/zurich.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 import csv
 
 # Layer code, like parsing_lib, is added to the path by AWS.

--- a/ingestion/functions/parsing/ch_zurich/zurich_test.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich_test.py
@@ -1,11 +1,5 @@
-import csv
-import json
 import os
-import tempfile
 import unittest
-from datetime import date
-
-import pytest
 
 from ch_zurich import zurich
 

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -6,11 +6,7 @@ import collections
 from typing import Callable, Dict, Generator, Any, List
 
 import boto3
-import google.auth.transport.requests
 import requests
-
-from enum import Enum
-from google.oauth2 import service_account
 
 ENV_FIELD = "env"
 SOURCE_URL_FIELD = "sourceUrl"

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -6,7 +6,6 @@ import boto3
 import json
 import os
 import pytest
-import requests
 import sys
 import tempfile
 import datetime
@@ -190,12 +189,14 @@ def test_run_lambda_e2e(
     assert response["count_created"] == num_created
     assert response["count_updated"] == num_updated
 
+
 def test_batch_of():
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
-    items = iter([1,2,3,4,5])
-    assert parsing_lib.batch_of(items, 3) == [1,2,3]
-    assert parsing_lib.batch_of(items, 3) == [4,5]
+    items = iter([1, 2, 3, 4, 5])
+    assert parsing_lib.batch_of(items, 3) == [1, 2, 3]
+    assert parsing_lib.batch_of(items, 3) == [4, 5]
     assert parsing_lib.batch_of(items, 3) == []
+
 
 def test_retrieve_raw_data_file_stores_s3_in_local_file(
         input_event, s3, sample_data):
@@ -248,6 +249,7 @@ def test_extract_event_fields_errors_if_missing_env_field(input_event):
     with pytest.raises(ValueError, match=parsing_lib.ENV_FIELD):
         del input_event[parsing_lib.ENV_FIELD]
         parsing_lib.extract_event_fields(input_event)
+
 
 def test_prepare_cases_adds_upload_id():
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
@@ -411,7 +413,7 @@ def test_filter_cases_by_date_unsupported_op(
         assert requests_mock.request_history[-1].json() == {"status": "ERROR", "summary": {
             "error": "SOURCE_CONFIGURATION_ERROR"}}
         return
-    assert "Should have raised a ValueError exception" == False
+    assert not "Should have raised a ValueError exception"
 
 
 def test_remove_nested_none_and_empty_removes_only_nones_and_empty_str():

--- a/ingestion/functions/parsing/estonia/estonia.py
+++ b/ingestion/functions/parsing/estonia/estonia.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 import csv
 
 # Layer code, like parsing_lib, is added to the path by AWS.

--- a/ingestion/functions/parsing/estonia/estonia_test.py
+++ b/ingestion/functions/parsing/estonia/estonia_test.py
@@ -1,11 +1,5 @@
-import csv
-import json
 import os
-import tempfile
 import unittest
-from datetime import date
-
-import pytest
 
 from estonia import estonia
 

--- a/ingestion/functions/parsing/hongkong/hongkong.py
+++ b/ingestion/functions/parsing/hongkong/hongkong.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 import csv
 
 # Layer code, like parsing_lib, is added to the path by AWS.
@@ -17,7 +17,8 @@ except ImportError:
 
 # Fixed location, all cases are for Hong Kong.
 _LOCATION = {
-    "country": "China", # "One country, two systems". We only store countries here.
+    # "One country, two systems". We only store countries here.
+    "country": "China",
     "administrativeAreaLevel1": "Hong Kong",
     "geoResolution": "Admin1",
     "name": "Hong Kong",
@@ -36,6 +37,7 @@ _OUTCOME_INDEX = 6
 _NOTES_INDEX = 8
 _CERTAINTY_INDEX = 9
 
+
 def convert_date(raw_date: str):
     """
     Convert raw date field into a value interpretable by the dataserver.
@@ -51,6 +53,7 @@ def convert_date(raw_date: str):
     date = datetime.strptime(raw_date, f"%d/%m/{formatYear}")
     return date.strftime("%m/%d/%YZ")
 
+
 def convert_gender(raw_gender: str):
     if raw_gender.upper() == "M":
         return "Male"
@@ -58,17 +61,19 @@ def convert_gender(raw_gender: str):
         return "Female"
     return None
 
+
 def convert_age(age: float):
     return {
         "start": age,
         "end": age,
     }
 
+
 def parse_cases(raw_data_file: str, source_id: str, source_url: str):
     """Parses G.h-format case data from raw API data."""
     with open(raw_data_file, "r") as f:
         reader = csv.reader(f)
-        next(reader) # Skip the header.
+        next(reader)  # Skip the header.
         cases = []
         for row in reader:
             # CSV contains both "Probable" and "Confirmed" cases.
@@ -135,6 +140,7 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                 })
             cases.append(case)
         return cases
+
 
 def lambda_handler(event, context):
     return parsing_lib.run_lambda(event, context, parse_cases)

--- a/ingestion/functions/parsing/hongkong/hongkong_test.py
+++ b/ingestion/functions/parsing/hongkong/hongkong_test.py
@@ -1,9 +1,5 @@
-import csv
-import json
 import os
-import tempfile
 import unittest
-from datetime import date
 
 from hongkong import hongkong
 
@@ -20,130 +16,134 @@ class HongKongTest(unittest.TestCase):
         current_dir = os.path.dirname(__file__)
         sample_data_file = os.path.join(current_dir, "sample_data.csv")
 
-        result = hongkong.parse_cases(sample_data_file, _SOURCE_ID, _SOURCE_URL)
+        result = hongkong.parse_cases(
+            sample_data_file, _SOURCE_ID, _SOURCE_URL)
         self.assertCountEqual(result, [
-    {
-        "caseReference": {
-            "sourceId": _SOURCE_ID,
-            "sourceEntryId": "1",
-            "sourceUrl": _SOURCE_URL,
-        },
-        "location": {
-            "country": "China", # "One country, two systems". We only store countries here.
-            "administrativeAreaLevel1": "Hong Kong",
-            "geoResolution": "Admin1",
-            "name": "Hong Kong",
-            "geometry": {
-                "longitude": "114.15861",
-                "latitude": "22.27833",
-            },
-        },
-        "events": [
             {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": "01/23/2020Z",
-                    "end": "01/23/2020Z",
+                "caseReference": {
+                    "sourceId": _SOURCE_ID,
+                    "sourceEntryId": "1",
+                    "sourceUrl": _SOURCE_URL,
+                },
+                "location": {
+                    # "One country, two systems". We only store countries here.
+                    "country": "China",
+                    "administrativeAreaLevel1": "Hong Kong",
+                    "geoResolution": "Admin1",
+                    "name": "Hong Kong",
+                    "geometry": {
+                        "longitude": "114.15861",
+                        "latitude": "22.27833",
+                    },
+                },
+                "events": [
+                    {
+                        "name": "confirmed",
+                        "dateRange": {
+                            "start": "01/23/2020Z",
+                            "end": "01/23/2020Z",
+                        },
+                    }, {
+                        "name": "onsetSymptoms",
+                        "dateRange": {
+                            "start": "01/01/2020Z",
+                            "end": "01/01/2020Z",
+                        },
+                    }, {
+                        "name": "outcome",
+                        "value": "Recovered",
+                    },
+                ],
+                "symptoms": {
+                    "status": "Symptomatic",
+                },
+                "notes": "Imported case",
+                "demographics": {
+                    "ageRange": {
+                        "start": 39,
+                        "end": 39,
+                    },
+                    "gender": "Male",
                 },
             }, {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": "01/01/2020Z",
-                    "end": "01/01/2020Z",
+                "caseReference": {
+                    "sourceId": _SOURCE_ID,
+                    "sourceEntryId": "2",
+                    "sourceUrl": _SOURCE_URL,
+                },
+                "location": {
+                    # "One country, two systems". We only store countries here.
+                    "country": "China",
+                    "administrativeAreaLevel1": "Hong Kong",
+                    "geoResolution": "Admin1",
+                    "name": "Hong Kong",
+                    "geometry": {
+                        "longitude": "114.15861",
+                        "latitude": "22.27833",
+                    },
+                },
+                "events": [
+                    {
+                        "name": "confirmed",
+                        "dateRange": {
+                            "start": "01/24/2020Z",
+                            "end": "01/24/2020Z",
+                        },
+                    }, {
+                        "name": "hospitalAdmission",
+                        "value": "Yes",
+                    },
+                ],
+                "symptoms": {
+                    "status": "Asymptomatic",
+                },
+                "notes": "Imported case",
+                "demographics": {
+                    "ageRange": {
+                        "start": 40,
+                        "end": 40,
+                    },
+                    "gender": "Female",
                 },
             }, {
-                "name": "outcome",
-                "value": "Recovered",
-            },
-        ],
-        "symptoms": {
-            "status": "Symptomatic",
-        },
-        "notes": "Imported case",
-        "demographics": {
-            "ageRange": {
-                "start": 39,
-                "end": 39,
-            },
-            "gender": "Male",
-        },
-    }, {
-        "caseReference": {
-            "sourceId": _SOURCE_ID,
-            "sourceEntryId": "2",
-            "sourceUrl": _SOURCE_URL,
-        },
-        "location": {
-            "country": "China", # "One country, two systems". We only store countries here.
-            "administrativeAreaLevel1": "Hong Kong",
-            "geoResolution": "Admin1",
-            "name": "Hong Kong",
-            "geometry": {
-                "longitude": "114.15861",
-                "latitude": "22.27833",
-            },
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": "01/24/2020Z",
-                    "end": "01/24/2020Z",
+                "caseReference": {
+                    "sourceId": _SOURCE_ID,
+                    "sourceEntryId": "3",
+                    "sourceUrl": _SOURCE_URL,
                 },
-            }, {
-                "name": "hospitalAdmission",
-                "value": "Yes",
-            }, 
-        ],
-        "symptoms": {
-            "status": "Asymptomatic",
-        },
-        "notes": "Imported case",
-        "demographics": {
-            "ageRange": {
-                "start": 40,
-                "end": 40,
-            },
-            "gender": "Female",
-        },
-    }, {
-        "caseReference": {
-            "sourceId": _SOURCE_ID,
-            "sourceEntryId": "3",
-            "sourceUrl": _SOURCE_URL,
-        },
-        "location": {
-            "country": "China", # "One country, two systems". We only store countries here.
-            "administrativeAreaLevel1": "Hong Kong",
-            "geoResolution": "Admin1",
-            "name": "Hong Kong",
-            "geometry": {
-                "longitude": "114.15861",
-                "latitude": "22.27833",
-            },
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": "01/25/2020Z",
-                    "end": "01/25/2020Z",
+                "location": {
+                    # "One country, two systems". We only store countries here.
+                    "country": "China",
+                    "administrativeAreaLevel1": "Hong Kong",
+                    "geoResolution": "Admin1",
+                    "name": "Hong Kong",
+                    "geometry": {
+                        "longitude": "114.15861",
+                        "latitude": "22.27833",
+                    },
                 },
-            }, {
-                "name": "outcome",
-                "value": "Death",
-            }, 
-        ],
-        "symptoms": {
-            "status": "Asymptomatic",
-        },
-        "notes": "Imported case",
-        "demographics": {
-            "ageRange": {
-                "start": 40,
-                "end": 40,
+                "events": [
+                    {
+                        "name": "confirmed",
+                        "dateRange": {
+                            "start": "01/25/2020Z",
+                            "end": "01/25/2020Z",
+                        },
+                    }, {
+                        "name": "outcome",
+                        "value": "Death",
+                    },
+                ],
+                "symptoms": {
+                    "status": "Asymptomatic",
+                },
+                "notes": "Imported case",
+                "demographics": {
+                    "ageRange": {
+                        "start": 40,
+                        "end": 40,
+                    },
+                    "gender": "Female",
+                },
             },
-            "gender": "Female",
-        },
-    },
         ])

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.

--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -4,8 +4,6 @@ import os
 import pytest
 import tempfile
 
-from datetime import date
-
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "https://foo.bar"
 _PARSED_CASE = (

--- a/ingestion/functions/parsing/japan/japan.py
+++ b/ingestion/functions/parsing/japan/japan.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.
@@ -15,12 +15,14 @@ except ImportError:
             'common/python'))
     import parsing_lib
 
+
 def convert_gender(raw_gender):
     if "gender" in raw_gender:
         if raw_gender["gender"] == "M":
             return "Male"
         if raw_gender["gender"] == "F":
             return "Female"
+
 
 def convert_age(raw_age):
     age_range = {}
@@ -31,6 +33,7 @@ def convert_age(raw_age):
     else:
         return None
 
+
 def convert_location(raw_entry):
     query_terms = [
         term for term in [
@@ -40,20 +43,23 @@ def convert_location(raw_entry):
         if term and term != "Unspecified"]
     return {"query":  ", ".join(query_terms)}
 
+
 def detect_notes(raw_notes):
     if "notes" in raw_notes:
         return raw_notes["notes"]
     else:
         return None
 
+
 def convert_date(raw_date: str):
-    """ 
+    """
     Convert raw date field into a value interpretable by the dataserver.
 
     The date filtering API expects mm/dd/YYYYZ format.
     """
     date = datetime.strptime(raw_date, "%Y-%m-%d")
     return date.strftime("%m/%d/%YZ")
+
 
 def parse_cases(raw_data_file, source_id, source_url):
     """

--- a/ingestion/functions/parsing/japan/japan_test.py
+++ b/ingestion/functions/parsing/japan/japan_test.py
@@ -3,8 +3,6 @@ import os
 import pytest
 import tempfile
 
-from datetime import date
-
 
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "https://foo.bar"
@@ -56,4 +54,3 @@ def test_parse_cases_converts_fields_to_ghdsi_schema(sample_data):
 
         result = next(japan.parse_cases(f.name, _SOURCE_ID, _SOURCE_URL))
         assert result == _PARSED_CASE
-

--- a/ingestion/functions/parsing/peru/peru.py
+++ b/ingestion/functions/parsing/peru/peru.py
@@ -1,7 +1,6 @@
-import json
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 import csv
 
 # Layer code, like parsing_lib, is added to the path by AWS.
@@ -18,7 +17,7 @@ except ImportError:
 
 
 def convert_date(raw_date: str):
-    """ 
+    """
     Convert raw date field into a value interpretable by the dataserver.
 
     The date is listed in YYYYmmdd format, but the data server API will
@@ -62,36 +61,34 @@ def parse_cases(raw_data_file, source_id, source_url):
 
     with open(raw_data_file, "r") as f:
         reader = csv.DictReader(f)
-        cases = []
         for entry in reader:
-            case =  {
-                    "caseReference": {
-                        "sourceId": source_id,
-                        "sourceEntryId": entry["UUID"],
-                        "sourceUrl": source_url
-                    },
-                    "location": convert_location(entry),
-                    "events": [
-                        {
-                            "name": "confirmed",
-                            "value": conf_methods.get(entry['METODODX']),
-                            "dateRange":
+            case = {
+                "caseReference": {
+                    "sourceId": source_id,
+                    "sourceEntryId": entry["UUID"],
+                    "sourceUrl": source_url
+                },
+                "location": convert_location(entry),
+                "events": [
+                    {
+                        "name": "confirmed",
+                        "value": conf_methods.get(entry['METODODX']),
+                        "dateRange":
                             {
                                 "start": convert_date(entry["FECHA_RESULTADO"]),
                                 "end": convert_date(entry["FECHA_RESULTADO"])
-                            }
                         }
-                    ],
-                    "demographics": {
-                        "ageRange": {
-                            "start": float(entry["EDAD"]),
-                            "end": float(entry["EDAD"])
-                        },
-                        "gender": convert_gender(entry["SEXO"])
                     }
+                ],
+                "demographics": {
+                    "ageRange": {
+                        "start": float(entry["EDAD"]),
+                        "end": float(entry["EDAD"])
+                    },
+                    "gender": convert_gender(entry["SEXO"])
                 }
+            }
             yield case
-    
 
 
 def lambda_handler(event, context):

--- a/ingestion/functions/parsing/peru/peru_test.py
+++ b/ingestion/functions/parsing/peru/peru_test.py
@@ -1,9 +1,5 @@
-import csv
-import json
 import os
-import tempfile
 import unittest
-from datetime import date
 from peru import peru
 
 _SOURCE_ID = "place_holder"
@@ -16,54 +12,56 @@ class PeruTest(unittest.TestCase):
 
     def test_parse(self):
         '''
-        Includes a row where province and district are unspecified, where it should return just 
+        Includes a row where province and district are unspecified, where it should return just
         the department and country
         '''
         current_dir = os.path.dirname(__file__)
         sample_data_file = os.path.join(current_dir, "sample_data.csv")
 
         result = peru.parse_cases(sample_data_file, _SOURCE_ID, _SOURCE_URL)
-        self.assertCountEqual(list(result), [{'caseReference': {'sourceId': 'place_holder',
-                                                          'sourceEntryId': '7320cabdc1aaca6c59014cae76a134e6',
-                                                          'sourceUrl': 'place_holder'},
-                                        'location': {'query': 'AYACUCHO, HUAMANGA, AYACUCHO, Peru'},
-                                        'demographics': {'ageRange': {'start': 58.0, 'end': 58.0}, 'gender': 'Male'},
-                                        'events': [{'name': 'confirmed',
-                                                    'value': 'PCR test',
-                                                    'dateRange': {'start': '07/24/2020Z', 'end': '07/24/2020Z'}}]},
-                                       {'caseReference': {'sourceId': 'place_holder',
-                                                          'sourceEntryId': 'e81602051997ace8340bb8c18fe24c65',
-                                                          'sourceUrl': 'place_holder'},
-                                        'location': {'query': 'CHIMBOTE, SANTA, ANCASH, Peru'},
-                                        'demographics': {'ageRange': {'start': 53.0, 'end': 53.0},
-                                                         'gender': 'Female'},
-                                        'events': [{'name': 'confirmed',
-                                                    'value': 'PCR test',
-                                                    'dateRange': {'start': '07/24/2020Z', 'end': '07/24/2020Z'}}]},
-                                       {'caseReference': {'sourceId': 'place_holder',
-                                                          'sourceEntryId': 'cecdbf10074dbc011ae05b3cbd320a6f',
-                                                          'sourceUrl': 'place_holder'},
-                                        'location': {'query': 'ANCON, LIMA, LIMA, Peru'},
-                                        'demographics': {'ageRange': {'start': 58.0, 'end': 58.0}, 'gender': 'Male'},
-                                        'events': [{'name': 'confirmed',
-                                                    'value': 'PCR test',
-                                                    'dateRange': {'start': '07/23/2020Z', 'end': '07/23/2020Z'}}]},
-                                       {'caseReference': {'sourceId': 'place_holder',
-                                                          'sourceEntryId': '566af4276cbe9359abe93f9aa86396c3',
-                                                          'sourceUrl': 'place_holder'},
-                                        'location': {'query': 'CUSCO, CUSCO, CUSCO, Peru'},
-                                        'demographics': {'ageRange': {'start': 58.0, 'end': 58.0}, 'gender': 'Male'},
-                                        'events': [{'name': 'confirmed',
-                                                    'value': 'PCR test',
-                                                    'dateRange': {'start': '07/23/2020Z', 'end': '07/23/2020Z'}}]},
-                                       {'caseReference': {'sourceId': 'place_holder',
-                                                          'sourceEntryId': '027561e9d126e7c283d79c02cede562d',
-                                                          'sourceUrl': 'place_holder'},
-                                        'location': {'query': 'LIMA, Peru'},
-                                        'demographics': {'ageRange': {'start': 28.0, 'end': 28.0}, 'gender': 'Male'},
-                                        'events': [{'name': 'confirmed',
-                                                    'value': 'PCR test',
-                                                    'dateRange': {'start': '07/24/2020Z', 'end': '07/24/2020Z'}
-                                                    }]}
-                                       ]
-                              )
+        self.assertCountEqual(
+            list(result), [
+                {'caseReference': {'sourceId': 'place_holder',
+                                   'sourceEntryId': '7320cabdc1aaca6c59014cae76a134e6',
+                                   'sourceUrl': 'place_holder'},
+                 'location': {'query': 'AYACUCHO, HUAMANGA, AYACUCHO, Peru'},
+                 'demographics': {'ageRange': {'start': 58.0, 'end': 58.0}, 'gender': 'Male'},
+                 'events': [{'name': 'confirmed',
+                             'value': 'PCR test',
+                             'dateRange': {'start': '07/24/2020Z', 'end': '07/24/2020Z'}}]},
+                {'caseReference': {'sourceId': 'place_holder',
+                                   'sourceEntryId': 'e81602051997ace8340bb8c18fe24c65',
+                                   'sourceUrl': 'place_holder'},
+                 'location': {'query': 'CHIMBOTE, SANTA, ANCASH, Peru'},
+                 'demographics': {'ageRange': {'start': 53.0, 'end': 53.0},
+                                  'gender': 'Female'},
+                 'events': [{'name': 'confirmed',
+                             'value': 'PCR test',
+                             'dateRange': {'start': '07/24/2020Z', 'end': '07/24/2020Z'}}]},
+                {'caseReference': {'sourceId': 'place_holder',
+                                   'sourceEntryId': 'cecdbf10074dbc011ae05b3cbd320a6f',
+                                   'sourceUrl': 'place_holder'},
+                 'location': {'query': 'ANCON, LIMA, LIMA, Peru'},
+                 'demographics': {'ageRange': {'start': 58.0, 'end': 58.0}, 'gender': 'Male'},
+                 'events': [{'name': 'confirmed',
+                             'value': 'PCR test',
+                             'dateRange': {'start': '07/23/2020Z', 'end': '07/23/2020Z'}}]},
+                {'caseReference': {'sourceId': 'place_holder',
+                                   'sourceEntryId': '566af4276cbe9359abe93f9aa86396c3',
+                                   'sourceUrl': 'place_holder'},
+                 'location': {'query': 'CUSCO, CUSCO, CUSCO, Peru'},
+                 'demographics': {'ageRange': {'start': 58.0, 'end': 58.0}, 'gender': 'Male'},
+                 'events': [{'name': 'confirmed',
+                             'value': 'PCR test',
+                             'dateRange': {'start': '07/23/2020Z', 'end': '07/23/2020Z'}}]},
+                {'caseReference': {'sourceId': 'place_holder',
+                                   'sourceEntryId': '027561e9d126e7c283d79c02cede562d',
+                                   'sourceUrl': 'place_holder'},
+                 'location': {'query': 'LIMA, Peru'},
+                 'demographics': {'ageRange': {'start': 28.0, 'end': 28.0}, 'gender': 'Male'},
+                 'events': [{'name': 'confirmed',
+                             'value': 'PCR test',
+                             'dateRange': {'start': '07/24/2020Z', 'end': '07/24/2020Z'}
+                             }]}
+            ]
+        )

--- a/ingestion/functions/parsing/thai/thai.py
+++ b/ingestion/functions/parsing/thai/thai.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from datetime import date, datetime
+from datetime import datetime
 
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.

--- a/ingestion/functions/parsing/thai/thai_test.py
+++ b/ingestion/functions/parsing/thai/thai_test.py
@@ -1,10 +1,5 @@
-import json
 import os
-import pytest
-import tempfile
 import unittest
-
-from datetime import date
 
 from thai import thai
 

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -6,7 +6,6 @@ import io
 from chardet import detect
 
 import boto3
-import google.auth.transport.requests
 import requests
 
 from datetime import datetime, timezone
@@ -101,7 +100,7 @@ def retrieve_content(
         bytesio = io.BytesIO(r.content)
         print('detecting encoding of retrieved content.')
         # Read 2MB to be quite sure about the encoding.
-        detected_enc = detect(bytesio.read(2<<20))
+        detected_enc = detect(bytesio.read(2 << 20))
         bytesio.seek(0)
         print(f'Source encoding is presumably {detected_enc}')
         source_encoding = detected_enc['encoding']

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -129,7 +129,7 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3,
 
 def test_extract_event_fields_returns_env_and_source_id(valid_event):
     from retrieval import retrieval
-    env, source_id, auth = retrieval.extract_event_fields(valid_event)
+    env, source_id, _ = retrieval.extract_event_fields(valid_event)
     assert env == valid_event["env"]
     assert source_id == valid_event["sourceId"]
 
@@ -154,7 +154,8 @@ def test_get_source_details_returns_url_and_format(
     requests_mock.get(f"{_SOURCE_API_URL}/sources/{source_id}",
                       json={"format": "CSV",
                             "origin": {"url": content_url, "license": "MIT"}})
-    result = retrieval.get_source_details("env", source_id, "upload_id", {}, {})
+    result = retrieval.get_source_details(
+        "env", source_id, "upload_id", {}, {})
     assert result[0] == content_url
     assert result[1] == "CSV"
     assert result[2] == ""
@@ -171,7 +172,8 @@ def test_get_source_details_returns_parser_arn_if_present(
         json={"origin": {"url": content_url, "license": "MIT"},
               "format": "JSON",
               "automation": {"parser": {"awsLambdaArn": lambda_arn}}})
-    result = retrieval.get_source_details("env", source_id, "upload_id", {}, {})
+    result = retrieval.get_source_details(
+        "env", source_id, "upload_id", {}, {})
     assert result[2] == lambda_arn
 
 
@@ -197,7 +199,7 @@ def test_get_source_details_raises_error_if_source_not_found(
         return
 
     # We got the wrong exception or no exception, fail the test.
-    assert "Should have raised an exception." == False
+    assert not "Should have raised an exception."
 
 
 def test_get_source_details_raises_error_if_other_errors_getting_source(
@@ -222,7 +224,7 @@ def test_get_source_details_raises_error_if_other_errors_getting_source(
         return
 
     # We got the wrong exception or no exception, fail the test.
-    assert "Should have raised an exception." == False
+    assert not "Should have raised an exception."
 
 
 def test_retrieve_content_persists_downloaded_json_locally(requests_mock):
@@ -284,7 +286,7 @@ def test_retrieve_content_raises_error_for_non_supported_format(
         return
 
     # We got the wrong exception or no exception, fail the test.
-    assert "Should have raised an exception." == False
+    assert not "Should have raised an exception."
 
 
 def test_retrieve_content_raises_error_for_source_content_not_found(
@@ -308,7 +310,7 @@ def test_retrieve_content_raises_error_for_source_content_not_found(
         return
 
     # We got the wrong exception or no exception, fail the test.
-    assert "Should have raised an exception." == False
+    assert not "Should have raised an exception."
 
 
 def test_retrieve_content_raises_error_if_other_errors_getting_source_content(
@@ -332,7 +334,7 @@ def test_retrieve_content_raises_error_if_other_errors_getting_source_content(
         return
 
     # We got the wrong exception or no exception, fail the test.
-    assert "Should have raised an exception." == False
+    assert not "Should have raised an exception."
 
 
 def test_upload_to_s3_writes_indicated_file_to_key(s3):
@@ -370,4 +372,4 @@ def test_upload_to_s3_raises_error_on_s3_error(
         return
 
     # We got the wrong exception or no exception, fail the test.
-    assert "Should have raised an exception." == False
+    assert not "Should have raised an exception."


### PR DESCRIPTION
Basically ran autopep8 and `python3 -m flake8 **/*.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics` on the ingestion dir, it seems that we have a CI for that but it doens't error out when errors are encountered:

https://github.com/globaldothealth/list/runs/1100557888?check_suite_focus=true

I'd love to have an autopep8 pre-commit hook as well as we do for the typescript code, will look into that.