### PR TITLE
uncompress zip files when source URL points to one

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -77,7 +77,7 @@ def get_source_details(env, source_id, upload_id, api_headers, cookies):
             e, env, common_lib.UploadError.INTERNAL_ERROR, source_id, upload_id,
             api_headers, cookies)
 
-def raw_content(url:str, content: bytes) -> io.BytesIO:
+def raw_content(url: str, content: bytes) -> io.BytesIO:
     # Detect the mimetype of a given URL.
     print(f'Guessing mimetype of {url}')
     mimetype, _ = mimetypes.guess_type(url)

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -1,8 +1,11 @@
 import codecs
+import io
 import json
+import mimetypes
 import os
 import sys
-import io
+import tempfile
+import zipfile
 from chardet import detect
 
 import boto3
@@ -74,6 +77,25 @@ def get_source_details(env, source_id, upload_id, api_headers, cookies):
             e, env, common_lib.UploadError.INTERNAL_ERROR, source_id, upload_id,
             api_headers, cookies)
 
+def raw_content(url:str, content: bytes) -> io.BytesIO:
+    # Detect the mimetype of a given URL.
+    print(f'Guessing mimetype of {url}')
+    mimetype, _ = mimetypes.guess_type(url)
+    if mimetype == "application/zip":
+        print('File seems to be a zip file, decompressing it now')
+        # Writing the zip file to temp dir.
+        with tempfile.NamedTemporaryFile("wb", delete=False) as temp:
+            temp.write(content)
+            temp.flush()
+            # Opening the zip file, extracting its first file.
+            with zipfile.ZipFile(temp.name, "r") as zf:
+                for name in zf.namelist():
+                    with zf.open(name) as f:
+                        return io.BytesIO(f.read())
+    elif not mimetype:
+        print('Could not determine mimetype')
+    return io.BytesIO(content)
+
 
 def retrieve_content(
         env, source_id, upload_id, url, source_format, api_headers, cookies):
@@ -97,7 +119,7 @@ def retrieve_content(
         # sources.
         # Make the encoding of retrieved content consistent (UTF-8) for all
         # parsers as per https://github.com/globaldothealth/list/issues/867.
-        bytesio = io.BytesIO(r.content)
+        bytesio = raw_content(url, r.content)
         print('detecting encoding of retrieved content.')
         # Read 2MB to be quite sure about the encoding.
         detected_enc = detect(bytesio.read(2 << 20))

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -377,7 +377,7 @@ def test_upload_to_s3_raises_error_on_s3_error(
     # We got the wrong exception or no exception, fail the test.
     assert not "Should have raised an exception."
 
-def test_decompress_zip_file():
+def test_raw_content_unzips():
     from retrieval import retrieval
     # Creating a fake zip file with one file in it.
     name = None
@@ -392,7 +392,7 @@ def test_decompress_zip_file():
         # Content should be the content of the first file in the zip.
         assert wrappedBytes.read() == b'foo'
 
-def test_ignores_unknown_mimetypes():
+def test_raw_content_ignores_unknown_mimetypes():
     from retrieval import retrieval
     url = 'http://mock/url'
     wrappedBytes = retrieval.raw_content(url, b'foo')

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -3,7 +3,10 @@ import datetime
 import json
 import os
 import pytest
+import tempfile
+import io
 import sys
+import zipfile
 
 from moto import mock_s3
 from unittest.mock import MagicMock, patch
@@ -373,3 +376,24 @@ def test_upload_to_s3_raises_error_on_s3_error(
 
     # We got the wrong exception or no exception, fail the test.
     assert not "Should have raised an exception."
+
+def test_decompress_zip_file():
+    from retrieval import retrieval
+    # Creating a fake zip file with one file in it.
+    name = None
+    with tempfile.NamedTemporaryFile('w', delete=False) as temp:
+        name = temp.name
+    with zipfile.ZipFile(name, 'w') as zf:
+        zf.writestr('somefile', 'foo')
+
+    url = 'http://mock/url.zip'
+    with open(name, "rb") as f:
+        wrappedBytes = retrieval.raw_content(url, f.read())
+        # Content should be the content of the first file in the zip.
+        assert wrappedBytes.read() == b'foo'
+
+def test_ignores_unknown_mimetypes():
+    from retrieval import retrieval
+    url = 'http://mock/url'
+    wrappedBytes = retrieval.raw_content(url, b'foo')
+    assert wrappedBytes.read() == b'foo'


### PR DESCRIPTION
Advantage is that it requires no configuration per source, disadvantage is that it makes assumptions like having one file in the zip file that we're interested in. Fortunately I think that's the case for Mexico data that we're trying to ingest so it seems fine to me. I couldn't confirm though as I can't download the original zip file (need to vpn somewhere it seems, can't DL from Europe :( ).

For #1155