### PR TITLE
Revert some changes from #1226

### DIFF
--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -93,7 +93,7 @@
           "additionalProperties": false,
           "properties": {
             "sampleCollectionDate": {
-              "bsonType": ["date", "string"]
+              "bsonType": ["date"]
             },
             "repositoryUrl": {
               "bsonType": "string"
@@ -178,10 +178,10 @@
               "additionalProperties": false,
               "properties": {
                 "start": {
-                  "bsonType": ["date", "string"]
+                  "bsonType": ["date"]
                 },
                 "end": {
-                  "bsonType": ["date", "string"]
+                  "bsonType": ["date"]
                 }
               }
             }
@@ -286,10 +286,10 @@
                   "additionalProperties": false,
                   "properties": {
                     "start": {
-                      "bsonType": ["date", "string"]
+                      "bsonType": ["date"]
                     },
                     "end": {
-                      "bsonType": ["date", "string"]
+                      "bsonType": ["date"]
                     }
                   }
                 },
@@ -378,7 +378,7 @@
                 "bsonType": "string"
               },
               "date": {
-                "bsonType": ["date", "string"]
+                "bsonType": ["date"]
               },
               "notes": {
                 "bsonType": "string"
@@ -393,7 +393,7 @@
                 "bsonType": "string"
               },
               "date": {
-                "bsonType": ["date", "string"]
+                "bsonType": ["date"]
               },
               "notes": {
                 "bsonType": "string"

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -301,11 +301,7 @@ export class CasesController {
                 });
                 return;
             }
-            let bulkWriteResult;
-            if (req.body.cases.length > 0) {
-                // Use this method rather than Case.bulkWrite() as that method
-                // causes an out of memory error for a large number of cases.
-                const bulk = Case.collection.initializeUnorderedBulkOp();
+            const bulkWriteResult = await Case.bulkWrite(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 req.body.cases.map((c: any) => {
                     delete c.caseCount;
@@ -313,26 +309,34 @@ export class CasesController {
                         c.caseReference?.sourceId &&
                         c.caseReference?.sourceEntryId
                     ) {
-                        delete c._id;
-                        bulk.find({
-                            'caseReference.sourceId': c.caseReference.sourceId,
-                            'caseReference.sourceEntryId':
-                                c.caseReference.sourceEntryId,
-                        })
-                            .upsert()
-                            .updateOne({ $set: c });
+                        return {
+                            updateOne: {
+                                filter: {
+                                    'caseReference.sourceId':
+                                        c.caseReference.sourceId,
+                                    'caseReference.sourceEntryId':
+                                        c.caseReference.sourceEntryId,
+                                },
+                                update: c,
+                                upsert: true,
+                            },
+                        };
                     } else {
-                        bulk.insert(c);
+                        return {
+                            insertOne: {
+                                document: c,
+                            },
+                        };
                     }
-                });
-                bulkWriteResult = await bulk.execute();
-            }
+                }),
+                { ordered: false },
+            );
             res.status(200).json({
                 phase: 'UPSERT',
                 numCreated:
-                    (bulkWriteResult?.nInserted || 0) +
-                    (bulkWriteResult?.nUpserted || 0),
-                numUpdated: bulkWriteResult?.nModified || 0,
+                    (bulkWriteResult.insertedCount || 0) +
+                    (bulkWriteResult.upsertedCount || 0),
+                numUpdated: bulkWriteResult.modifiedCount,
                 errors: [],
             });
             return;

--- a/data-serving/data-service/src/controllers/preprocessor.ts
+++ b/data-serving/data-service/src/controllers/preprocessor.ts
@@ -16,7 +16,7 @@ const createNewMetadata = (curatorEmail: string): any => {
         revisionNumber: 0,
         creationMetadata: {
             curator: curatorEmail,
-            date: new Date().toISOString(),
+            date: Date.now(),
         },
     };
 };
@@ -28,11 +28,11 @@ const createUpdateMetadata = (c: CaseDocument, curatorEmail: string): any => {
         revisionNumber: ++c.revisionMetadata.revisionNumber,
         creationMetadata: {
             curator: c.revisionMetadata.creationMetadata.curator,
-            date: c.revisionMetadata.creationMetadata.date,
+            date: c.revisionMetadata.creationMetadata.date.getTime(),
         },
         updateMetadata: {
             curator: curatorEmail,
-            date: new Date().toISOString(),
+            date: Date.now(),
         },
     };
 };

