### PR TITLE
Ensure retrieval->parsing upload continuity

### DIFF
--- a/ingestion/functions/parsing/common/python/parsing_lib/input_event.json
+++ b/ingestion/functions/parsing/common/python/parsing_lib/input_event.json
@@ -4,9 +4,7 @@
     "s3Key": "5f0b9a7ead3a2b003edc0e7f/2020/07/12/2320/content.json",
     "sourceUrl": "https://foo.bar",
     "sourceId": "5f0b9a7ead3a2b003edc0e7f",
-    "uploadIds": [
-        "123456789012345678901234"
-    ],
+    "uploadId": "123456789012345678901234",
     "dateRange": {
         "start": "2020-01-01",
         "end": "2020-09-21"

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -14,7 +14,7 @@ SOURCE_URL_FIELD = "sourceUrl"
 S3_BUCKET_FIELD = "s3Bucket"
 S3_KEY_FIELD = "s3Key"
 SOURCE_ID_FIELD = "sourceId"
-UPLOAD_IDS_FIELD = "uploadIds"
+UPLOAD_ID_FIELD = "uploadId"
 DATE_FILTER_FIELD = "dateFilter"
 DATE_RANGE_FIELD = "dateRange"
 AUTH_FIELD = "auth"
@@ -65,7 +65,7 @@ def extract_event_fields(event: Dict):
         )
         e = ValueError(error_message)
         common_lib.complete_with_error(e)
-    return event[ENV_FIELD], event[SOURCE_URL_FIELD], event[SOURCE_ID_FIELD], event.get(UPLOAD_IDS_FIELD), event[
+    return event[ENV_FIELD], event[SOURCE_URL_FIELD], event[SOURCE_ID_FIELD], event.get(UPLOAD_ID_FIELD), event[
         S3_BUCKET_FIELD], event[S3_KEY_FIELD], event.get(DATE_FILTER_FIELD, {}), event.get(DATE_RANGE_FIELD, {}), event.get(AUTH_FIELD, None)
 
 

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -171,7 +171,7 @@ def test_run_lambda_e2e(
 
     # Delete the provided upload ID to force parsing_lib to create a new upload.
     # Mock the create and update upload calls.
-    del input_event[parsing_lib.UPLOAD_IDS_FIELD]
+    del input_event[parsing_lib.UPLOAD_ID_FIELD]
     base_upload_url = f"{_SOURCE_API_URL}/sources/{input_event['sourceId']}/uploads"
     create_upload_url = base_upload_url
     upload_id = "123456789012345678901234"
@@ -230,7 +230,7 @@ def test_extract_event_fields_returns_all_present_fields(input_event):
         input_event[parsing_lib.ENV_FIELD],
         input_event[parsing_lib.SOURCE_URL_FIELD],
         input_event[parsing_lib.SOURCE_ID_FIELD],
-        input_event[parsing_lib.UPLOAD_IDS_FIELD],
+        input_event[parsing_lib.UPLOAD_ID_FIELD],
         input_event[parsing_lib.S3_BUCKET_FIELD],
         input_event[parsing_lib.S3_KEY_FIELD],
         {},  # Date filter isn't provided, per the following test case.


### PR DESCRIPTION
Apologies, I missed this reviewing [this change](https://github.com/globaldothealth/list/commit/22f2ab7ef994e20888944134615868a6d71b6b40#diff-f4c0cfa1bb556db884ca7efd0b4d60b9). The data provided in the `parsing` input event is sent from the retrieval function. The field between the two should still be a single upload ID, since it's just the ID generated for the new upload as part of retrieval.