### PR TITLE
Don't disaggregate non-line-list India data

### DIFF
--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -9,7 +9,7 @@ _PARSED_CASES = [
     {
         "caseReference": {
             "sourceId": _SOURCE_ID,
-            "sourceEntryId": "297634-1",
+            "sourceEntryId": "OR-A-123",
             "sourceUrl": _SOURCE_URL,
             "additionalSources": [
                 {
@@ -46,70 +46,6 @@ _PARSED_CASES = [
             ]
         },
         "notes": "was also suffering from Diabetes, hypertension."
-    },
-    {
-        "caseReference": {
-            "sourceId": _SOURCE_ID,
-            "sourceEntryId": "297649-1",
-            "sourceUrl": _SOURCE_URL,
-            "additionalSources": [
-                {
-                    "sourceUrl": "https://twitter.com/PIB_Patna/status/1308375952653611008"
-                }
-            ]
-        },
-        "location": {
-            "limitToResolution": "Admin2,Admin1,Country",
-            "query": "Arwal, Bihar, India"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange":
-                        {
-                            "start": "09/22/2020Z",
-                            "end": "09/22/2020Z"
-                        }
-            },
-            {
-                "name": "hospitalAdmission",
-                "value": "Yes"
-            }
-        ],
-        "demographics": None,
-        "notes": None
-    },
-    {
-        "caseReference": {
-            "sourceId": _SOURCE_ID,
-            "sourceEntryId": "297649-2",
-            "sourceUrl": _SOURCE_URL,
-            "additionalSources": [
-                {
-                    "sourceUrl": "https://twitter.com/PIB_Patna/status/1308375952653611008"
-                }
-            ]
-        },
-        "location": {
-            "limitToResolution": "Admin2,Admin1,Country",
-            "query": "Arwal, Bihar, India"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange":
-                        {
-                            "start": "09/22/2020Z",
-                            "end": "09/22/2020Z"
-                        }
-            },
-            {
-                "name": "hospitalAdmission",
-                "value": "Yes"
-            }
-        ],
-        "demographics": None,
-        "notes": None
     },
 ]
 

--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -9,7 +9,7 @@ _PARSED_CASES = [
     {
         "caseReference": {
             "sourceId": _SOURCE_ID,
-            "sourceEntryId": "OR-A-123",
+            "sourceEntryId": "OR-A-123-1",
             "sourceUrl": _SOURCE_URL,
             "additionalSources": [
                 {
@@ -23,15 +23,12 @@ _PARSED_CASES = [
         },
         "events": [
             {
-                "name": "confirmed",
-                "dateRange":
-                        {
-                            "start": "09/22/2020Z",
-                            "end": "09/22/2020Z"
-                        }
-            },
-            {
                 "name": "outcome",
+                "dateRange":
+                {
+                    "start": "09/22/2020Z",
+                    "end": "09/22/2020Z",
+                },
                 "value": "Death"
             }
         ],
@@ -46,6 +43,80 @@ _PARSED_CASES = [
             ]
         },
         "notes": "was also suffering from Diabetes, hypertension."
+    },
+    {
+        "caseReference": {
+            "sourceId": _SOURCE_ID,
+            "sourceEntryId": "Entry-297649-1",
+            "sourceUrl": _SOURCE_URL,
+            "additionalSources": [
+                {
+                    "sourceUrl": "https://twitter.com/PIB_Patna/status/1308375952653611008"
+                }
+            ]
+        },
+        "location": {
+            "limitToResolution": "Admin2,Admin1,Country",
+            "query": "Arwal, Bihar, India"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange":
+                        {
+                            "start": "09/22/2020Z",
+                            "end": "09/22/2020Z"
+                        }
+            },
+            {
+                "name": "hospitalAdmission",
+                "dateRange":
+                        {
+                            "start": "09/22/2020Z",
+                            "end": "09/22/2020Z"
+                        },
+                "value": "Yes"
+            }
+        ],
+        "demographics": None,
+        "notes": None
+    },
+    {
+        "caseReference": {
+            "sourceId": _SOURCE_ID,
+            "sourceEntryId": "Entry-297649-2",
+            "sourceUrl": _SOURCE_URL,
+            "additionalSources": [
+                {
+                    "sourceUrl": "https://twitter.com/PIB_Patna/status/1308375952653611008"
+                }
+            ]
+        },
+        "location": {
+            "limitToResolution": "Admin2,Admin1,Country",
+            "query": "Arwal, Bihar, India"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange":
+                        {
+                            "start": "09/22/2020Z",
+                            "end": "09/22/2020Z"
+                        }
+            },
+            {
+                "name": "hospitalAdmission",
+                "dateRange":
+                        {
+                            "start": "09/22/2020Z",
+                            "end": "09/22/2020Z"
+                        },
+                "value": "Yes"
+            }
+        ],
+        "demographics": None,
+        "notes": None
     },
 ]
 

