### PR TITLE
[#1006] Current page number & page size should be persisted while moving between case details and list view

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -336,4 +336,29 @@ describe('Linelist table', function () {
         cy.contains('Germany');
         cy.contains('United Kingdom');
     });
+
+    it('Pagination settings stays the same after returning from details modal', function () {
+        for (let i = 0; i < 7; i++) {
+            cy.addCase({
+                country: 'France',
+                notes: 'some notes',
+                sourceUrl: 'foo.bar',
+            });
+        }
+        cy.server();
+        cy.route('GET', '/api/cases/*').as('getCases');
+        cy.visit('/cases');
+        cy.wait('@getCases');
+        cy.contains('rows').click();
+        cy.route('GET', '/api/cases/?limit=5&page=1').as('getFirstPage');
+        cy.get('li').contains('5').click();
+        cy.wait('@getFirstPage');
+
+        cy.contains('chevron_right').click();
+        cy.contains('td', 'France').first().click({ force: true });
+        cy.get('button[aria-label="close overlay"').click();
+
+        cy.contains('6-7 of 7').should('exist');
+        cy.contains('5 rows').should('exist');
+    });
 });

--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -317,6 +317,8 @@ export default function App(): JSX.Element {
         setCreateNewButtonAnchorEl,
     ] = useState<Element | null>();
     const [selectedMenuIndex, setSelectedMenuIndex] = React.useState<number>();
+    const [listPage, setListPage] = React.useState<number>(0);
+    const [listPageSize, setListPageSize] = React.useState<number>(50);
     const lastLocation = useLastLocation();
     const history = useHistory();
     const location = useLocation<LocationState>();
@@ -615,6 +617,10 @@ export default function App(): JSX.Element {
                                 <LinelistTable
                                     user={user}
                                     setSearchLoading={setSearchLoading}
+                                    page={listPage}
+                                    pageSize={listPageSize}
+                                    onChangePage={setListPage}
+                                    onChangePageSize={setListPageSize}
                                 />
                             </Route>
                         )}

--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -1,11 +1,12 @@
 import '@testing-library/jest-dom/extend-expect';
 
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, wait } from '@testing-library/react';
 
 import LinelistTable from './LinelistTable';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Router } from 'react-router-dom';
 import React from 'react';
 import axios from 'axios';
