### PR TITLE
Allow both date filter and date range, only using range

### DIFF
--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -59,12 +59,6 @@ def extract_event_fields(event: Dict):
             f"{SOURCE_ID_FIELD}; {S3_KEY_FIELD} not found in input event json.")
         e = ValueError(error_message)
         common_lib.complete_with_error(e)
-    if event.get(DATE_FILTER_FIELD) and event.get(DATE_RANGE_FIELD):
-        error_message = (
-            f"At most one of fields {DATE_FILTER_FIELD} and {DATE_RANGE_FIELD} can be provided."
-        )
-        e = ValueError(error_message)
-        common_lib.complete_with_error(e)
     return event[ENV_FIELD], event[SOURCE_URL_FIELD], event[SOURCE_ID_FIELD], event.get(UPLOAD_ID_FIELD), event[
         S3_BUCKET_FIELD], event[S3_KEY_FIELD], event.get(DATE_FILTER_FIELD, None), event.get(DATE_RANGE_FIELD, None), event.get(AUTH_FIELD, None)
 
@@ -189,6 +183,9 @@ def filter_cases_by_date(
     If a date_range is provided, returns only cases within the specified start
     and end bounds (inclusive). Else if date_filter is provided, returns the
     cases within that specification. Else, returns all cases.
+
+    Notice that if _both_ date_range and date_filter are provided, then date_range is used
+    and date_filter is ignored.
     """
     if date_range:
         print(f'Filtering cases using date range {date_range}')

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -234,20 +234,9 @@ def test_extract_event_fields_returns_all_present_fields(input_event):
         input_event[parsing_lib.UPLOAD_ID_FIELD],
         input_event[parsing_lib.S3_BUCKET_FIELD],
         input_event[parsing_lib.S3_KEY_FIELD],
-        None,  # Date filter isn't provided, per the following test case.
+        None,
         input_event[parsing_lib.DATE_RANGE_FIELD],
         input_event[parsing_lib.AUTH_FIELD])
-
-
-def test_extract_event_fields_errors_if_date_filter_and_range_provided(
-        input_event):
-    from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
-    with pytest.raises(ValueError, match=parsing_lib.DATE_FILTER_FIELD):
-        input_event[parsing_lib.DATE_FILTER_FIELD] = {
-            "numDaysBeforeToday": 3,
-            "op": "LT"
-        }
-        parsing_lib.extract_event_fields(input_event)
 
 
 def test_extract_event_fields_errors_if_missing_bucket_field(input_event):


### PR DESCRIPTION
@z023 reported that backfill hasn't worked since Oct 2. What I found is that when you request a backfill, you set the date range on the retrieval request (which is fed through to the parser). The parser lib loads the definition for the source, _including its date filter_. But this means that the parser lib tries to use _both_ the range and the filter when limiting the dates of cases, and boom. Backfill always errors.

I could have fixed this by removing the filter if the range is specified, but instead I chose to relax the "one or the other" assumption and instead document that the range always trumps the filter. That's because the range has always been explicitly requested by the user for this specific event, so should always be treated as deliberate.