### PR TITLE
show geocoding errors properly in bulk upload

### DIFF
--- a/verification/curator-service/ui/cypress/fixtures/no_header.csv
+++ b/verification/curator-service/ui/cypress/fixtures/no_header.csv
@@ -1,0 +1,2 @@
+def,Female,142,42,Canada,Alberta,,Banff,06/23/2020,true,,,,
+def,Female,142,42,Canada,Alberta,,Banff,06/23/2020,true,,,,

--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -274,4 +274,31 @@ describe('Bulk upload form', function () {
         cy.visit('/cases');
         cy.contains('No records to display');
     });
+
+    it('Fails gracefully when no header in CSV', function () {
+        cy.addSource('Bulk source', 'www.bulksource.com');
+
+        cy.visit('/cases');
+        cy.contains('No records to display');
+
+        cy.visit('/');
+        cy.get('button[data-testid="create-new-button"]').click();
+        cy.contains('li', 'New bulk upload').click();
+        cy.get('div[data-testid="caseReference"]').type('www.bulksource.com');
+        cy.contains('li', 'www.bulksource.com').click();
+        const csvFixture = '../fixtures/no_header.csv';
+        cy.get('input[type="file"]').attachFile(csvFixture);
+        cy.server();
+        cy.route('POST', '/api/cases/batchUpsert').as('batchUpsert');
+        cy.get('button[data-testid="submit"]').click();
+        cy.wait('@batchUpsert');
+        cy.contains(
+            'li',
+            'location.query must be specified to be able to geocode',
+        );
+        cy.get('button[aria-label="close overlay"').click();
+
+        cy.visit('/cases');
+        cy.contains('No records to display');
+    });
 });

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -422,6 +422,7 @@ class BulkCaseForm extends React.Component<
         const casesToSend = cases.flatMap((c) =>
             Array.from({ length: c.caseCount || 1 }, () => c),
         );
+        // TODO: Split and send smaller batches.
         const response = await axios.post<BatchUpsertResponse>(
             '/api/cases/batchUpsert',
             {

--- a/verification/curator-service/ui/src/components/bulk-case-form-fields/CaseValidationError.test.ts
+++ b/verification/curator-service/ui/src/components/bulk-case-form-fields/CaseValidationError.test.ts
@@ -26,4 +26,8 @@ describe('constructed object', () => {
                 '`gender`',
         );
     });
+    it('falls back to raw string for unsupported errors', () => {
+        const o = new CaseValidationError(42, 'some error');
+        expect(o.formattedIssues).toEqual(['some error']);
+    });
 });

--- a/verification/curator-service/ui/src/components/bulk-case-form-fields/CaseValidationError.ts
+++ b/verification/curator-service/ui/src/components/bulk-case-form-fields/CaseValidationError.ts
@@ -29,6 +29,12 @@ export default class CaseValidationError {
      * @param apiResponse The raw text response received from the validation API.
      */
     constructor(public readonly rowNumber: number, apiResponse: string) {
+        // Geocoding errors are not prefixed like validation errors, in that
+        // case just return the error as is.
+        if (!apiResponse.startsWith(CaseValidationError.leadingErrorText)) {
+            this.formattedIssues = [apiResponse];
+            return;
+        }
         const sortedErrorsByField = apiResponse
             .substr(CaseValidationError.leadingErrorText.length)
             .split(CaseValidationError.errorDelimiter)


### PR DESCRIPTION
For #1144

Not sure how we could 100% detect that a CSV without header was uploaded but this adds a fall back in case the error returned are not formatted as expected.