+import range from 'lodash/range';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -94,6 +95,10 @@ it('loads and displays cases', async () => {
                 user={curator}
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 setSearchLoading={(x: boolean): void => {}}
+                page={0}
+                pageSize={50}
+                onChangePage={jest.fn()}
+                onChangePageSize={jest.fn()}
             />
         </MemoryRouter>,
     );
@@ -155,6 +160,10 @@ it('API errors are displayed', async () => {
                 user={curator}
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 setSearchLoading={(x: boolean): void => {}}
+                page={0}
+                pageSize={50}
+                onChangePage={jest.fn()}
+                onChangePageSize={jest.fn()}
             />
         </MemoryRouter>,
     );
@@ -219,6 +228,10 @@ it('can delete a row', async () => {
                 user={curator}
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 setSearchLoading={(x: boolean): void => {}}
+                page={0}
+                pageSize={50}
+                onChangePage={jest.fn()}
+                onChangePageSize={jest.fn()}
             />
         </MemoryRouter>,
     );
@@ -309,6 +322,10 @@ it('can cancel delete action', async () => {
                 user={curator}
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 setSearchLoading={(x: boolean): void => {}}
+                page={0}
+                pageSize={50}
+                onChangePage={jest.fn()}
+                onChangePageSize={jest.fn()}
             />
         </MemoryRouter>,
     );
@@ -379,6 +396,10 @@ it('cannot edit data if not curator', async () => {
                 }}
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 setSearchLoading={(x: boolean): void => {}}
+                page={0}
+                pageSize={50}
+                onChangePage={jest.fn()}
+                onChangePageSize={jest.fn()}
             />
         </MemoryRouter>,
     );
@@ -388,4 +409,147 @@ it('cannot edit data if not curator', async () => {
     expect(row).toBeInTheDocument();
 
     expect(queryByTestId(/row menu/)).not.toBeInTheDocument();
+});
+
+it('initializes with correct page and page size values', async () => {
+    const sampleCase = {
+        _id: 'abc123',
+        caseReference: {
+            sourceId: 'CDC',
+            sourceUrl: 'www.example.com',
+        },
+        importedCase: {
+            outcome: 'Recovered',
+        },
+        location: {
+            country: 'France',
+            geoResolution: 'Country',
+        },
+        events: [
+            {
+                name: 'confirmed',
+                dateRange: {
+                    start: new Date().toJSON(),
+                },
+            },
+        ],
+        notes: 'some notes',
+    };
+
+    // generate 20 cases for pagination purposes
+    const cases = range(20).map(() => sampleCase);
+
+    const axiosResponse = {
+        data: {
+            cases: cases,
+            total: cases.length,
+        },
+        status: 200,
+        statusText: 'OK',
+        config: {},
+        headers: {},
+    };
+    mockedAxios.get.mockResolvedValueOnce(axiosResponse);
+
+    const { findByText, findAllByText } = render(
+        <MemoryRouter>
+            <LinelistTable
+                user={curator}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setSearchLoading={(x: boolean): void => {}}
+                page={1}
+                pageSize={10}
+                onChangePage={jest.fn()}
+                onChangePageSize={jest.fn()}
+            />
+        </MemoryRouter>,
+    );
+
+    const rowsCounter = await findAllByText('11-20 of 20');
+    const pageSizeCounter = await findByText('10 rows');
+    // there are two DOM elements showing number of elements
+    expect(rowsCounter).toHaveLength(2);
+    expect(pageSizeCounter).toBeInTheDocument();
+});
+
+it('paginates through data', async () => {
+    const sampleCase = {
+        _id: 'abc123',
+        caseReference: {
+            sourceId: 'CDC',
+            sourceUrl: 'www.example.com',
+        },
+        importedCase: {
+            outcome: 'Recovered',
+        },
+        location: {
+            country: 'France',
+            geoResolution: 'Country',
+        },
+        events: [
+            {
+                name: 'confirmed',
+                dateRange: {
+                    start: new Date().toJSON(),
+                },
+            },
+        ],
+        notes: 'some notes',
+    };
+
+    // generate 20 cases for pagination purposes
+    const cases = range(20).map(() => sampleCase);
+
+    const axiosResponse = {
+        data: {
+            cases: cases,
+            total: cases.length,
+        },
+        status: 200,
+        statusText: 'OK',
+        config: {},
+        headers: {},
+    };
+    mockedAxios.get.mockResolvedValueOnce(axiosResponse);
+
+    const changePage = jest.fn();
+    const changePageSize = jest.fn();
+
+    const { getByText, getAllByText, findAllByText } = render(
+        <MemoryRouter>
+            <LinelistTable
+                user={curator}
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setSearchLoading={(x: boolean): void => {}}
+                page={0}
+                pageSize={10}
+                onChangePage={changePage}
+                onChangePageSize={changePageSize}
+            />
+        </MemoryRouter>,
+    );
+
+    expect(await findAllByText('1-10 of 20')).toHaveLength(2);
+
+    fireEvent.click(getByText('chevron_right'));
+
+    expect(changePage).toHaveBeenCalledTimes(1);
+    expect(changePage).toHaveBeenCalledWith(1);
+
+    wait(() => {
+        expect(getAllByText('11-20 of 20')).toHaveLength(2);
+        expect(getAllByText('France')).toHaveLength(10);
+    });
+
+    fireEvent.click(getByText('10 rows'));
+
+    wait(() => {
+        fireEvent.click(getByText('5'));
+        expect(changePageSize).toHaveBeenCalledTimes(1);
+
+        expect(getAllByText('5 rows')).toBeInTheDocument();
+        expect(getAllByText('1-5 of 20')).toHaveLength(2);
+
+        expect(getAllByText('France')).toHaveLength(5);
+    });
 });

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -46,6 +46,7 @@ interface ListResponse {
 interface LinelistTableState {
     url: string;
     error: string;
+    page: number;
     pageSize: number;
     // The rows which are selected on the current page.
     selectedRowsCurrentPage: TableRow[];
@@ -78,6 +79,8 @@ interface LocationState {
     editedCaseIds: string[];
     bulkMessage: string;
     search: string;
+    page: number;
+    pageSize: number;
 }
 
 interface Props
@@ -85,6 +88,12 @@ interface Props
         WithStyles<typeof styles> {
     user: User;
     setSearchLoading: (a: boolean) => void;
+    page: number;
+    pageSize: number;
+
+    onChangePage: (page: number) => void;
+
+    onChangePageSize: (pageSize: number) => void;
 }
 
 const styles = (theme: Theme) =>
@@ -279,7 +288,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         this.state = {
             url: '/api/cases/',
             error: '',
-            pageSize: 50,
+            page: this.props.page ?? 0,
+            pageSize: this.props.pageSize ?? 50,
             selectedRowsCurrentPage: [],
             numSelectedRows: 0,
             totalNumRows: 0,
@@ -301,7 +311,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
     componentDidMount(): void {
         // history.location.state can be updated with new values on which we
         // must refresh the table
-        this.unlisten = this.props.history.listen((_, __) => {
+        this.unlisten = this.props.history.listen(({ state }, _) => {
             this.tableRef.current?.onQueryChange();
         });
     }
@@ -664,8 +674,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                     data={(query): Promise<QueryResult<TableRow>> =>
                         new Promise((resolve, reject) => {
                             let listUrl = this.state.url;
-                            listUrl += '?limit=' + this.state.pageSize;
-                            listUrl += '&page=' + (query.page + 1);
+                            listUrl += '?limit=' + query.pageSize;
+                            listUrl += '&page=' + (this.state.page + 1);
                             const trimmedQ = this.props.location.state?.search?.trim();
                             if (trimmedQ) {
                                 listUrl += '&q=' + encodeURIComponent(trimmedQ);
@@ -723,7 +733,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                     });
                                     resolve({
                                         data: flattenedCases,
-                                        page: query.page,
+                                        page: this.state.page,
                                         totalCount: result.data.total,
                                     });
                                 })
@@ -752,6 +762,33 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                     <span className={classes.spacer}></span>
                                     <TablePagination
                                         {...props}
+                                        onChangeRowsPerPage={(event): void => {
+                                            const newPage = 0;
+                                            const newPageSize = Number(
+                                                event.target.value,
+                                            );
+
+                                            this.setState({
+                                                page: newPage,
+                                                pageSize: newPageSize,
+                                            });
+
+                                            props.onChangeRowsPerPage(event);
+
+                                            this.props.onChangePage(newPage);
+                                            this.props.onChangePageSize(
+                                                newPageSize,
+                                            );
+                                        }}
+                                        onChangePage={(
+                                            event,
+                                            newPage: number,
+                                        ): void => {
+                                            this.setState({ page: newPage });
+
+                                            this.props.onChangePage(newPage);
+                                            props.onChangePage(event, newPage);
+                                        }}
                                     ></TablePagination>
                                 </div>
                             ) : (
@@ -812,10 +849,6 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             ).includes(rowData.id)
                                 ? { backgroundColor: '#F0FBF9' }
                                 : {},
-                    }}
-                    onChangeRowsPerPage={(newPageSize: number) => {
-                        this.setState({ pageSize: newPageSize });
-                        this.tableRef.current.onQueryChange();
                     }}
                     onRowClick={(_, rowData?: TableRow): void => {
                         if (rowData) {


### PR DESCRIPTION
#1006 Fix

**What:**
Now, when we move between the case details and the list view, the value doesn't change (#1006). At first, I wanted the changes to be consistent with the search (also stored in the same location object), but I've decided to do that in a more straightforward way so it could be more maintainable in the future. Now, the current page number and page size are persisted in the App component to avoid resetting between list re-render events.

The issue was about the page number, but the page size should be included in this fix as well. Otherwise, it doesn't make sense to save only the page number. There was also a bug that is very closely related to the pagination feature. When the user is changing the page size, the request to the backend is sending twice. This problem also fixed in this pull request.

**Why:**
Issue #1006: When the user returns to the list from the case details and pagination resets to the first page.

**Technical note:**
Events related to page & pageSize had to be moved to the props of the custom Pagination component in that (kind of middleware-like) way to make sure that the internal state change has to happen before material-table requests the data.

**Checklist:**
- [x] Make a fix for page number
- [x] Make a fix for page size
- [x] Fix request duplication
- [x] Add unit tests
- [x] Add cypress tests
- [x] Review internally (HTD)