### PR TITLE
Changes to parser to deal with port quarantine cases

### DIFF
--- a/ingestion/functions/parsing/japan/japan.py
+++ b/ingestion/functions/parsing/japan/japan.py
@@ -37,13 +37,16 @@ def convert_age(raw_age):
 
 
 def convert_location(raw_entry):
-    query_terms = [
-        term for term in [
-            raw_entry.get("detectedCityTown", ""),
-            raw_entry.get("detectedPrefecture", ""),
-            "Japan"]
-        if term and term != "Unspecified"]
-    return {"query": ", ".join(query_terms)}
+    if raw_entry["detectedPrefecture"] == "Port Quarantine":
+        return {"query": "Japan"}
+    else:
+        query_terms = [
+            term for term in [
+                raw_entry.get("detectedCityTown", ""),
+                raw_entry.get("detectedPrefecture", ""),
+                "Japan"]
+            if term and term != "Unspecified"]
+        return {"query": ", ".join(query_terms)}
 
 
 def detect_notes(raw_notes):

--- a/ingestion/functions/parsing/japan/japan_test.py
+++ b/ingestion/functions/parsing/japan/japan_test.py
@@ -97,6 +97,47 @@ _PARSED_CASES = [
             "gender": "Male"
         },
         "notes": None
+    },
+    # Add a case from port quarantine
+    {
+        "caseReference": {
+            "sourceId": _SOURCE_ID,
+            "sourceEntryId": "468",
+            "sourceUrl": _SOURCE_URL,
+            "additionalSources": [
+                {
+                    "sourceUrl": "https://www.pref.kanagawa.jp/osirase/1369/"
+                },
+                {
+                    "sourceUrl": "https://www.pref.kanagawa.jp/docs/ga4/bukanshi/occurrence.html"
+                }
+            ]
+        },
+        "location": {
+            "query": "Japan"
+        },
+        "events": [
+            {
+                "name": "confirmed",
+                "dateRange":
+                        {
+                            "start": "02/11/2020Z",
+                            "end": "02/11/2020Z"
+                        }
+            },
+            {
+                "name": "outcome",
+                "value": "Unknown"
+            }
+        ],
+        "demographics": {
+            "ageRange": {
+                "start": 50,
+                "end": 59
+            },
+            "gender": "Male"
+        },
+        "notes": "Quarantine officer on Cruise ship (Kanagawa patient #2)"
     }
 ]
 

--- a/ingestion/functions/parsing/japan/sample_data.json
+++ b/ingestion/functions/parsing/japan/sample_data.json
@@ -32,5 +32,19 @@
         "deceasedDate": "2020-03-23",
         "sourceURL": "https://www3.nhk.or.jp/news/html/20200323/k10012345631000.html",
         "confirmedPatient": true
+    },
+    {
+	    "patientId": "468",
+	    "dateAnnounced": "2020-02-11",
+	    "ageBracket": 50,
+	    "gender": "M",
+	    "residence": "Kanagawa",
+	    "detectedPrefecture": "Port Quarantine",
+	    "notes": "Quarantine officer on Cruise ship (Kanagawa patient #2)",
+	    "knownCluster": "Cruise Quarantine Officer",
+	    "prefecturePatientNumber": "Kanagawa#2",
+	    "prefectureSourceURL": "https://www.pref.kanagawa.jp/docs/ga4/bukanshi/occurrence.html",
+	    "sourceURL": "https://www.pref.kanagawa.jp/osirase/1369/",
+	    "confirmedPatient": true
     }
 ]


### PR DESCRIPTION
I realize this is quite a crude fix so please let me know if there is a better way. 
In the absence of knowing exactly how the geocoding works I am also not 100% sure this will return the country Japan and not the neighbourhood in Indonesia called Japan, but `query: country` seems to have worked in the case of Argentina. 
Closes #1345 