### PR TITLE
increase Mexico parser memory allocation

### DIFF
--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -238,6 +238,7 @@ Resources:
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSLambdaReadOnlyAccess
+      MemorySize: 1024
       Layers:
         - !Ref ParsingLibLayer
   ArgentinaParsingFunction:


### PR DESCRIPTION
Parser is running out of memory, hopefully this should do the trick.