### PR TITLE
Handle a number of remaining edge cases in India's data set

### DIFF
--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -63,12 +63,27 @@ def convert_demographics(row):
 
     if row["Age Bracket"]:
         raw = row["Age Bracket"]
-        age = float(raw.split(" ", 1)[
-                    0]) / 12 if " months" in raw.lower() else float(row["Age Bracket"])
-        demo["ageRange"] = {
-            "start": age,
-            "end": age
-        }
+        # Handle ranges, e.g. "28-35"
+        if "-" in raw:
+            parts = raw.split("-", 1)
+            demo["ageRange"] = {
+                "start": float(parts[0]),
+                "end": float(parts[1])
+            }
+        # Handle months, e.g. "6 months"
+        elif " months" in raw.lower():
+            age = float(raw.split(" ", 1)[0]) / 12
+            demo["ageRange"] = {
+                "start": age,
+                "end": age
+            }
+        # Handle standard ages
+        else:
+            age = float(raw)
+            demo["ageRange"] = {
+                "start": age,
+                "end": age
+            }
     if row["Gender"]:
         demo["gender"] = convert_gender(row["Gender"])
     if row["Nationality"]:

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -114,7 +114,7 @@ def update_for_outcome(row, case):
             },
             "value": "Yes"
         })
-    if row["Current Status"] == "Recovered":
+    elif row["Current Status"] == "Recovered":
         case["events"].append({
             "name": "outcome",
             "dateRange":

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -85,6 +85,16 @@ def convert_sources(row):
 
 
 def update_for_outcome(row, case):
+    if row["Current Status"] == "Hospitalized":
+        case["events"].append({
+            "name": "hospitalAdmission",
+            "dateRange":
+            {
+                "start": convert_date(row["Date Announced"]),
+                "end": convert_date(row["Date Announced"])
+            },
+            "value": "Yes"
+        })
     if row["Current Status"] == "Recovered":
         case["events"].append({
             "name": "outcome",
@@ -105,36 +115,6 @@ def update_for_outcome(row, case):
             },
             "value": "Death"
         })
-
-
-def populate_relevant_confirmations(row):
-    """
-    Populates a confirmed event (and hospitalization), if required.
-
-    Only cases with a status of Hospitalized represent a report of case
-    confirmation. Other reported statuses (e.g. Recovered) represent an
-    outcome event on a case that should already exist.
-    """
-    events = []
-    if row["Current Status"] == "Hospitalized":
-        events.append({
-            "name": "confirmed",
-            "dateRange":
-            {
-                "start": convert_date(row["Date Announced"]),
-                "end": convert_date(row["Date Announced"])
-            }
-        })
-        events.append({
-            "name": "hospitalAdmission",
-            "dateRange":
-            {
-                "start": convert_date(row["Date Announced"]),
-                "end": convert_date(row["Date Announced"])
-            },
-            "value": "Yes"
-        })
-    return events
 
 
 def parse_cases(raw_data_file: str, source_id: str, source_url: str):
@@ -172,7 +152,16 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                     "additionalSources": convert_sources(row)
                 },
                 "location": convert_location(row),
-                "events": populate_relevant_confirmations(row),
+                "events": [
+                    {
+                        "name": "confirmed",
+                        "dateRange":
+                            {
+                                "start": convert_date(row["Date Announced"]),
+                                "end": convert_date(row["Date Announced"])
+                            }
+                    }
+                ],
                 "demographics": convert_demographics(row),
                 "notes": row["Notes"] or None
             }

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -78,9 +78,13 @@ def convert_demographics(row):
 
 
 def convert_sources(row):
+    # Sources must be unique, per our case schema.
+    included = set()
     additionalSources = [{"sourceUrl": row[col]}
                          for col in ["Source_1", "Source_2", "Source_3"]
-                         if row[col]]
+                         if row[col] and
+                         row[col] not in included and not included.add(
+                             row[col])]
     return additionalSources or None
 
 

--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -86,7 +86,12 @@ _PARSED_CASES = [
                 "value": "Yes"
             }
         ],
