### PR TITLE
Client-side rate limit geocode requests

### DIFF
--- a/data-serving/data-service/package-lock.json
+++ b/data-serving/data-service/package-lock.json
@@ -8333,6 +8333,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",

--- a/data-serving/data-service/package.json
+++ b/data-serving/data-service/package.json
@@ -71,6 +71,7 @@
     "express-openapi-validator": "^3.17.1",
     "express-status-monitor": "^1.3.3",
     "express-validator": "^6.6.1",
+    "limiter": "^1.1.5",
     "lodash": "^4.17.20",
     "longjohn": "^0.2.12",
     "lru-cache": "^6.0.0",

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -30,6 +30,7 @@ import mongoose from 'mongoose';
 import swaggerUi from 'swagger-ui-express';
 import validateEnv from './util/validate-env';
 import { logger } from './util/logger';
+import { RateLimiter } from 'limiter';
 
 const app = express();
 
@@ -111,6 +112,10 @@ new OpenApiValidator({
                     env.MAPBOX_PERMANENT_GEOCODE
                         ? 'mapbox.places-permanent'
                         : 'mapbox.places',
+                    new RateLimiter(
+                        env.MAPBOX_GEOCODE_RATE_LIMIT_PER_SEC,
+                        'second',
+                    ),
                 ),
             );
         }

--- a/data-serving/data-service/src/util/validate-env.ts
+++ b/data-serving/data-service/src/util/validate-env.ts
@@ -1,4 +1,4 @@
-import { CleanEnv, cleanEnv, port, str, bool } from 'envalid';
+import { CleanEnv, cleanEnv, port, str, bool, num } from 'envalid';
 
 export default function validateEnv(): Readonly<{
     DB_CONNECTION_STRING: string;
@@ -7,6 +7,7 @@ export default function validateEnv(): Readonly<{
     MAPBOX_PERMANENT_GEOCODE: boolean;
     MAPBOX_TOKEN: string;
     ENABLE_FAKE_GEOCODER: boolean;
+    MAPBOX_GEOCODE_RATE_LIMIT_PER_SEC: number;
 }> &
     CleanEnv & {
         readonly [varName: string]: string | undefined;
@@ -36,6 +37,12 @@ export default function validateEnv(): Readonly<{
             desc: 'Whether to enable the fake seedable geocoder',
             devDefault: true,
             default: false,
+        }),
+        MAPBOX_GEOCODE_RATE_LIMIT_PER_SEC: num({
+            desc:
+                'number of requests per seconds allowed to mapbox geocode endpoint',
+            devDefault: 50,
+            default: 600,
         }),
     });
 }

--- a/data-serving/data-service/test/geocoding/mapbox.test.ts
+++ b/data-serving/data-service/test/geocoding/mapbox.test.ts
@@ -6,6 +6,7 @@ import Geocoder from '../../src/geocoding/mapbox';
 import { MapiRequest } from '@mapbox/mapbox-sdk/lib/classes/mapi-request';
 import { MapiResponse } from '@mapbox/mapbox-sdk/lib/classes/mapi-response';
 import axios from 'axios';
+import { RateLimiter } from 'limiter';
 
 // Typings defined by DefinitelyTyped are not fully compatible with the response we get.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,7 +53,11 @@ describe('geocode', () => {
             },
         });
         features.push(lyon);
-        const geocoder = new Geocoder('token', 'mapbox.places');
+        const geocoder = new Geocoder(
+            'token',
+            'mapbox.places',
+            new RateLimiter(100, 'second'),
+        );
         let feats = await geocoder.geocode('some query', {
             limitToResolution: [Resolution.Admin3, Resolution.Admin2],
         });
@@ -74,7 +79,11 @@ describe('geocode', () => {
         expect(callCount).toBe(1);
     });
     it('can return no results', async () => {
-        const geocoder = new Geocoder('token', 'mapbox.places');
+        const geocoder = new Geocoder(
+            'token',
+            'mapbox.places',
+            new RateLimiter(100, 'second'),
+        );
         const feats = await geocoder.geocode('some query');
         expect(feats).toHaveLength(0);
     });


### PR DESCRIPTION
Fixes #1131

Will talk to @gtuli to raise the limits on the mapbox side now that we have that in place.

Note that this assumes 600 requests per second per task, it's not global rate limiting (no shared state between dev/prod tasks), we'll need a more complex solution if we want to support that.