### PR TITLE
Disable search bar when search is ongoing

### DIFF
--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -426,6 +426,8 @@ export default function App(): JSX.Element {
         getUser();
     }, []);
 
+    const [searchLoading, setSearchLoading] = React.useState(false);
+
     const classes = useStyles();
     return (
         <div className={classes.root}>
@@ -459,6 +461,7 @@ export default function App(): JSX.Element {
                                                 search: searchQuery,
                                             });
                                         }}
+                                        loading={searchLoading}
                                     ></SearchBar>
                                 </div>
                                 <DownloadButton
@@ -589,7 +592,10 @@ export default function App(): JSX.Element {
                     <Switch>
                         {user && (
                             <Route exact path="/cases">
-                                <LinelistTable user={user} />
+                                <LinelistTable
+                                    user={user}
+                                    setSearchLoading={setSearchLoading}
+                                />
                             </Route>
                         )}
                         {hasAnyRole(['curator']) && (

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -92,9 +92,8 @@ it('loads and displays cases', async () => {
         <MemoryRouter>
             <LinelistTable
                 user={curator}
-                setSearchLoading={(x: boolean): void => {
-                    console.log(`search loading ? ${x}`);
-                }}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setSearchLoading={(x: boolean): void => {}}
             />
         </MemoryRouter>,
     );
@@ -154,9 +153,8 @@ it('API errors are displayed', async () => {
         <MemoryRouter>
             <LinelistTable
                 user={curator}
-                setSearchLoading={(x: boolean): void => {
-                    console.log(`search loading ? ${x}`);
-                }}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setSearchLoading={(x: boolean): void => {}}
             />
         </MemoryRouter>,
     );
@@ -219,9 +217,8 @@ it('can delete a row', async () => {
         <MemoryRouter>
             <LinelistTable
                 user={curator}
-                setSearchLoading={(x: boolean): void => {
-                    console.log(`search loading ? ${x}`);
-                }}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setSearchLoading={(x: boolean): void => {}}
             />
         </MemoryRouter>,
     );
@@ -310,9 +307,8 @@ it('can cancel delete action', async () => {
         <MemoryRouter>
             <LinelistTable
                 user={curator}
-                setSearchLoading={(x: boolean): void => {
-                    console.log(`search loading ? ${x}`);
-                }}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setSearchLoading={(x: boolean): void => {}}
             />
         </MemoryRouter>,
     );
@@ -381,9 +377,8 @@ it('cannot edit data if not curator', async () => {
                     email: 'foo@bar.com',
                     roles: [],
                 }}
-                setSearchLoading={(x: boolean): void => {
-                    console.log(`search loading ? ${x}`);
-                }}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setSearchLoading={(x: boolean): void => {}}
             />
         </MemoryRouter>,
     );

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -90,7 +90,12 @@ it('loads and displays cases', async () => {
 
     const { findByText, findByTestId } = render(
         <MemoryRouter>
-            <LinelistTable user={curator} />
+            <LinelistTable
+                user={curator}
+                setSearchLoading={(x: boolean): void => {
+                    console.log(`search loading ? ${x}`);
+                }}
+            />
         </MemoryRouter>,
     );
 
@@ -147,7 +152,12 @@ it('API errors are displayed', async () => {
 
     const { getByText, findByText, getByTestId } = render(
         <MemoryRouter>
-            <LinelistTable user={curator} />
+            <LinelistTable
+                user={curator}
+                setSearchLoading={(x: boolean): void => {
+                    console.log(`search loading ? ${x}`);
+                }}
+            />
         </MemoryRouter>,
     );
 
@@ -207,7 +217,12 @@ it('can delete a row', async () => {
     // Load table
     const { getByText, findByText, getByTestId } = render(
         <MemoryRouter>
-            <LinelistTable user={curator} />
+            <LinelistTable
+                user={curator}
+                setSearchLoading={(x: boolean): void => {
+                    console.log(`search loading ? ${x}`);
+                }}
+            />
         </MemoryRouter>,
     );
     expect(mockedAxios.get).toHaveBeenCalledTimes(1);
@@ -293,7 +308,12 @@ it('can cancel delete action', async () => {
     // Load table
     const { getByText, findByText, getByTestId } = render(
         <MemoryRouter>
-            <LinelistTable user={curator} />
+            <LinelistTable
+                user={curator}
+                setSearchLoading={(x: boolean): void => {
+                    console.log(`search loading ? ${x}`);
+                }}
+            />
         </MemoryRouter>,
     );
     expect(mockedAxios.get).toHaveBeenCalledTimes(1);
@@ -360,6 +380,9 @@ it('cannot edit data if not curator', async () => {
                     name: 'Alice Smith',
                     email: 'foo@bar.com',
                     roles: [],
+                }}
+                setSearchLoading={(x: boolean): void => {
+                    console.log(`search loading ? ${x}`);
                 }}
             />
         </MemoryRouter>,

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -84,6 +84,7 @@ interface Props
     extends RouteComponentProps<never, never, LocationState>,
         WithStyles<typeof styles> {
     user: User;
+    setSearchLoading: (a: boolean) => void;
 }
 
 const styles = (theme: Theme) =>
@@ -653,7 +654,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             if (trimmedQ) {
                                 listUrl += '&q=' + encodeURIComponent(trimmedQ);
                             }
-                            this.setState({ error: '' });
+                            this.setState({ isLoading: true, error: '' });
+                            this.props.setSearchLoading(true);
                             const response = axios.get<ListResponse>(listUrl);
                             response
                                 .then((result) => {
@@ -716,6 +718,10 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                             e.toString(),
                                     });
                                     reject(e);
+                                })
+                                .finally(() => {
+                                    this.setState({ isLoading: false });
+                                    this.props.setSearchLoading(false);
                                 });
                         })
                     }

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -57,6 +57,7 @@ const StyledSearchTextField = withStyles({
 export default function SearchBar(props: {
     searchQuery: string;
     onSearchChange: (search: string) => void;
+    loading: boolean;
 }): JSX.Element {
     const [search, setSearch] = React.useState<string>(props.searchQuery ?? '');
     const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -95,6 +96,7 @@ export default function SearchBar(props: {
                 value={search}
                 variant="outlined"
                 fullWidth
+                disabled={props.loading}
                 InputProps={{
                     margin: 'dense',
                     startAdornment: (


### PR DESCRIPTION
loading state is up in the App component because it has to be sent to the search bar by the linelist component, feels a bit clunky but I think that's right (aka. the React way of moving the state up).

Fixes #1115 