--- a/data-serving/data-service/test/controllers/preprocessor.test.ts
+++ b/data-serving/data-service/test/controllers/preprocessor.test.ts
@@ -41,12 +41,6 @@ afterAll(() => {
     return mongoServer.stop();
 });
 
-interface RevisionMetadataType {
-    revisionNumber: number;
-    creationMetadata: { curator: string; date: string };
-    updateMetadata?: { curator: string; date: string };
-}
-
 describe('create', () => {
     it('sets create metadata', async () => {
         const requestBody = {
@@ -61,17 +55,16 @@ describe('create', () => {
         );
 
         expect(nextFn).toHaveBeenCalledTimes(1);
-        const revisionMetadata: RevisionMetadataType =
-            requestBody.revisionMetadata;
-        expect(requestBody.caseReference).toEqual(minimalCase.caseReference);
-        expect(revisionMetadata.revisionNumber).toEqual(0);
-        expect(revisionMetadata.creationMetadata.curator).toEqual(
-            'creator@gmail.com',
-        );
-        expect(revisionMetadata.creationMetadata.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata.updateMetadata).toEqual(undefined);
+        expect(requestBody).toEqual({
+            ...minimalCase,
+            revisionMetadata: {
+                revisionNumber: 0,
+                creationMetadata: {
+                    curator: 'creator@gmail.com',
+                    date: Date.now(),
+                },
+            },
+        });
     });
     it('does not create a case revision', async () => {
         const requestBody = {
@@ -120,27 +113,20 @@ describe('update', () => {
         );
 
         expect(nextFn).toHaveBeenCalledTimes(1);
-        expect(requestBody.caseReference).toEqual(minimalCase.caseReference);
-
-        const revisionMetadata: RevisionMetadataType =
-            requestBody.revisionMetadata;
-        expect(revisionMetadata.revisionNumber).toEqual(1);
-        expect(revisionMetadata.creationMetadata.curator).toEqual(
-            'creator@gmail.com',
-        );
-        expect(
-            new Date(revisionMetadata.creationMetadata.date)
-                .toISOString()
-                .substring(0, 16),
-        ).toEqual(
-            new Date(Date.parse('2020-01-01')).toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata.updateMetadata?.curator).toEqual(
-            'updater@gmail.com',
-        );
-        expect(revisionMetadata.updateMetadata?.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
+        expect(requestBody).toEqual({
+            ...minimalCase,
+            revisionMetadata: {
+                revisionNumber: 1,
+                creationMetadata: {
+                    curator: 'creator@gmail.com',
+                    date: Date.parse('2020-01-01'),
+                },
+                updateMetadata: {
+                    curator: 'updater@gmail.com',
+                    date: Date.now(),
+                },
+            },
+        });
     });
     it('sets update metadata and replaces existing update metadata', async () => {
         const c = new Case({
@@ -175,26 +161,20 @@ describe('update', () => {
         );
 
         expect(nextFn).toHaveBeenCalledTimes(1);
-        expect(requestBody.caseReference).toEqual(minimalCase.caseReference);
-        const revisionMetadata: RevisionMetadataType =
-            requestBody.revisionMetadata;
-        expect(revisionMetadata.revisionNumber).toEqual(2);
-        expect(revisionMetadata.creationMetadata.curator).toEqual(
-            'creator@gmail.com',
-        );
-        expect(
-            new Date(revisionMetadata.creationMetadata.date)
-                .toISOString()
-                .substring(0, 16),
-        ).toEqual(
-            new Date(Date.parse('2020-01-01')).toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata.updateMetadata?.curator).toEqual(
-            'updater2@gmail.com',
-        );
-        expect(revisionMetadata.updateMetadata?.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
+        expect(requestBody).toEqual({
+            ...minimalCase,
+            revisionMetadata: {
+                revisionNumber: 2,
+                creationMetadata: {
+                    curator: 'creator@gmail.com',
+                    date: Date.parse('2020-01-01'),
+                },
+                updateMetadata: {
+                    curator: 'updater2@gmail.com',
+                    date: Date.now(),
+                },
+            },
+        });
     });
     it('creates a case revision', async () => {
         const c = new Case({
@@ -253,17 +233,16 @@ describe('upsert', () => {
         );
 
         expect(nextFn).toHaveBeenCalledTimes(1);
-        expect(requestBody.caseReference).toEqual(upsertCase.caseReference);
-        const revisionMetadata: RevisionMetadataType =
-            requestBody.revisionMetadata;
-        expect(revisionMetadata.revisionNumber).toEqual(0);
-        expect(revisionMetadata.creationMetadata.curator).toEqual(
-            'creator@gmail.com',
-        );
-        expect(revisionMetadata.creationMetadata.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata.updateMetadata).toEqual(undefined);
+        expect(requestBody).toEqual({
+            ...upsertCase,
+            revisionMetadata: {
+                revisionNumber: 0,
+                creationMetadata: {
+                    curator: 'creator@gmail.com',
+                    date: Date.now(),
+                },
+            },
+        });
     });
     it('with existing case sets update metadata', async () => {
         const upsertCase = {
@@ -297,26 +276,20 @@ describe('upsert', () => {
         );
 
         expect(nextFn).toHaveBeenCalledTimes(1);
-        expect(requestBody.caseReference).toEqual(upsertCase.caseReference);
-        const revisionMetadata: RevisionMetadataType =
-            requestBody.revisionMetadata;
-        expect(revisionMetadata.revisionNumber).toEqual(1);
-        expect(revisionMetadata.creationMetadata.curator).toEqual(
-            'creator@gmail.com',
-        );
-        expect(
-            new Date(revisionMetadata.creationMetadata.date)
-                .toISOString()
-                .substring(0, 16),
-        ).toEqual(
-            new Date(Date.parse('2020-01-01')).toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata.updateMetadata?.curator).toEqual(
-            'updater@gmail.com',
-        );
-        expect(revisionMetadata.updateMetadata?.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
+        expect(requestBody).toEqual({
+            ...upsertCase,
+            revisionMetadata: {
+                revisionNumber: 1,
+                creationMetadata: {
+                    curator: 'creator@gmail.com',
+                    date: Date.parse('2020-01-01'),
+                },
+                updateMetadata: {
+                    curator: 'updater@gmail.com',
+                    date: Date.now(),
+                },
+            },
+        });
     });
     it('with no existing case does not create a case revision', async () => {
         const upsertCase = {
@@ -420,45 +393,34 @@ describe('batch upsert', () => {
         );
 
         expect(nextFn).toHaveBeenCalledTimes(1);
-
-        expect(requestBody.cases[0].caseReference).toEqual(
-            existingCaseWithUpdate.caseReference,
-        );
-        const revisionMetadata0: RevisionMetadataType =
-            requestBody.cases[0].revisionMetadata;
-        expect(revisionMetadata0.revisionNumber).toEqual(1);
-        expect(revisionMetadata0.creationMetadata.curator).toEqual(
-            'creator@gmail.com',
-        );
-        expect(
-            new Date(revisionMetadata0.creationMetadata.date)
-                .toISOString()
-                .substring(0, 16),
-        ).toEqual(
-            new Date(Date.parse('2020-01-01')).toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata0.updateMetadata?.curator).toEqual(
-            'updater@gmail.com',
-        );
-        expect(revisionMetadata0.updateMetadata?.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
-
-        expect(requestBody.cases[1].caseReference).toEqual(
-            newCase.caseReference,
-        );
-        const revisionMetadata1: RevisionMetadataType =
-            requestBody.cases[1].revisionMetadata;
-        expect(revisionMetadata1.revisionNumber).toEqual(0);
-        expect(revisionMetadata1.creationMetadata.curator).toEqual(
-            'updater@gmail.com',
-        );
-        expect(
-            new Date(revisionMetadata1.creationMetadata.date)
-                .toISOString()
-                .substring(0, 16),
-        ).toEqual(new Date().toISOString().substring(0, 16));
-        expect(revisionMetadata1.updateMetadata).toEqual(undefined);
+        expect(requestBody).toEqual({
+            cases: [
+                {
+                    ...existingCaseWithUpdate,
+                    revisionMetadata: {
+                        revisionNumber: 1,
+                        creationMetadata: {
+                            curator: 'creator@gmail.com',
+                            date: Date.parse('2020-01-01'),
+                        },
+                        updateMetadata: {
+                            curator: 'updater@gmail.com',
+                            date: Date.now(),
+                        },
+                    },
+                },
+                {
+                    ...newCase,
+                    revisionMetadata: {
+                        revisionNumber: 0,
+                        creationMetadata: {
+                            curator: 'updater@gmail.com',
+                            date: Date.now(),
+                        },
+                    },
+                },
+            ],
+        });
     });
     it('does not add update metadata if case semantically unchanged', async () => {
         const existingCase = {
@@ -641,51 +603,40 @@ describe('batch update', () => {
         );
 
         expect(nextFn).toHaveBeenCalledTimes(1);
-        expect(requestBody.cases[0].caseReference).toEqual(
-            minimalCase.caseReference,
-        );
-        const revisionMetadata0: RevisionMetadataType =
-            requestBody.cases[0].revisionMetadata;
-        expect(revisionMetadata0.revisionNumber).toEqual(1);
-        expect(revisionMetadata0.creationMetadata.curator).toEqual(
-            'creator@gmail.com',
-        );
-        expect(
-            new Date(revisionMetadata0.creationMetadata.date)
-                .toISOString()
-                .substring(0, 16),
-        ).toEqual(
-            new Date(Date.parse('2020-01-01')).toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata0.updateMetadata?.curator).toEqual(
-            'updater@gmail.com',
-        );
-        expect(revisionMetadata0.updateMetadata?.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
-
-        expect(requestBody.cases[1].caseReference).toEqual(
-            minimalCase.caseReference,
-        );
-        const revisionMetadata1: RevisionMetadataType =
-            requestBody.cases[1].revisionMetadata;
-        expect(revisionMetadata1.revisionNumber).toEqual(2);
-        expect(revisionMetadata1.creationMetadata.curator).toEqual(
-            'creator2@gmail.com',
-        );
-        expect(
-            new Date(revisionMetadata1.creationMetadata.date)
-                .toISOString()
-                .substring(0, 16),
-        ).toEqual(
-            new Date(Date.parse('2020-01-01')).toISOString().substring(0, 16),
-        );
-        expect(revisionMetadata1.updateMetadata?.curator).toEqual(
-            'updater@gmail.com',
-        );
-        expect(revisionMetadata1.updateMetadata?.date.substring(0, 16)).toEqual(
-            new Date().toISOString().substring(0, 16),
-        );
+        expect(requestBody).toEqual({
+            cases: [
+                {
+                    ...minimalCase,
+                    _id: c._id,
+                    revisionMetadata: {
+                        revisionNumber: 1,
+                        creationMetadata: {
+                            curator: 'creator@gmail.com',
+                            date: Date.parse('2020-01-01'),
+                        },
+                        updateMetadata: {
+                            curator: 'updater@gmail.com',
+                            date: Date.now(),
+                        },
+                    },
+                },
+                {
+                    ...minimalCase,
+                    _id: c2._id,
+                    revisionMetadata: {
+                        revisionNumber: 2,
+                        creationMetadata: {
+                            curator: 'creator2@gmail.com',
+                            date: Date.parse('2020-01-01'),
+                        },
+                        updateMetadata: {
+                            curator: 'updater@gmail.com',
+                            date: Date.now(),
+                        },
+                    },
+                },
+            ],
+        });
     });
     it('with existing cases creates case revisions', async () => {
         const c = new Case({


### PR DESCRIPTION
Reverting the preprocessor changes and the bulk write changes from #1226. It broke the mongo charts since the date types were saved as strings. The bulkWrite call converts the dates into the right format for us which the other bulk method didn't do. There are occasionally OOM errors with the bulkWrite call locally for 10k cases. But with dev and prod getting memory upgrades it shouldn't happen there. We also think it unlikely that bulk upload will be a highly used feature.