### PR TITLE
fix email env vars in dev

### DIFF
--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -71,6 +71,10 @@ spec:
                 secretKeyRef:
                   name: curator-dev-bch28c9gkm
                   key: mapbox_token
+            - name: EMAIL_USER_ADDRESS
+              value: ''
+            - name: EMAIL_USER_PASSWORD
+              value: ''
           resources:
             requests:
               memory: "256Mi"

--- a/verification/curator-service/api/src/util/validate-env.ts
+++ b/verification/curator-service/api/src/util/validate-env.ts
@@ -59,7 +59,8 @@ export default function validateEnv(): Readonly<{
             devDefault: '',
         }),
         EMAIL_USER_PASSWORD: str({
-            desc: 'MongoDB URI provided to MongoClient.',
+            desc:
+                'Password of the email address account used to send notification emails.',
             devDefault: '',
         }),
         ENABLE_FAKE_GEOCODER: bool({


### PR DESCRIPTION
Tried to reload dev today but it failed because the env vars weren't defined.
Just setting them to empty for now until a proper account is available.