### PR TITLE
Increase node group instance size

### DIFF
--- a/aws/cluster.yaml
+++ b/aws/cluster.yaml
@@ -12,10 +12,10 @@ availabilityZones: ["us-east-1a", "us-east-1b"]
 
 managedNodeGroups:
   - name: managed-worker-ng
-    minSize: 2
-    maxSize: 5
-    desiredCapacity: 2
-    instanceType: t3.small
+    minSize: 1
+    maxSize: 2
+    desiredCapacity: 1
+    instanceType: r6g.large
     labels: { role: worker }
     tags:
       nodegroup-role: worker

--- a/aws/cluster.yaml
+++ b/aws/cluster.yaml
@@ -12,10 +12,10 @@ availabilityZones: ["us-east-1a", "us-east-1b"]
 
 managedNodeGroups:
   - name: managed-worker-ng
-    minSize: 1
+    minSize: 2
     maxSize: 2
-    desiredCapacity: 1
-    instanceType: r6g.large
+    desiredCapacity: 2
+    instanceType: t3.large
     labels: { role: worker }
     tags:
       nodegroup-role: worker

--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -167,10 +167,10 @@ spec:
                   key: email_user_password
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "150m"
             limits:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "250m"
 ---
 apiVersion: v1

--- a/aws/curator.yaml
+++ b/aws/curator.yaml
@@ -100,7 +100,7 @@ spec:
     matchLabels:
       environment: prod
       app: curator
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -53,10 +53,10 @@ spec:
                   key: mapbox_token
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "100m"
             limits:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "250m"
 ---
 apiVersion: apps/v1
@@ -109,10 +109,10 @@ spec:
                   key: mapbox_token
           resources:
             requests:
-              memory: "512Mi"
+              memory: "4Gi"
               cpu: "500m"
             limits:
-              memory: "1.5Gi"
+              memory: "8Gi"
               cpu: "1000m"
 ---
 apiVersion: v1

--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -71,7 +71,7 @@ spec:
     matchLabels:
       environment: prod
       app: data
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
@@ -112,7 +112,7 @@ spec:
               memory: "4Gi"
               cpu: "500m"
             limits:
-              memory: "8Gi"
+              memory: "6Gi"
               cpu: "1000m"
 ---
 apiVersion: v1


### PR DESCRIPTION
@attwad: Gaurav mentioned in Slack that it'd be fine to move to `r6g.large` -- thoughts on this resource allocation?

I've drafted this up for 2x`t3.small` --> 1x `r6g.large`, but:

- Two instances is better than one from a redundancy standpoint, but with the current set up we require both instances to meet our resource allocations, anyway.
- We lose 2 total vCPU by doing this -- though I can't tell if we're ever CPU limited.
- I haven't actually used the full 16 GiB of memory.

We could do something like 1x `t3.small` and 1x `t3.large` instead, though I'd have to check if there are consequences to running multiple managed node groups.