### PR TITLE
add catch for if location code not in dictionaries

### DIFF
--- a/ingestion/functions/parsing/mexico/input_event.json
+++ b/ingestion/functions/parsing/mexico/input_event.json
@@ -1,7 +1,7 @@
 {
     "env": "local",
     "s3Bucket": "epid-sources-raw",
-    "s3Key": "5f59e8c47ef66004bc9c91ce/2020/09/10/0855/content.csv",
+    "s3Key": "5f77335466b1ce0028f328b1/2020/10/02/1410/content.csv",
     "sourceUrl": "http://datosabiertos.salud.gob.mx/gobmx/salud/datos_abiertos/datos_abiertos_covid19.zip",
-    "sourceId": "5f59e8c47ef66004bc9c91ce"
+    "sourceId": "5f77335466b1ce0028f328b1"
 }

--- a/ingestion/functions/parsing/mexico/mexico.py
+++ b/ingestion/functions/parsing/mexico/mexico.py
@@ -32,15 +32,16 @@ _MUNICIPALITIES = maps["municipalities"]
 
 def convert_location(state_code: str, municipality_code: str):
     """
-    Codes beginning with 9 denote missing information
+    Convert state and municipality codes into location query.
     """
     query_list = []
-    if municipality_code[0] != "9":
+    missing_value_prefix = "9"
+    if municipality_code[0] != missing_value_prefix:
         try:
             query_list.append(_MUNICIPALITIES[state_code + municipality_code])
         except KeyError:
             print(f"Municipality code missing: {municipality_code}")
-    if state_code[0] != "9":
+    if state_code[0] != missing_value_prefix:
         try:
             query_list.append(_STATES[state_code])
         except KeyError:

--- a/ingestion/functions/parsing/mexico/mexico.py
+++ b/ingestion/functions/parsing/mexico/mexico.py
@@ -45,7 +45,7 @@ def convert_location(state_code: str, municipality_code: str):
             query_list.append(_STATES[state_code])
         except KeyError:
             print(f"State Code Missing: {state_code}")
-    query_string = ", ".join(query_list + ["MEXICO"])
+    query_string = ", ".join(query_list + ["MÉXICO"])
     return {"query": query_string}
 
 

--- a/ingestion/functions/parsing/mexico/mexico.py
+++ b/ingestion/functions/parsing/mexico/mexico.py
@@ -35,14 +35,17 @@ def convert_location(state_code: str, municipality_code: str):
     Codes beginning with 9 denote missing information
     """
     query_list = []
-    if (
-        municipality_code[0] != "9"
-        and (state_code + municipality_code) in _MUNICIPALITIES.keys()
-    ):
-        query_list.append(_MUNICIPALITIES[state_code + municipality_code])
-    if state_code[0] != "9" and state_code in _STATES.keys():
-        query_list.append(_STATES[state_code])
-    query_string = ", ".join(query_list + ["MÉXICO"])
+    if municipality_code[0] != "9":
+        try:
+            query_list.append(_MUNICIPALITIES[state_code + municipality_code])
+        except KeyError:
+            print(f"Municipality code missing: {municipality_code}")
+    if state_code[0] != "9":
+        try:
+            query_list.append(_STATES[state_code])
+        except KeyError:
+            print(f"State Code Missing: {state_code}")
+    query_string = ", ".join(query_list + ["MEXICO"])
     return {"query": query_string}
 
 
@@ -114,9 +117,9 @@ def convert_demographics(gender: str, age: str, nationality: str, national_origi
     if age:
         demo["ageRange"] = {"start": float(age), "end": float(age)}
     if nationality == "1":
-        demo["nationalities"] = "Mexican"
+        demo["nationalities"] = ["Mexican"]
     elif nationality == "2":
-        demo["nationalities"] = national_origin
+        demo["nationalities"] = [national_origin]
     return demo or None
 
 
@@ -199,7 +202,7 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                     case["notes"] = notes
                 yield case
             except ValueError as ve:
-                raise ValueError("Unhandled data: {}".format(ve))
+                raise ValueError(f"Unhandled data: {ve}")
 
 
 def lambda_handler(event, context):

--- a/ingestion/functions/parsing/mexico/mexico.py
+++ b/ingestion/functions/parsing/mexico/mexico.py
@@ -18,14 +18,16 @@ except ImportError:
     import parsing_lib
 
 
-with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "dictionaries.json")) as json_file:
+with open(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "dictionaries.json")
+) as json_file:
     maps = json.load(json_file)
 
-_COMORBIDITIES_DICT = maps['comorbidities']
+_COMORBIDITIES_DICT = maps["comorbidities"]
 
-_STATES = maps['states']
+_STATES = maps["states"]
 
-_MUNICIPALITIES = maps['municipalities']
+_MUNICIPALITIES = maps["municipalities"]
 
 
 def convert_location(state_code: str, municipality_code: str):
@@ -33,11 +35,14 @@ def convert_location(state_code: str, municipality_code: str):
     Codes beginning with 9 denote missing information
     """
     query_list = []
