### PR TITLE
Flip order for geocoding query

### DIFF
--- a/ingestion/functions/parsing/germany/germany.py
+++ b/ingestion/functions/parsing/germany/germany.py
@@ -86,7 +86,7 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                 case = {
                     "caseReference": {"sourceId": source_id, "sourceUrl": source_url},
                     "location": {
-                        "query": ", ".join(("Germany", row[_ADMIN1], row[_ADMIN2])),
+                        "query": ", ".join((row[_ADMIN2], row[_ADMIN1], "Germany")),
                         "limitToResolution": "Admin2",
                     },
                     "events": [

--- a/ingestion/functions/parsing/germany/germany_test.py
+++ b/ingestion/functions/parsing/germany/germany_test.py
@@ -18,7 +18,7 @@ _PARSED_CASE = [
          "sourceUrl":"foo.bar"
       },
       "location":{
-         "query":"Germany, Schleswig-Holstein, SK Flensburg",
+         "query":"SK Flensburg, Schleswig-Holstein, Germany",
          "limitToResolution": "Admin2"
       },
       "events":[


### PR DESCRIPTION
The mapbox geocoder prefers query text in the reverse order from how I initially had it. This commit should fix that issue.