### PR TITLE
do not show charts on homepage for non curators or admins

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
@@ -15,11 +15,20 @@ describe('App', function () {
     });
 
     it('Shows charts on home page', function () {
+        cy.login();
         cy.visit('/');
 
         cy.contains('Completeness');
         cy.contains('Cumulative');
         cy.contains('Freshness');
+    });
+
+    it('Does not show charts on home page when logged-out', function () {
+        cy.visit('/');
+
+        cy.contains('Completeness').should('not.exist');
+        cy.contains('Cumulative').should('not.exist');
+        cy.contains('Freshness').should('not.exist');
     });
 
     it('shows login button when logged out', function () {

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -610,7 +610,7 @@ export default function App(): JSX.Element {
                             />
                         )}
                         <Route exact path="/">
-                            <Charts />
+                            {hasAnyRole(['curator', 'admin']) && <Charts />}
                         </Route>
                     </Switch>
                 </main>


### PR DESCRIPTION
Fixes #1020

Rationale:
- we should have a proper homepage instead
- doesn't show up when in incognito mode
- charts are potentially expensive until we figure out proper indexes for them (#790)