### PR TITLE
Add a dateFilter for greater than X days ago

### DIFF
--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -205,6 +205,8 @@ def filter_cases_by_date(
                 return delta_days == 0
             elif op == "LT":
                 return delta_days < 0
+            elif op == "GT":
+                return delta_days > 0
             else:
                 e = ValueError(f'Unsupported date filter operand: {op}')
                 common_lib.complete_with_error(

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -378,7 +378,7 @@ def test_write_to_server_raises_error_for_failed_batch_upsert_with_validation_er
 
 
 @patch('parsing_lib.parsing_lib.get_today')
-def test_filter_cases_by_date_today(mock_today):
+def test_filter_cases_by_date_keeps_exact_with_EQ(mock_today):
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
     mock_today.return_value = datetime.datetime(2020, 6, 8)
     cases = parsing_lib.filter_cases_by_date(
@@ -390,7 +390,7 @@ def test_filter_cases_by_date_today(mock_today):
 
 
 @patch('parsing_lib.parsing_lib.get_today')
-def test_filter_cases_by_date_not_today(mock_today):
+def test_filter_cases_by_date_removes_nonexact_with_EQ(mock_today):
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
     mock_today.return_value = datetime.datetime(2020, 10, 10)
     cases = parsing_lib.filter_cases_by_date(
@@ -402,7 +402,7 @@ def test_filter_cases_by_date_not_today(mock_today):
 
 
 @patch('parsing_lib.parsing_lib.get_today')
-def test_filter_cases_by_date_exactly_before_today(mock_today):
+def test_filter_cases_by_date_removes_exact_with_LT(mock_today):
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
     mock_today.return_value = datetime.datetime(2020, 6, 8)
     cases = parsing_lib.filter_cases_by_date(
@@ -414,12 +414,36 @@ def test_filter_cases_by_date_exactly_before_today(mock_today):
 
 
 @patch('parsing_lib.parsing_lib.get_today')
-def test_filter_cases_by_date_before_today(mock_today):
+def test_filter_cases_by_date_keeps_before_LT(mock_today):
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
     mock_today.return_value = datetime.datetime(2020, 6, 10)
     cases = parsing_lib.filter_cases_by_date(
         (CASE_JUNE_FIFTH,),
         {"numDaysBeforeToday": 3, "op": "LT"},
+        None,
+        "env", "source_id", "upload_id", {}, {})  # api_creds
+    assert next(cases) == CASE_JUNE_FIFTH
+
+
+@patch('parsing_lib.parsing_lib.get_today')
+def test_filter_cases_by_date_removes_exact_with_GT(mock_today):
+    from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
+    mock_today.return_value = datetime.datetime(2020, 6, 8)
+    cases = parsing_lib.filter_cases_by_date(
+        [CASE_JUNE_FIFTH],
+        {"numDaysBeforeToday": 3, "op": "GT"},
+        None,
+        "env", "source_id", "upload_id", {}, {})  # api_creds
+    assert not next(cases, None)
+
+
+@patch('parsing_lib.parsing_lib.get_today')
+def test_filter_cases_by_date_keeps_after_GT(mock_today):
+    from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
+    mock_today.return_value = datetime.datetime(2020, 6, 7)
+    cases = parsing_lib.filter_cases_by_date(
+        (CASE_JUNE_FIFTH,),
+        {"numDaysBeforeToday": 3, "op": "GT"},
         None,
         "env", "source_id", "upload_id", {}, {})  # api_creds
     assert next(cases) == CASE_JUNE_FIFTH

--- a/ingestion/functions/parsing/india/input_event.json
+++ b/ingestion/functions/parsing/india/input_event.json
@@ -1,7 +1,11 @@
 {
     "env": "local",
     "s3Bucket": "epid-sources-raw",
-    "s3Key": "5f0b9a7ead3a2b003edc0e7f/2020/07/12/2320/content.json",
+    "s3Key": "5f6a9df8310dcb0a1156782c/2020/09/28/2358/content.csv",
     "sourceUrl": "https://foo.bar",
-    "sourceId": "5f0b9a7ead3a2b003edc0e7f"
+    "sourceId": "5f6a9df8310dcb0a1156782c",
+    "dateFilter": {
+        "numDaysBeforeToday": 4,
+        "op": "GT"
+    }
 }

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1011,6 +1011,7 @@ components:
               type: string
               enum:
                 - EQ
+                - GT
                 - LT
         notificationRecipients:
           description: >

--- a/verification/curator-service/api/src/model/date-filter.ts
+++ b/verification/curator-service/api/src/model/date-filter.ts
@@ -8,6 +8,8 @@ export const dateFilterSchema = new mongoose.Schema(
             enum: [
                 // Only import cases from a given day.
                 'EQ',
+                // Import all cases strictly after a given day.
+                'GT',
                 // Import all cases strictly prior to a given day.
                 'LT',
             ],

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -455,6 +455,7 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                                     value: 'EQ',
                                                 },
                                                 { text: 'up to', value: 'LT' },
+                                                { text: 'after', value: 'GT' },
                                             ].map((pair) => (
                                                 <MenuItem
                                                     key={`op-${pair.value}`}

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -426,6 +426,15 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                             }{' '}
                                             day(s) ago
                                         </div>
+                                    ) : rowData.dateFilter?.op === 'GT' ? (
+                                        <div>
+                                            Parse all data after{' '}
+                                            {
+                                                rowData.dateFilter
+                                                    ?.numDaysBeforeToday
+                                            }{' '}
+                                            day(s) ago
+                                        </div>
                                     ) : (
                                         <div>None</div>
                                     ),


### PR DESCRIPTION
For large sources with UUIDs, this is the best way to get recent data. We can't ingest the entire corpus in each run, and using `EQ` runs the risk of missing data (a risk that's necessary/mitigated by delays for data without UUIDs).