### PR TITLE
bump memory available to retrieval function to 1GB

### DIFF
--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -22,7 +22,7 @@ Resources:
       CodeUri: retrieval/
       Handler: retrieval.lambda_handler
       Description: Retrieve raw source content
-      MemorySize: 512
+      MemorySize: 1024
       # Function's execution role
       Policies:
         - AWSLambdaFullAccess


### PR DESCRIPTION
For #508 I could successfully trigger a retrieval with that much RAM otherwise it fails with OOM.