### PR TITLE
Give more RAM and CPU to prod data service

### DIFF
--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -85,7 +85,7 @@ spec:
               memory: "256Mi"
               cpu: "100m"
             limits:
-              memory: "512Mi"
+              memory: "256Mi"
               cpu: "250m"
 ---
 apiVersion: apps/v1
@@ -167,10 +167,10 @@ spec:
                   key: email_user_password
           resources:
             requests:
-              memory: "512Mi"
+              memory: "256Mi"
               cpu: "150m"
             limits:
-              memory: "768Mi"
+              memory: "512Mi"
               cpu: "250m"
 ---
 apiVersion: v1

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -56,7 +56,7 @@ spec:
               memory: "256Mi"
               cpu: "100m"
             limits:
-              memory: "512Mi"
+              memory: "256Mi"
               cpu: "250m"
 ---
 apiVersion: apps/v1
@@ -112,8 +112,8 @@ spec:
               memory: "512Mi"
               cpu: "150m"
             limits:
-              memory: "768Mi"
-              cpu: "250m"
+              memory: "1.5Gi"
+              cpu: "500m"
 ---
 apiVersion: v1
 kind: Service

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -110,10 +110,10 @@ spec:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "150m"
+              cpu: "500m"
             limits:
               memory: "1.5Gi"
-              cpu: "500m"
+              cpu: "1000m"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
For #961

Basically took away 768Mi of RAM from dev and prod curator which do not need much memory (only data service is OOMing) and reassigned that to prod data service.

We're currently capping our RAM limits but for CPU we're totally still in the green so I've bumped it quite a lot.

FTR we currently have two t3.small nodes for workers which gives us 4Gigs of RAM and 4vCPU in total:
![image](https://user-images.githubusercontent.com/1255432/93981579-6fb51100-fd80-11ea-81f7-c9832c7d211e.png)