--- a/ingestion/functions/parsing/india/sample_data.csv
+++ b/ingestion/functions/parsing/india/sample_data.csv
@@ -1,3 +1,3 @@
 Entry_ID,State Patient Number,Date Announced,Age Bracket,Gender,Detected City,Detected District,Detected State,State code,Num Cases,Current Status,Contracted from which Patient (Suspected),Notes,Source_1,Source_2,Source_3,Nationality,Type of transmission,Status Change Date,Patient Number
-297634,,22/09/2020,6 Months,M,,Balasore,Odisha,OR,1,Deceased,,"was also suffering from Diabetes, hypertension.",https://twitter.com/HFWOdisha/status/1308286422281977856,,,Bengladeshi,,,
+297634,OR-A-123,22/09/2020,6 Months,M,,Balasore,Odisha,OR,1,Deceased,,"was also suffering from Diabetes, hypertension.",https://twitter.com/HFWOdisha/status/1308286422281977856,,,Bengladeshi,,,
 297649,,22/09/2020,,,,Arwal,Bihar,BR,2,Hospitalized,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,

--- a/ingestion/functions/parsing/india/sample_data.csv
+++ b/ingestion/functions/parsing/india/sample_data.csv
@@ -1,3 +1,4 @@
 Entry_ID,State Patient Number,Date Announced,Age Bracket,Gender,Detected City,Detected District,Detected State,State code,Num Cases,Current Status,Contracted from which Patient (Suspected),Notes,Source_1,Source_2,Source_3,Nationality,Type of transmission,Status Change Date,Patient Number
 297634,OR-A-123,22/09/2020,6 Months,M,,Balasore,Odisha,OR,1,Deceased,,"was also suffering from Diabetes, hypertension.",https://twitter.com/HFWOdisha/status/1308286422281977856,,,Bengladeshi,,,
 297649,,22/09/2020,,,,Arwal,Bihar,BR,2,Hospitalized,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,
+297649,,22/09/2020,,,,Arwal,Bihar,BR,2,Recovered,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,


### PR DESCRIPTION
Backfilling this data, I noticed that the vast majority isn't actually able to be disaggregated into our platform. While I'd previously assumed the patientNumber/entryID represented a unique case/report, that isn't true for the "bulk" data they include. We should/must avoid such cases (which are represented as rows with >1 numCases) for two reasons:

- Rows with >1 numCases don't contain demographic information (merely location/count). Which is a bummer, though not a deal breaker, however:
- They don't always represent new data; for instance, a state might publish the amount of currently hospitalized patients

AFAICT, for rows with numCases == 1 we can be sure:

- For cases that receive updates, a state patient number is used, which we can use ourselves to dedupe
- Rows without state patient numbers aren't updated

The second point is my best guess based on casually browsing the data. We could be totally sure by _only_ taking data with state patient numbers, but it'd further reduce the amount of usable data from India. @Mougk and @outbreakprepared for thoughts there.