### PR TITLE
Landing page: box height fixed to be flexible

### DIFF
--- a/verification/curator-service/ui/src/components/LandingPage.tsx
+++ b/verification/curator-service/ui/src/components/LandingPage.tsx
@@ -7,7 +7,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(() => ({
     paper: {
-        height: '440px',
+        height: 'auto',
         left: '50%',
         maxWidth: '100%',
         padding: '45px',


### PR DESCRIPTION
Resolves #1248 — logos overlapping with content box because box height is fixed and not flexible.