### PR TITLE
Add a test case where additional sources need to be made unique

### DIFF
--- a/ingestion/functions/parsing/japan/japan.py
+++ b/ingestion/functions/parsing/japan/japan.py
@@ -4,6 +4,7 @@ import sys
 from datetime import datetime
 from typing import Dict
 
+
 # Layer code, like parsing_lib, is added to the path by AWS.
 # To test locally (e.g. via pytest), we have to modify sys.path.
 # pylint: disable=import-error
@@ -68,8 +69,12 @@ def convert_additional_sources(additional_source_url: Dict):
         sources.append({"sourceUrl": additional_source_url["sourceURL"]})
     if "deathSourceURL" in additional_source_url:
         sources.append({"sourceUrl": additional_source_url["deathSourceURL"]})
+    if "citySourceURL" in additional_source_url:
+        sources.append({"sourceUrl": additional_source_url["citySourceURL"]})
+    if "prefectureSourceURL" in additional_source_url:
+        sources.append({"sourceUrl": additional_source_url["prefectureSourceURL"]})
     # Ensure only unique entries in additional sources
-    return list({v["sourceUrl"]:v for v in sources}.values()) or None
+    return list({v["sourceUrl"]: v for v in sources}.values()) or None
 
 
 def convert_outcome(raw_outcome: Dict, raw_death_date: Dict):

--- a/ingestion/functions/parsing/japan/japan_test.py
+++ b/ingestion/functions/parsing/japan/japan_test.py
@@ -2,11 +2,13 @@ import json
 import os
 import pytest
 import tempfile
+import unittest
+from japan import japan
 
 
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "https://foo.bar"
-_PARSED_CASE = (
+_PARSED_CASES = [
     {
         "caseReference": {
             "sourceId": _SOURCE_ID,
@@ -15,6 +17,9 @@ _PARSED_CASE = (
             "additionalSources": [
                 {
                     "sourceUrl": "https://www3.nhk.or.jp/news/html/20200313/k10012329851000.html"
+                },
+                {
+                    "sourceUrl": "http://www.pref.hokkaido.lg.jp/file.jsp?id=1279351"
                 }
             ]
         },
@@ -43,23 +48,64 @@ _PARSED_CASE = (
             "gender": "Female"
         },
         "notes": None
-    })
+    },
+    # Add a case with non-unique additional sources
+    {
+        "caseReference": {
+            "sourceId": _SOURCE_ID,
+            "sourceEntryId": "1201",
+            "sourceUrl": _SOURCE_URL,
+            "additionalSources": [
+                {
+                    "sourceUrl": "https://www3.nhk.or.jp/news/html/20200323/k10012345631000.html"
+                },
+                {
+                    "sourceUrl": "https://www.city.okazaki.lg.jp/houdou/p025977.html"
+                },
+                {
+                    "sourceUrl": "https://www.pref.aichi.jp/site/covid19-aichi/pressrelease-ncov200323.html"
+                }
+            ]
+        },
+        "location": {
+            "query": "Okazaki, Aichi, Japan"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange":
+                        {
+                            "start": "03/23/2020Z",
+                            "end": "03/23/2020Z"
+                        }
+            },
+            {
+                "name": "outcome",
+                "dateRange":
+                        {
+                            "start": "03/23/2020Z",
+                            "end": "03/23/2020Z"
+                        },
+                "value": "Death"
+            }
+        ],
+        "demographics": {
+            "ageRange": {
+                "start": 80,
+                "end": 89
+            },
+            "gender": "Male"
+        },
+        "notes": None
+    }
+]
 
 
-@pytest.fixture()
-def sample_data():
-    """Loads sample source data from file."""
-    current_dir = os.path.dirname(__file__)
-    file_path = os.path.join(current_dir, "sample_data.json")
-    with open(file_path) as event_file:
-        return json.load(event_file)
+class JapanTest(unittest.TestCase):
+    def test_parse(self):
+        self.maxDiff = 5000
+        current_dir = os.path.dirname(__file__)
+        sample_data_file = os.path.join(current_dir, "sample_data.json")
 
-
-def test_parse_cases_converts_fields_to_ghdsi_schema(sample_data):
-    from japan import japan  # Import locally to avoid superseding mock
-    with tempfile.NamedTemporaryFile("w") as f:
-        json.dump(sample_data, f)
-        f.flush()
-
-        result = next(japan.parse_cases(f.name, _SOURCE_ID, _SOURCE_URL))
-        assert result == _PARSED_CASE
+        result = japan.parse_cases(sample_data_file, _SOURCE_ID, _SOURCE_URL)
+        self.assertCountEqual(list(result), _PARSED_CASES)

--- a/ingestion/functions/parsing/japan/sample_data.json
+++ b/ingestion/functions/parsing/japan/sample_data.json
@@ -14,5 +14,23 @@
 	    "prefectureSourceURL": "http://www.pref.hokkaido.lg.jp/file.jsp?id=1279351",
 	    "sourceURL": "https://www3.nhk.or.jp/news/html/20200313/k10012329851000.html",
 	    "confirmedPatient": true
-	}
+	},
+	{
+    	"patientId": "1201",
+        "dateAnnounced": "2020-03-23",
+        "ageBracket": 80,
+        "gender": "M",
+        "residence": "Okazaki",
+        "detectedCityTown": "Okazaki",
+    	"detectedPrefecture": "Aichi",
+        "patientStatus": "Deceased",
+        "prefecturePatientNumber": "Aichi#144",
+        "cityPrefectureNumber": "Okazaki#3",
+        "prefectureSourceURL": "https://www.pref.aichi.jp/site/covid19-aichi/pressrelease-ncov200323.html",
+        "citySourceURL": "https://www.city.okazaki.lg.jp/houdou/p025977.html",
+        "deathSourceURL": "https://www3.nhk.or.jp/news/html/20200323/k10012345631000.html",
+        "deceasedDate": "2020-03-23",
+        "sourceURL": "https://www3.nhk.or.jp/news/html/20200323/k10012345631000.html",
+        "confirmedPatient": true
+    }
 ]


### PR DESCRIPTION
Added a test case where uniqueness of additional sources has to be enforced by the parser. Also updated unit test format to match what is being used in the newer parsers. 