### PR TITLE
bump memory of retrieval function

### DIFF
--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -20,6 +20,7 @@ Resources:
       CodeUri: retrieval/
       Handler: retrieval.lambda_handler
       Description: Retrieve raw source content
+      MemorySize: 512
       # Function's execution role
       Policies:
         - AWSLambdaFullAccess


### PR DESCRIPTION
For #1016

Deployed that new version and tried out a retrieval, it worked this time without the memory error.