### PR TITLE
Fix inability to clear dateFilter fields on source updates

### DIFF
--- a/verification/curator-service/api/src/controllers/sources.ts
+++ b/verification/curator-service/api/src/controllers/sources.ts
@@ -97,6 +97,12 @@ export default class SourcesController {
                 });
                 return;
             }
+            // Undefined fields are removed from the request body by openapi
+            // validator, if we want to unset the dateFilter we have to pass an
+            // empty object and set it undefined ourselves here.
+            if (JSON.stringify(req.body.dateFilter) === '{}') {
+                req.body.dateFilter = undefined;
+            }
             await source.set(req.body).validate();
             await this.updateAutomationScheduleAwsResources(source);
             const result = await source.save();

--- a/verification/curator-service/api/src/model/origin.ts
+++ b/verification/curator-service/api/src/model/origin.ts
@@ -1,12 +1,15 @@
 import mongoose from 'mongoose';
 
-export const originSchema = new mongoose.Schema({
-    url: {
-        type: String,
-        required: 'Enter an origin URL',
+export const originSchema = new mongoose.Schema(
+    {
+        url: {
+            type: String,
+            required: 'Enter an origin URL',
+        },
+        license: String,
     },
-    license: String,
-});
+    { _id: false },
+);
 
 export type OriginDocument = mongoose.Document & {
     url: string;

--- a/verification/curator-service/api/test/sources.test.ts
+++ b/verification/curator-service/api/test/sources.test.ts
@@ -183,6 +183,40 @@ describe('PUT', () => {
         expect(res.body.origin.url).toEqual('http://foo.bar');
         expect(mockPutRule).not.toHaveBeenCalled();
     });
+    it('should update date filtering of a source', async () => {
+        const source = await new Source({
+            name: 'test-source',
+            origin: { url: 'http://foo.bar', license: 'MIT' },
+            format: 'JSON',
+        }).save();
+        let res = await curatorRequest
+            .put(`/api/sources/${source.id}`)
+            .send({
+                dateFilter: {
+                    numDaysBeforeToday: '3',
+                    op: 'EQ',
+                },
+            })
+            .expect(200)
+            .expect('Content-Type', /json/);
+        // Check what changed.
+        expect(res.body.dateFilter).toEqual({
+            numDaysBeforeToday: 3,
+            op: 'EQ',
+        });
+        // Now clear the date filter.
+        res = await curatorRequest
+            .put(`/api/sources/${source.id}`)
+            .send({
+                dateFilter: {},
+            })
+            .expect(200)
+            .expect('Content-Type', /json/);
+        // Check what changed.
+        expect(res.body.dateFilter).toBeUndefined();
+
+        expect(mockPutRule).not.toHaveBeenCalledTimes(2);
+    });
     it('should create an AWS rule with target if provided schedule expression', async () => {
         const source = await new Source({
             name: 'test-source',

--- a/verification/curator-service/ui/cypress/integration/components/EditCase.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/EditCase.spec.ts
@@ -25,7 +25,7 @@ describe('Edit case', function () {
             cy.contains('21').should('not.exist');
             // Change a few things.
             cy.get('div[data-testid="gender"]').click();
-            cy.get('li[data-value="Female"').click();
+            cy.get('li[data-value="Female"]').click();
             cy.get('input[name="age"]').type('21');
             // Submit the changes.
             cy.server();

--- a/verification/curator-service/ui/cypress/integration/components/SourceTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/SourceTableTest.spec.ts
@@ -1,5 +1,3 @@
-import { groupBy } from 'cypress/types/lodash';
-
 /* eslint-disable no-undef */
 describe('Sources table', function () {
     beforeEach(() => {

--- a/verification/curator-service/ui/cypress/integration/components/SourceTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/SourceTableTest.spec.ts
@@ -1,3 +1,5 @@
+import { groupBy } from 'cypress/types/lodash';
+
 /* eslint-disable no-undef */
 describe('Sources table', function () {
     beforeEach(() => {
@@ -20,6 +22,34 @@ describe('Sources table', function () {
         cy.contains('Example source').should('not.exist');
         cy.contains('Edited source');
         cy.contains('arn:aws:lambda:us-east-1:612888738066:function:test-func');
+    });
+
+    it('Can update date filters', function () {
+        cy.addSource('Example source', 'www.example.com');
+        cy.visit('/sources');
+        cy.contains('Example source');
+
+        // Set up date filtering.
+        cy.get('button[title="Edit"]').click();
+        cy.get('input[placeholder="Operator"]').parent().click();
+        cy.get('li[data-value="LT"]').click();
+        cy.get('input[placeholder="days"]').clear().type('3');
+        cy.get('button[title="Save"]').click();
+        cy.contains(/up to 3 day\(s\) ago/);
+
+        // Now change to another operator.
+        cy.get('button[title="Edit"]').click();
+        cy.get('input[placeholder="Operator"]').parent().click();
+        cy.get('li[data-value="EQ"]').click();
+        cy.get('input[placeholder="days"]').clear().type('5');
+        cy.get('button[title="Save"]').click();
+        cy.contains(/from 5 day\(s\) ago/);
+
+        // Now clear date filter.
+        cy.get('button[title="Edit"]').click();
+        cy.get('button[data-testid="clear-date-filter"]').click();
+        cy.get('button[title="Save"]').click();
+        cy.contains(/from 5 day\(s\) ago/).should('not.exist');
     });
 
     it('Can delete a source', function () {

--- a/verification/curator-service/ui/src/components/SourceTable.test.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.test.tsx
@@ -83,7 +83,7 @@ it('loads and displays sources', async () => {
     expect(await findByText(new RegExp(awsLambdaArn))).toBeInTheDocument();
     expect(await findByText(new RegExp(awsRuleArn))).toBeInTheDocument();
     expect(
-        await findByText('Only parse data from 666 days ago'),
+        await findByText('Only parse data from 666 day(s) ago'),
     ).toBeInTheDocument();
     expect(
         await findByText(

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -175,12 +175,17 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                 this.state.url + oldRowData._id,
                 newSource,
             );
-            response.then(resolve).catch((e) => {
-                this.setState({
-                    error: e.response?.data?.message || e.toString(),
+            response
+                .then(() => {
+                    this.setState({ error: '' });
+                    resolve();
+                })
+                .catch((e) => {
+                    this.setState({
+                        error: e.response?.data?.message || e.toString(),
+                    });
+                    reject(e);
                 });
-                reject(e);
-            });
         });
     }
 

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -18,7 +18,6 @@ import ParsersAutocomplete from './ParsersAutocomplete';
 import SourceRetrievalButton from './SourceRetrievalButton';
 import TextField from '@material-ui/core/TextField';
 import axios from 'axios';
-import { isUndefined } from 'util';
 import ChipInput from 'material-ui-chip-input';
 
 interface ListResponse {
@@ -158,7 +157,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
         oldRowData: TableRow | undefined,
     ): Promise<unknown> {
         return new Promise((resolve, reject) => {
-            if (isUndefined(oldRowData)) {
+            if (oldRowData === undefined) {
                 return reject();
             }
             if (
@@ -172,7 +171,6 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                 return reject();
             }
             const newSource = this.updateSourceFromRowData(newRowData);
-            this.setState({ error: '' });
             const response = axios.put(
                 this.state.url + oldRowData._id,
                 newSource,
@@ -221,7 +219,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             dateFilter:
                 rowData.dateFilter?.numDaysBeforeToday || rowData.dateFilter?.op
                     ? rowData.dateFilter
-                    : undefined,
+                    : {},
             notificationRecipients: rowData.notificationRecipients,
         };
     }
@@ -412,7 +410,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                                 rowData.dateFilter
                                                     ?.numDaysBeforeToday
                                             }{' '}
-                                            days ago
+                                            day(s) ago
                                         </div>
                                     ) : rowData.dateFilter?.op === 'LT' ? (
                                         <div>
@@ -421,7 +419,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                                 rowData.dateFilter
                                                     ?.numDaysBeforeToday
                                             }{' '}
-                                            ago
+                                            day(s) ago
                                         </div>
                                     ) : (
                                         <div>None</div>


### PR DESCRIPTION
It turns out that fields with undefined values are just dropped from the request body by the openapi validator, so we were sending {dateFilter: undefined} and within the source controller updater handler we were seeing req.body == {}

:-(

There doesn't seem to be an option in openapi to keep those fields, there is "nullable" but that just sets the field to null when we save the source document, it doesn't remove it from the document as we want.

So the manual-and-cumbersome alternative that I found was to check and set the field to undefined ourselves if we got an empty {} (non null and non undefined) dateFilter.

Also fixes a typo in the edit case cypress test (how was it working until now??) and better English on the displayed date filter.

For #1198