### PR TITLE
Run actions on all pull requests

### DIFF
--- a/.github/workflows/curator-api-node.yml
+++ b/.github/workflows/curator-api-node.yml
@@ -10,7 +10,6 @@ on:
       - ".github/workflows/curator-api-node.yml"
       - "verification/curator-service/api/**"
   pull_request:
-    branches: [main]
     paths:
       - ".github/workflows/curator-api-node.yml"
       - "verification/curator-service/api/**"

--- a/.github/workflows/curator-ui-node.yml
+++ b/.github/workflows/curator-ui-node.yml
@@ -10,7 +10,6 @@ on:
       - ".github/workflows/curator-ui-node.yml"
       - "verification/curator-service/ui/**"
   pull_request:
-    branches: [main]
     paths:
       - ".github/workflows/curator-ui-node.yml"
       - "verification/curator-service/ui/**"

--- a/.github/workflows/data-service-node.yml
+++ b/.github/workflows/data-service-node.yml
@@ -10,7 +10,6 @@ on:
       - ".github/workflows/data-service-node.yml"
       - "data-serving/data-service/**"
   pull_request:
-    branches: [main]
     paths:
       - ".github/workflows/data-service-node.yml"
       - "data-serving/data-service/**"

--- a/.github/workflows/ingestion-aws-sam-build.yml
+++ b/.github/workflows/ingestion-aws-sam-build.yml
@@ -2,7 +2,6 @@ name: Ingestion functions AWS SAM build
 
 on:
   pull_request:
-    branches: [main]
     paths:
     - '.github/workflows/ingestion-aws-sam-build.yml'
     - 'ingestion/functions/**'

--- a/.github/workflows/ingestion-functions-python.yml
+++ b/.github/workflows/ingestion-functions-python.yml
@@ -7,7 +7,6 @@ on:
     - '.github/workflows/ingestion-functions-python.yml'
     - 'ingestion/functions/**'
   pull_request:
-    branches: [main]
     paths:
     - '.github/workflows/ingestion-functions-python.yml'
     - 'ingestion/functions/**'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,6 @@ on:
       - "data-serving/data-service/**"
       - "data-serving/samples/**"
   pull_request:
-    branches: [main]
     paths:
       - ".github/workflows/integration-tests.yml"
       - "dev/docker-compose.yml"

--- a/.github/workflows/suggest-python.yml
+++ b/.github/workflows/suggest-python.yml
@@ -7,7 +7,6 @@ on:
     - '.github/workflows/suggest-python.yml'
     - 'suggest/acronyms/**'
   pull_request:
-    branches: [main]
     paths:
     - '.github/workflows/suggest-python.yml'
     - 'suggest/acronyms/**'


### PR DESCRIPTION
As opposed to merely those against main.

Since these actions are now unlimited/free, and since folks occasionally chain PRs, this is useful.