### PR TITLE
Temporarily increase dev data server memory

### DIFF
--- a/aws/data.yaml
+++ b/aws/data.yaml
@@ -53,10 +53,10 @@ spec:
                   key: mapbox_token
           resources:
             requests:
-              memory: "512Mi"
+              memory: "2.5Gi"
               cpu: "100m"
             limits:
-              memory: "512Mi"
+              memory: "2.5Gi"
               cpu: "250m"
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
We have headroom for another 2Gi, according to the current node configuration (the other node is just running one replica of each prod service):

```
Non-terminated Pods:          (13 in total)
  Namespace                   Name                                         CPU Requests  CPU Limits  Memory Requests  Memory Limits  AGE
  ---------                   ----                                         ------------  ----------  ---------------  -------------  ---
  cert-manager                cert-manager-9b8969d86-49w62                 0 (0%)        0 (0%)      0 (0%)           0 (0%)         109m
  cert-manager                cert-manager-cainjector-8545fdf87c-lt8xv     0 (0%)        0 (0%)      0 (0%)           0 (0%)         109m
  cert-manager                cert-manager-webhook-8c5db9fb6-974qj         0 (0%)        0 (0%)      0 (0%)           0 (0%)         109m
  default                     curator-dev-666d4955dd-jhjw8                 100m (5%)     250m (12%)  256Mi (3%)       256Mi (3%)     109m
  default                     curator-prod-bd7d467b8-sw5d4                 150m (7%)     250m (12%)  512Mi (7%)       1Gi (14%)      106m
  default                     data-dev-55dcc8bcb7-wkgg4                    100m (5%)     250m (12%)  512Mi (7%)       512Mi (7%)     109m
  default                     data-prod-7dbcd4bff8-vngmf                   500m (25%)    1 (51%)     3Gi (43%)        3Gi (43%)      88m
  ingress-nginx               ingress-nginx-controller-5cc4589cc8-hljxn    100m (5%)     0 (0%)      90Mi (1%)        0 (0%)         109m
  kube-system                 aws-node-mwhk6                               10m (0%)      0 (0%)      0 (0%)           0 (0%)         112m
  kube-system                 coredns-55c5fcd78f-klxn8                     100m (5%)     0 (0%)      70Mi (0%)        170Mi (2%)     109m
  kube-system                 kube-proxy-l7d6s                             100m (5%)     0 (0%)      0 (0%)           0 (0%)         112m
  kubernetes-dashboard        dashboard-metrics-scraper-c79c65bb7-whtrw    0 (0%)        0 (0%)      0 (0%)           0 (0%)         109m
  kubernetes-dashboard        kubernetes-dashboard-56484d4c5-2cfvc         0 (0%)        0 (0%)      0 (0%)           0 (0%)         109m
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                    Requests      Limits
  --------                    --------      ------
  cpu                         1160m (60%)   1750m (90%)
  memory                      4512Mi (63%)  5034Mi (70%)
  ephemeral-storage           0 (0%)        0 (0%)
  hugepages-1Gi               0 (0%)        0 (0%)
  hugepages-2Mi               0 (0%)        0 (0%)
  attachable-volumes-aws-ebs  0             0
Events:                       <none>
```

I can dial this back afterwards -- but this will help test backfill pre-prod while Allyson/Stephen finalize details for the prod work.