### PR TITLE
Don't wrap table headers and certain values so they fit on one line

### DIFF
--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -606,10 +606,13 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             field: 'confirmedDate',
                             render: (rowData): string =>
                                 renderDate(rowData.confirmedDate),
+                            headerStyle: { whiteSpace: 'nowrap' },
+                            cellStyle: { whiteSpace: 'nowrap' },
                         },
                         {
                             title: 'Admin 3',
                             field: 'adminArea3',
+                            headerStyle: { whiteSpace: 'nowrap' },
                         },
                         {
                             title: 'Admin 2',
@@ -630,6 +633,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 rowData.age[0] === rowData.age[1]
                                     ? rowData.age[0]
                                     : `${rowData.age[0]}-${rowData.age[1]}`,
+                            cellStyle: { whiteSpace: 'nowrap' },
                         },
                         {
                             title: 'Gender',
@@ -642,6 +646,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                         {
                             title: 'Source URL',
                             field: 'sourceUrl',
+                            headerStyle: { whiteSpace: 'nowrap' },
                         },
                     ]}
                     isLoading={this.state.isLoading}


### PR DESCRIPTION
Fixes #1213
Fixes #1211

Before:
![Screen Shot 2020-09-25 at 11 19 19 AM](https://user-images.githubusercontent.com/30459667/94256143-3a93f480-ff21-11ea-8f45-911d7c0f9470.png)

After:
![Screen Shot 2020-09-25 at 11 20 08 AM](https://user-images.githubusercontent.com/30459667/94256164-4384c600-ff21-11ea-8738-2d0b1dad30af.png)