-        "demographics": None,
+        "demographics": {
+            "ageRange": {
+                "start": 28,
+                "end": 35
+            }
+        },
         "notes": None
     },
     {
@@ -123,7 +128,12 @@ _PARSED_CASES = [
                 "value": "Yes"
             }
         ],
-        "demographics": None,
+        "demographics": {
+            "ageRange": {
+                "start": 28,
+                "end": 35
+            }
+        },
         "notes": None
     },
 ]

--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -23,6 +23,14 @@ _PARSED_CASES = [
         },
         "events": [
             {
+                "name": "confirmed",
+                "dateRange":
+                        {
+                            "start": "09/22/2020Z",
+                            "end": "09/22/2020Z"
+                        }
+            },
+            {
                 "name": "outcome",
                 "dateRange":
                 {

--- a/ingestion/functions/parsing/india/sample_data.csv
+++ b/ingestion/functions/parsing/india/sample_data.csv
@@ -1,4 +1,4 @@
 Entry_ID,State Patient Number,Date Announced,Age Bracket,Gender,Detected City,Detected District,Detected State,State code,Num Cases,Current Status,Contracted from which Patient (Suspected),Notes,Source_1,Source_2,Source_3,Nationality,Type of transmission,Status Change Date,Patient Number
 297634,OR-A-123,22/09/2020,6 Months,M,,Balasore,Odisha,OR,1,Deceased,,"was also suffering from Diabetes, hypertension.",https://twitter.com/HFWOdisha/status/1308286422281977856,https://twitter.com/HFWOdisha/status/1308286422281977856,,Bengladeshi,,,
-297649,,22/09/2020,,,,Arwal,Bihar,BR,2,Hospitalized,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,
+297649,,22/09/2020,28-35,,,Arwal,Bihar,BR,2,Hospitalized,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,
 297649,,22/09/2020,,,,Arwal,Bihar,BR,2,Recovered,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,

--- a/ingestion/functions/parsing/india/sample_data.csv
+++ b/ingestion/functions/parsing/india/sample_data.csv
@@ -1,4 +1,4 @@
 Entry_ID,State Patient Number,Date Announced,Age Bracket,Gender,Detected City,Detected District,Detected State,State code,Num Cases,Current Status,Contracted from which Patient (Suspected),Notes,Source_1,Source_2,Source_3,Nationality,Type of transmission,Status Change Date,Patient Number
-297634,OR-A-123,22/09/2020,6 Months,M,,Balasore,Odisha,OR,1,Deceased,,"was also suffering from Diabetes, hypertension.",https://twitter.com/HFWOdisha/status/1308286422281977856,,,Bengladeshi,,,
+297634,OR-A-123,22/09/2020,6 Months,M,,Balasore,Odisha,OR,1,Deceased,,"was also suffering from Diabetes, hypertension.",https://twitter.com/HFWOdisha/status/1308286422281977856,https://twitter.com/HFWOdisha/status/1308286422281977856,,Bengladeshi,,,
 297649,,22/09/2020,,,,Arwal,Bihar,BR,2,Hospitalized,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,
 297649,,22/09/2020,,,,Arwal,Bihar,BR,2,Recovered,,,https://twitter.com/PIB_Patna/status/1308375952653611008,,,,,,


### PR DESCRIPTION
Some of the early CSV data is pretty loosely formatted. This cleans up a couple odds-and-ends, and allows the first set (`raw_data1.csv`) to be ingested without error. Each commit title tl;dr's the issue being addressed, but to expand slightly:

- I'd cleverly thought to avoid conflating an updated case's initial confirmation date with the date on which an outcome is reported by omitting a `confirmed` event for updates. As it turns out, this won't work because the presence of a `confirmed` event is required, and despite `events` being an array, we're rewriting (rather than appending to) the array with batchUpsert.
- Our schema specifies that additional sources must be unique. Which makes sense, but for whatever reason some rows have duplicate sources listed within them.
- A few rows have age ranges listed.