### PR TITLE
remove reader from roles, all logged-in users can now see the linelist and sources

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -50,7 +50,7 @@ Note that the user must be logged-in into the portal before you can issue this c
 If for some obscure reason the command above do not work, here is how to update a user in mongo directly:
 
 ```mongo
-db.users.updateOne({email: "your-google-email"}, {$set: {roles: ['admin', 'reader', 'curator']}})
+db.users.updateOne({email: "your-google-email"}, {$set: {roles: ['admin', 'curator']}})
 ```
 
 ### Let's run this thing!

--- a/dev/make_superuser.sh
+++ b/dev/make_superuser.sh
@@ -6,6 +6,6 @@ set -e
 pushd `pwd`
 # We have to run docker-compose from this directory for it to pick up the .env file.
 cd `dirname "$0"`
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml exec mongo mongo covid19 --eval "var email='$1'; var roles=['admin', 'curator', 'reader'];" /verification/scripts/roles.js
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml exec mongo mongo covid19 --eval "var email='$1'; var roles=['admin', 'curator'];" /verification/scripts/roles.js
 # Restore directory.
 popd

--- a/ingestion/functions/README.md
+++ b/ingestion/functions/README.md
@@ -143,7 +143,7 @@ sam build
 sam local invoke "RetrievalFunction" -e retrieval/valid_scheduled_event.json --docker-network=host
 ```
 
-If you get a 403 error, go to the [user administration page](http://localhost:3002/sources) and assign the `curator` and `reader` roles to the `ingestion@covid-19-map-277002.iam.gserviceaccount.com` service account there.
+If you get a 403 error, go to the [user administration page](http://localhost:3002/sources) and assign the `curator` role to the `ingestion@covid-19-map-277002.iam.gserviceaccount.com` service account there.
 
 Upon success you'll see in the output something like
 `{"bucket":"epid-sources-raw","key":"5f311a9795e338003016593a/2020/08/10/1009/content.csv"}`

--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -97,7 +97,7 @@ def login(email: str):
     endpoint = "http://localhost:3001/auth/register"
     res = requests.post(endpoint, json={
         "email": email,
-        "roles": ['curator', 'reader'],
+        "roles": ['curator'],
     })
     if not res or res.status_code != 200:
         raise RuntimeError(

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1430,7 +1430,6 @@ components:
       enum:
         - admin
         - curator
-        - reader
     RoleArray:
       type: object
       properties:

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -1,6 +1,10 @@
 import * as usersController from './controllers/users';
 
-import { AuthController, mustHaveAnyRole } from './controllers/auth';
+import {
+    AuthController,
+    mustBeAuthenticated,
+    mustHaveAnyRole,
+} from './controllers/auth';
 import { NextFunction, Request, Response } from 'express';
 import session, { SessionOptions } from 'express-session';
 
@@ -233,29 +237,25 @@ new OpenApiValidator({
             env.DATASERVER_URL,
             geocoders,
         );
-        apiRouter.get(
-            '/cases',
-            mustHaveAnyRole(['reader', 'curator', 'admin']),
-            casesController.list,
-        );
+        apiRouter.get('/cases', mustBeAuthenticated, casesController.list);
         apiRouter.get(
             '/cases/symptoms',
-            mustHaveAnyRole(['reader', 'curator']),
+            mustHaveAnyRole(['curator']),
             casesController.listSymptoms,
         );
         apiRouter.get(
             '/cases/placesOfTransmission',
-            mustHaveAnyRole(['reader', 'curator']),
+            mustHaveAnyRole(['curator']),
             casesController.listPlacesOfTransmission,
         );
         apiRouter.get(
             '/cases/occupations',
-            mustHaveAnyRole(['reader', 'curator']),
+            mustHaveAnyRole(['curator']),
             casesController.listOccupations,
         );
         apiRouter.get(
             '/cases/:id([a-z0-9]{24})',
-            mustHaveAnyRole(['reader', 'curator', 'admin']),
+            mustBeAuthenticated,
             casesController.get,
         );
         apiRouter.post(
@@ -265,7 +265,7 @@ new OpenApiValidator({
         );
         apiRouter.post(
             '/cases/download',
-            mustHaveAnyRole(['reader', 'curator', 'admin']),
+            mustBeAuthenticated,
             casesController.download,
         );
         apiRouter.post(

--- a/verification/curator-service/api/src/model/user.ts
+++ b/verification/curator-service/api/src/model/user.ts
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 
-export const userRoles = ['admin', 'curator', 'reader'];
+export const userRoles = ['admin', 'curator'];
 
 const userSchema = new mongoose.Schema({
     name: String,

--- a/verification/curator-service/api/test/cases.test.ts
+++ b/verification/curator-service/api/test/cases.test.ts
@@ -78,18 +78,11 @@ describe('Cases', () => {
         curatorRequest = supertest.agent(app);
         await curatorRequest
             .post('/auth/register')
-            .send({ ...baseUser, ...{ roles: ['reader', 'curator'] } })
+            .send({ ...baseUser, ...{ roles: ['curator'] } })
             .expect(200);
     });
     afterEach(async () => {
         await curatorRequest.post('/api/geocode/clear').expect(200);
-    });
-    it('denies access to non readers', async () => {
-        return supertest
-            .agent(app)
-            .get('/api/cases?limit=10&page=1&q=')
-            .expect(403, /reader/)
-            .expect('Content-Type', /json/);
     });
     it('proxies list calls', async () => {
         mockedAxios.get.mockResolvedValueOnce({
@@ -283,7 +276,7 @@ describe('Cases', () => {
         const adminRequest = supertest.agent(app);
         await adminRequest
             .post('/auth/register')
-            .send({ ...baseUser, ...{ roles: ['reader', 'curator', 'admin'] } })
+            .send({ ...baseUser, ...{ roles: ['curator', 'admin'] } })
             .expect(200);
         await adminRequest
             .delete('/api/cases')

--- a/verification/curator-service/api/test/model/user.test.ts
+++ b/verification/curator-service/api/test/model/user.test.ts
@@ -6,7 +6,7 @@ describe('User schema', () => {
             name: 'test source',
             email: 'foo@bar.com',
             googleID: 'baz',
-            roles: ['admin', 'reader'],
+            roles: ['admin', 'curator'],
         }).validateSync();
         expect(errors).toBeUndefined();
     });

--- a/verification/curator-service/api/test/users.test.ts
+++ b/verification/curator-service/api/test/users.test.ts
@@ -45,7 +45,7 @@ describe('GET', () => {
             .get('/api/users/roles')
             .expect(200)
             .expect('Content-Type', /json/);
-        expect(res.body.roles).toEqual(['admin', 'curator', 'reader']);
+        expect(res.body.roles).toEqual(['admin', 'curator']);
     });
 
     it('list should return 200', async () => {
@@ -65,7 +65,7 @@ describe('GET', () => {
                 name: 'Alice Smith',
                 email: 'foo@bar.com',
                 googleID: `testGoogleID${i}`,
-                roles: ['reader'],
+                roles: ['curator'],
             }).save();
         }
         // Fetch first page as an admin.

--- a/verification/curator-service/auth.md
+++ b/verification/curator-service/auth.md
@@ -12,7 +12,6 @@ The different roles are:
 
 - admin
 - curator
-- reader
 
 A user can have no roles.
 
@@ -20,11 +19,11 @@ Here are the permissions granted to each roles:
 
 - Admin
   - List users based on their roles
-  - Assign/unassign role to users 
+  - Assign/unassign role to users
 - Curator
   - CRUD cases and ingestion sources
-- Reader
-  - Read-only access to cases and sources
+
+By default all logged-in users have read-only access to the linelist data and sources used to populate it.
 
 ## Unit-testing
 

--- a/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
@@ -96,8 +96,8 @@ describe('App', function () {
         cy.contains('Manage users').should('not.exist');
     });
 
-    it('Homepage with logged in reader', function () {
-        cy.login({ roles: ['reader'] });
+    it('Homepage with logged in user with no roles', function () {
+        cy.login({ roles: [] });
         cy.visit('/');
 
         cy.contains('Create new').should('not.exist');

--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -5,7 +5,7 @@ describe('Linelist table', function () {
         cy.login({
             email: 'test@bar.com',
             name: 'test',
-            roles: ['admin', 'curator', 'reader'],
+            roles: ['admin', 'curator'],
         });
     });
 

--- a/verification/curator-service/ui/cypress/integration/components/ProfileTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/ProfileTest.spec.ts
@@ -4,13 +4,12 @@ describe('Profile', function () {
         cy.login({
             name: 'Alice Smith',
             email: 'alice@test.com',
-            roles: ['reader', 'curator'],
+            roles: ['curator'],
         });
         cy.visit('/profile');
 
         cy.contains('Alice Smith');
         cy.contains('alice@test.com');
-        cy.contains('reader');
         cy.contains('curator');
     });
 });

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -8,7 +8,7 @@ describe('Manage users page', function () {
         cy.login({
             name: 'Bob',
             email: 'bob@test.com',
-            roles: ['curator', 'reader'],
+            roles: ['curator'],
         });
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
         cy.visit('/users');
@@ -18,12 +18,8 @@ describe('Manage users page', function () {
         cy.get('div[data-testid="Alice-select-roles"]')
             .contains('curator')
             .should('not.exist');
-        cy.get('div[data-testid="Alice-select-roles"]')
-            .contains('reader')
-            .should('not.exist');
         cy.contains('Bob');
         cy.get('div[data-testid="Bob-select-roles"]').contains('curator');
-        cy.get('div[data-testid="Bob-select-roles"]').contains('reader');
         cy.get('div[data-testid="Bob-select-roles"]')
             .contains('admin')
             .should('not.exist');
@@ -33,13 +29,12 @@ describe('Manage users page', function () {
         cy.login({
             name: 'Bob',
             email: 'bob@test.com',
-            roles: ['curator', 'reader'],
+            roles: ['curator'],
         });
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
         cy.visit('/users');
         cy.contains('Bob');
         cy.get('div[data-testid="Bob-select-roles"]').contains('curator');
-        cy.get('div[data-testid="Bob-select-roles"]').contains('reader');
         cy.get('div[data-testid="Bob-select-roles"]')
             .contains('admin')
             .should('not.exist');
@@ -53,22 +48,20 @@ describe('Manage users page', function () {
         cy.wait('@updateUser');
         cy.wait('@getUsers');
         cy.get('div[data-testid="Bob-select-roles"]').click();
-        cy.get('li[data-value="reader"]').click();
+        cy.get('li[data-value="curator"]').click();
         cy.wait('@updateUser');
         cy.wait('@getUsers');
 
-        cy.get('div[data-testid="Bob-select-roles"]').contains('curator');
         cy.get('div[data-testid="Bob-select-roles"]').contains('admin');
         cy.get('div[data-testid="Bob-select-roles"]')
-            .contains('reader')
+            .contains('curator')
             .should('not.exist');
 
         // Roles are maintained on refresh
         cy.visit('/users');
-        cy.get('div[data-testid="Bob-select-roles"]').contains('curator');
         cy.get('div[data-testid="Bob-select-roles"]').contains('admin');
         cy.get('div[data-testid="Bob-select-roles"]')
-            .contains('reader')
+            .contains('curator')
             .should('not.exist');
     });
 
@@ -80,16 +73,16 @@ describe('Manage users page', function () {
         cy.server();
         cy.route('PUT', '/api/users/*').as('updateUser');
         cy.get('div[data-testid="Alice-select-roles"]').click();
-        cy.get('li[data-value="reader"]').click();
+        cy.get('li[data-value="curator"]').click();
         cy.wait('@updateUser');
 
-        // Home page has reader links
+        // Home page has logged-in user links
         cy.visit('/');
         cy.contains('Linelist');
 
         // Profile page is updated
         cy.visit('/profile');
         cy.contains('admin');
-        cy.contains('reader');
+        cy.contains('curator');
     });
 });

--- a/verification/curator-service/ui/cypress/support/commands.ts
+++ b/verification/curator-service/ui/cypress/support/commands.ts
@@ -94,7 +94,7 @@ export function login(opts: {
         body: {
             name: opts?.name ?? 'superuser',
             email: opts?.email ?? 'superuser@test.com',
-            roles: opts?.roles ?? ['admin', 'curator', 'reader'],
+            roles: opts?.roles ?? ['admin', 'curator'],
         },
     });
 }

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -304,8 +304,7 @@ export default function App(): JSX.Element {
             text: 'Linelist',
             icon: <ListIcon />,
             to: { pathname: '/cases', state: { search: '' } },
-            displayCheck: (): boolean =>
-                hasAnyRole(['reader', 'curator', 'admin']),
+            displayCheck: (): boolean => true,
         },
         {
             text: 'Sources',
@@ -532,7 +531,7 @@ export default function App(): JSX.Element {
                 >
                     <div className={classes.drawerHeader} />
                     <Switch>
-                        {hasAnyRole(['curator', 'reader', 'admin']) && (
+                        {user.email && (
                             <Route exact path="/cases">
                                 <LinelistTable user={user} />
                             </Route>
@@ -595,7 +594,7 @@ export default function App(): JSX.Element {
                                 }}
                             />
                         )}
-                        {hasAnyRole(['curator', 'reader']) && (
+                        {user.email && (
                             <Route
                                 path="/cases/view/:id"
                                 render={({ match }): JSX.Element => {

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -304,7 +304,7 @@ export default function App(): JSX.Element {
             text: 'Linelist',
             icon: <ListIcon />,
             to: { pathname: '/cases', state: { search: '' } },
-            displayCheck: (): boolean => true,
+            displayCheck: (): boolean => user.email !== '',
         },
         {
             text: 'Sources',

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -308,7 +308,7 @@ it('can cancel delete action', async () => {
     expect(row).toBeInTheDocument();
 });
 
-it('cannot edit data as a reader only', async () => {
+it('cannot edit data if not curator', async () => {
     const cases = [
         {
             _id: 'abc123',
@@ -359,7 +359,7 @@ it('cannot edit data as a reader only', async () => {
                     _id: 'testUser',
                     name: 'Alice Smith',
                     email: 'foo@bar.com',
-                    roles: ['reader'],
+                    roles: [],
                 }}
             />
         </MemoryRouter>,

--- a/verification/curator-service/ui/src/components/Profile.test.tsx
+++ b/verification/curator-service/ui/src/components/Profile.test.tsx
@@ -10,14 +10,14 @@ test('shows profile when passed user information', async () => {
                 _id: 'abc123',
                 name: 'Alice Smith',
                 email: 'foo@bar.com',
-                roles: ['admin', 'reader'],
+                roles: ['admin', 'curator'],
             }}
         />,
     );
     expect(screen.getByText(/Alice Smith/i)).toBeInTheDocument();
     expect(screen.getByText(/foo@bar.com/i)).toBeInTheDocument();
     expect(screen.getByText(/admin/i)).toBeInTheDocument();
-    expect(screen.getByText(/reader/i)).toBeInTheDocument();
+    expect(screen.getByText(/curator/i)).toBeInTheDocument();
 });
 
 test('shows login message when not passed user information', async () => {

--- a/verification/curator-service/ui/src/components/Profile.tsx
+++ b/verification/curator-service/ui/src/components/Profile.tsx
@@ -63,11 +63,6 @@ export default function Profile(props: { user: User }): JSX.Element {
                         );
                     };
                     switch (role) {
-                        case 'reader':
-                            return tooltip(
-                                'readers can read the linelist data',
-                                role,
-                            );
                         case 'curator':
                             return tooltip(
                                 'curators can submit and verify cases and ingestion sources',

--- a/verification/curator-service/ui/src/components/Users.test.tsx
+++ b/verification/curator-service/ui/src/components/Users.test.tsx
@@ -18,7 +18,7 @@ function mockGetAxios(getUsersResponse: any): void {
         switch (url) {
             case '/api/users/roles':
                 return Promise.resolve({
-                    data: { roles: ['admin', 'curator', 'reader'] },
+                    data: { roles: ['admin', 'curator'] },
                 });
             case '/api/users/':
             case '/api/users/?limit=10&page=1':
@@ -35,7 +35,7 @@ test('lists users', async () => {
             _id: 'abc123',
             name: 'Alice Smith',
             email: 'foo@bar.com',
-            roles: ['admin', 'reader'],
+            roles: ['admin'],
         },
         {
             _id: 'abc321',
@@ -79,7 +79,7 @@ test('updates roles on selection', async () => {
             _id: 'abc123',
             name: 'Alice Smith',
             email: 'foo@bar.com',
-            roles: ['admin', 'reader'],
+            roles: ['admin', 'curator'],
         },
     ];
     const axiosResponse = {
@@ -104,7 +104,7 @@ test('updates roles on selection', async () => {
         />,
     );
     expect(await findByText('Alice Smith')).toBeInTheDocument();
-    expect(await findByText(/admin, reader/)).toBeInTheDocument();
+    expect(await findByText(/admin, curator/)).toBeInTheDocument();
     expect(queryByText('curator')).not.toBeInTheDocument();
 
     // Select new role
@@ -113,7 +113,7 @@ test('updates roles on selection', async () => {
             _id: 'abc123',
             name: 'Alice Smith',
             email: 'foo@bar.com',
-            roles: ['admin', 'reader', 'curator'],
+            roles: ['admin'],
         },
     ];
     const axiosPutResponse = {
@@ -134,7 +134,7 @@ test('updates roles on selection', async () => {
     // Check roles are updated
     expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     expect(mockedAxios.put).toHaveBeenCalledWith('/api/users/abc123', {
-        roles: ['admin', 'reader', 'curator'],
+        roles: ['admin'],
     });
 });
 
@@ -143,7 +143,7 @@ test('calls callback when user is changed', async () => {
         _id: 'abc123',
         name: 'Alice Smith',
         email: 'foo@bar.com',
-        roles: ['admin', 'reader'],
+        roles: ['admin'],
     };
     const axiosResponse = {
         data: {
@@ -167,7 +167,7 @@ test('calls callback when user is changed', async () => {
         _id: 'abc123',
         name: 'Alice Smith',
         email: 'foo@bar.com',
-        roles: ['admin', 'reader', 'curator'],
+        roles: ['admin', 'curator'],
     };
     const axiosPutResponse = {
         data: {
@@ -199,7 +199,7 @@ test('callback not called when other users are changed', async () => {
         _id: 'abc123',
         name: 'Alice Smith',
         email: 'foo@bar.com',
-        roles: ['admin', 'reader'],
+        roles: ['admin'],
     };
     const axiosResponse = {
         data: {
@@ -227,7 +227,7 @@ test('callback not called when other users are changed', async () => {
         _id: 'abc123',
         name: 'Alice Smith',
         email: 'foo@bar.com',
-        roles: ['admin', 'reader', 'curator'],
+        roles: ['admin', 'curator'],
     };
     const axiosPutResponse = {
         data: {

--- a/verification/scripts/README.md
+++ b/verification/scripts/README.md
@@ -5,11 +5,11 @@ This directory contains various scripts to manage the verification part of the G
 ## Bootstrapping admin roles
 
 When the application is first used, logged-in users have no roles associated with them.
-To bootstrap the admin process, you can assign a user with a given email the admin, reader and curator roles:
+To bootstrap the admin process, you can assign a user with a given email the admin and curator roles:
 
 ```shell
 mongo "mongodb://user:pass@some-connection-string/somedb" \
-  --eval 'var email="some-email@foo.bar"; var roles=["admin", "reader", "curator"];' \
+  --eval 'var email="some-email@foo.bar"; var roles=["admin", "curator"];' \
   roles.js
 ```
 


### PR DESCRIPTION
Fixes #1025 

I will remove the reader roles from existing users with the mongo shell command:
`db.users.updateMany({}, {$pull: {roles: 'reader'}})`
so that updates pass validation.