### PR TITLE
Avoid filling in unprovided date filters or ranges

### DIFF
--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -66,7 +66,7 @@ def extract_event_fields(event: Dict):
         e = ValueError(error_message)
         common_lib.complete_with_error(e)
     return event[ENV_FIELD], event[SOURCE_URL_FIELD], event[SOURCE_ID_FIELD], event.get(UPLOAD_ID_FIELD), event[
-        S3_BUCKET_FIELD], event[S3_KEY_FIELD], event.get(DATE_FILTER_FIELD, {}), event.get(DATE_RANGE_FIELD, {}), event.get(AUTH_FIELD, None)
+        S3_BUCKET_FIELD], event[S3_KEY_FIELD], event.get(DATE_FILTER_FIELD, None), event.get(DATE_RANGE_FIELD, None), event.get(AUTH_FIELD, None)
 
 
 def retrieve_raw_data_file(s3_bucket: str, s3_key: str, out_file):

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -234,7 +234,7 @@ def test_extract_event_fields_returns_all_present_fields(input_event):
         input_event[parsing_lib.UPLOAD_ID_FIELD],
         input_event[parsing_lib.S3_BUCKET_FIELD],
         input_event[parsing_lib.S3_KEY_FIELD],
-        {},  # Date filter isn't provided, per the following test case.
+        None,  # Date filter isn't provided, per the following test case.
         input_event[parsing_lib.DATE_RANGE_FIELD],
         input_event[parsing_lib.AUTH_FIELD])
 


### PR DESCRIPTION
Fixes issue reported on #1315.

Looking at the latest failure, on log stream 2020/10/19/[$LATEST]4a51da6751da47a59c77810aad2af821:

```python
{'env': 'prod', 's3Bucket': 'epid-sources-raw', 'sourceId': '5f7716e4e78c686408f6743e', 's3Key': '5f7716e4e78c686408f6743e/2020/10/19/1205/content.csv', 'sourceUrl': 'https://drive.google.com/uc?export=download&id=16JBgPV2Px93iD_NbuDo13b3ye4KGxlcW', 'uploadId': '5f8d8104b5daec3b1f5d2670', 'dateFilter': {'numDaysBeforeToday': 3, 'op': 'EQ'}, 'dateRange': None}
```

The problem was that if the CloudWatch event doesn't pass `dateRange` (because it specified a filter instead), the lib uses an empty dict. Then `filter_cases_by_date` tests whether that empty dict is not `None` (it isn't), and if it isn't it destructures it: boom.

Here I leave either of these fields as `None` if they're left out of the CloudWatch event.