### PR TITLE
authenticate bearer holders in mustBeAuthenticated method

### DIFF
--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -26,8 +26,19 @@ export const mustBeAuthenticated = (
 ): void => {
     if (req.isAuthenticated()) {
         return next();
+    } else {
+        passport.authenticate('bearer', (err, user) => {
+            if (err) {
+                return next(err);
+            }
+            if (user) {
+                req.user = user;
+                return next();
+            } else {
+                res.sendStatus(403);
+            }
+        })(req, res, next);
     }
-    res.sendStatus(403);
 };
 
 /**


### PR DESCRIPTION
I noticed that doing a load test /api/cases was returning 403 and /api/sources was working fine, turns out we do not authenticate token bearer in the `mustBeAuthenticated` middleware as we do in the `mustHaveAnyRole` one. Now they are on par.

Now the load test passes fine locally, I need to push this to dev to be able to load test there.

For #1263 