-    if state_code[0] != "9":
-        query_list.append(_STATES[state_code])
-    if municipality_code[0] != "9":
+    if (
+        municipality_code[0] != "9"
+        and (state_code + municipality_code) in _MUNICIPALITIES.keys()
+    ):
         query_list.append(_MUNICIPALITIES[state_code + municipality_code])
-    query_string = ", ".join(query_list + ["MEXICO"])
+    if state_code[0] != "9" and state_code in _STATES.keys():
+        query_list.append(_STATES[state_code])
+    query_string = ", ".join(query_list + ["MÉXICO"])
     return {"query": query_string}
 
 

--- a/ingestion/functions/parsing/mexico/mexico_test.py
+++ b/ingestion/functions/parsing/mexico/mexico_test.py
@@ -27,7 +27,7 @@ _PARSED_CASE = {
     "demographics": {
         "gender": "Male",
         "ageRange": {"start": 56.0, "end": 56.0},
-        "nationalities": "Mexican",
+        "nationalities": ["Mexican"],
     },
     "preexistingConditions": {"values": ["obesity"]},
     "notes": "Smoker",

--- a/ingestion/functions/parsing/mexico/mexico_test.py
+++ b/ingestion/functions/parsing/mexico/mexico_test.py
@@ -7,7 +7,7 @@ _SOURCE_ID = "abc123"
 _SOURCE_URL = "https://mex.ico"
 _PARSED_CASE = {
     "caseReference": {"sourceId": "abc123", "sourceUrl": "https://mex.ico"},
-    "location": {"query": "MÉXICO, ATIZAPÁN DE ZARAGOZA, MEXICO"},
+    "location": {'query': 'ATIZAPÁN DE ZARAGOZA, MÉXICO, MÉXICO'},
     "events": [
         {
             "name": "confirmed",

--- a/ingestion/functions/retrieval/valid_scheduled_event.json
+++ b/ingestion/functions/retrieval/valid_scheduled_event.json
@@ -1,4 +1,8 @@
 {
     "env": "local",
-    "sourceId": "5f77335466b1ce0028f328b1"
+    "sourceId": "5f77335466b1ce0028f328b1",
+    "parsingDateRange": {
+        "start": "2020-09-01",
+        "end": "2020-09-21"
+    }
 }

--- a/ingestion/functions/retrieval/valid_scheduled_event.json
+++ b/ingestion/functions/retrieval/valid_scheduled_event.json
@@ -1,8 +1,4 @@
 {
     "env": "local",
-    "sourceId": "5f7337434ae4d50028bb34e0",
-    "parsingDateRange": {
-        "start": "2020-09-01",
-        "end": "2020-09-21"
-    }
+    "sourceId": "5f77335466b1ce0028f328b1"
 }


### PR DESCRIPTION
Now if a location code doesn't exist in the dictionary, the query string will simply contain 'MÉXICO'

I also changed the order of the query string to more closely match the way addressed are actually used in the country.