### PR TITLE
[#1283] Add more details to list view (table)

### DIFF
--- a/verification/curator-service/ui/src/components/LinelistTable.test.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.test.tsx
@@ -45,12 +45,19 @@ it('loads and displays cases', async () => {
                 administrativeAreaLevel3: 'some admin 3',
                 name: 'some place name',
                 geometry: {
-                    latitude: 42,
-                    longitude: 12,
+                    latitude: 42.123421,
+                    longitude: 12.376867,
                 },
                 geoResolution: 'Admin3',
             },
             events: [
+                {
+                    name: 'onsetSymptoms',
+                    dateRange: {
+                        start: new Date(Date.UTC(2020, 10, 28)).toJSON(),
+                        end: new Date(Date.UTC(2020, 10, 28)).toJSON(),
+                    },
+                },
                 {
                     name: 'confirmed',
                     dateRange: {
@@ -61,6 +68,10 @@ it('loads and displays cases', async () => {
                 {
                     name: 'hospitalAdmission',
                     value: 'Yes',
+                    dateRange: {
+                        start: new Date(Date.UTC(2020, 11, 1)).toJSON(),
+                        end: new Date(Date.UTC(2020, 11, 6)).toJSON(),
+                    },
                 },
                 {
                     name: 'outcome',
@@ -105,9 +116,13 @@ it('loads and displays cases', async () => {
     expect(await findByText('some admin 2')).toBeInTheDocument();
     expect(await findByText('some admin 3')).toBeInTheDocument();
     expect(await findByText('France')).toBeInTheDocument();
+    expect(await findByText('42.1234')).toBeInTheDocument();
+    expect(await findByText('12.3769')).toBeInTheDocument();
     expect(await findByText('1-3')).toBeInTheDocument();
     expect(await findByText('Female')).toBeInTheDocument();
     expect(await findByText('Recovered')).toBeInTheDocument();
+    expect(await findByText('2020-11-28')).toBeInTheDocument();
+    expect(await findByText('2020-12-01 - 2020-12-06')).toBeInTheDocument();
     expect(await findByTestId('verified-svg')).toBeInTheDocument();
 });
 

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -36,6 +36,7 @@ import { WithStyles } from '@material-ui/core/styles/withStyles';
 import axios from 'axios';
 import { createStyles } from '@material-ui/core/styles';
 import renderDate, { renderDateRange } from './util/date';
+import { round } from 'lodash';
 
 interface ListResponse {
     cases: Case[];
@@ -720,10 +721,14 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 c.location
                                                     ?.administrativeAreaLevel1,
                                             country: c.location.country,
-                                            latitude:
+                                            latitude: round(
                                                 c.location.geometry.latitude,
-                                            longitude:
+                                                4,
+                                            ),
+                                            longitude: round(
                                                 c.location.geometry.longitude,
+                                                4,
+                                            ),
                                             age: [
                                                 c.demographics?.ageRange?.start,
                                                 c.demographics?.ageRange?.end,

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -71,7 +71,7 @@ interface TableRow {
     age: [number, number]; // start, end.
     gender: string;
     outcome?: string;
-    hospitalizationDate?: string;
+    hospitalizationDateRange?: string;
     symptomsOnsetDate?: string;
     sourceUrl: string;
     verificationStatus?: VerificationStatus;
@@ -667,8 +667,8 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             field: 'outcome',
                         },
                         {
-                            title: 'Hospitalization date',
-                            field: 'hospitalizationDate',
+                            title: 'Hospitalization date/period',
+                            field: 'hospitalizationDateRange',
                         },
                         {
                             title: 'Symptoms onset date',
@@ -733,7 +733,7 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 (event) =>
                                                     event.name === 'outcome',
                                             )?.value,
-                                            hospitalizationDate: renderDateRange(
+                                            hospitalizationDateRange: renderDateRange(
                                                 c.events.find(
                                                     (event) =>
                                                         event.name ===

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -35,7 +35,7 @@ import { ReactComponent as VerifiedIcon } from './assets/verified_icon.svg';
 import { WithStyles } from '@material-ui/core/styles/withStyles';
 import axios from 'axios';
 import { createStyles } from '@material-ui/core/styles';
-import renderDate from './util/date';
+import renderDate, { renderDateRange } from './util/date';
 
 interface ListResponse {
     cases: Case[];
@@ -437,15 +437,6 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         );
     }
 
-    dateRange(range?: { start?: string; end?: string }): string {
-        if (!range || !range.start || !range.end) {
-            return '';
-        }
-        return range.start === range.end
-            ? renderDate(range.start)
-            : `${renderDate(range.start)} - ${renderDate(range.end)}`;
-    }
-
     render(): JSX.Element {
         const { history, classes } = this.props;
         return (
@@ -742,14 +733,14 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 (event) =>
                                                     event.name === 'outcome',
                                             )?.value,
-                                            hospitalizationDate: this.dateRange(
+                                            hospitalizationDate: renderDateRange(
                                                 c.events.find(
                                                     (event) =>
                                                         event.name ===
                                                         'hospitalAdmission',
                                                 )?.dateRange,
                                             ),
-                                            symptomsOnsetDate: this.dateRange(
+                                            symptomsOnsetDate: renderDateRange(
                                                 c.events.find(
                                                     (event) =>
                                                         event.name ===

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -71,6 +71,8 @@ interface TableRow {
     age: [number, number]; // start, end.
     gender: string;
     outcome?: string;
+    hospitalizationDate?: string;
+    symptomsOnsetDate?: string;
     sourceUrl: string;
     verificationStatus?: VerificationStatus;
 }
@@ -435,6 +437,15 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         );
     }
 
+    dateRange(range?: { start?: string; end?: string }): string {
+        if (!range || !range.start || !range.end) {
+            return '';
+        }
+        return range.start === range.end
+            ? renderDate(range.start)
+            : `${renderDate(range.start)} - ${renderDate(range.end)}`;
+    }
+
     render(): JSX.Element {
         const { history, classes } = this.props;
         return (
@@ -665,6 +676,14 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             field: 'outcome',
                         },
                         {
+                            title: 'Hospitalization date',
+                            field: 'hospitalizationDate',
+                        },
+                        {
+                            title: 'Symptoms onset date',
+                            field: 'symptomsOnsetDate',
+                        },
+                        {
                             title: 'Source URL',
                             field: 'sourceUrl',
                             headerStyle: { whiteSpace: 'nowrap' },
@@ -723,6 +742,20 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 (event) =>
                                                     event.name === 'outcome',
                                             )?.value,
+                                            hospitalizationDate: this.dateRange(
+                                                c.events.find(
+                                                    (event) =>
+                                                        event.name ===
+                                                        'hospitalAdmission',
+                                                )?.dateRange,
+                                            ),
+                                            symptomsOnsetDate: this.dateRange(
+                                                c.events.find(
+                                                    (event) =>
+                                                        event.name ===
+                                                        'onsetSymptoms',
+                                                )?.dateRange,
+                                            ),
                                             sourceUrl:
                                                 c.caseReference?.sourceUrl,
                                             verificationStatus:

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -66,6 +66,8 @@ interface TableRow {
     adminArea2: string;
     adminArea1: string;
     country: string;
+    latitude: number;
+    longitude: number;
     age: [number, number]; // start, end.
     gender: string;
     outcome?: string;
@@ -638,6 +640,14 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                             field: 'country',
                         },
                         {
+                            title: 'Latitude',
+                            field: 'latitude',
+                        },
+                        {
+                            title: 'Longitude',
+                            field: 'longitude',
+                        },
+                        {
                             title: 'Age',
                             field: 'age',
                             render: (rowData) =>
@@ -700,6 +710,10 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                 c.location
                                                     ?.administrativeAreaLevel1,
                                             country: c.location.country,
+                                            latitude:
+                                                c.location.geometry.latitude,
+                                            longitude:
+                                                c.location.geometry.longitude,
                                             age: [
                                                 c.demographics?.ageRange?.start,
                                                 c.demographics?.ageRange?.end,

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -722,11 +722,11 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                                     ?.administrativeAreaLevel1,
                                             country: c.location.country,
                                             latitude: round(
-                                                c.location.geometry.latitude,
+                                                c.location?.geometry?.latitude,
                                                 4,
                                             ),
                                             longitude: round(
-                                                c.location.geometry.longitude,
+                                                c.location?.geometry?.longitude,
                                                 4,
                                             ),
                                             age: [

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -17,7 +17,7 @@ import StaticMap from './StaticMap';
 import axios from 'axios';
 import createHref from './util/links';
 import { makeStyles } from '@material-ui/core';
-import renderDate from './util/date';
+import renderDate, { renderDateRange } from './util/date';
 import shortId from 'shortid';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { useTheme } from '@material-ui/core/styles';
@@ -121,15 +121,6 @@ function ageRange(range?: { start: number; end: number }): string {
     return range.start === range.end
         ? `${range.start}`
         : `${range.start}-${range.end}`;
-}
-
-function dateRange(range?: { start?: string; end?: string }): string {
-    if (!range || !range.start || !range.end) {
-        return '';
-    }
-    return range.start === range.end
-        ? renderDate(range.start)
-        : `${renderDate(range.start)} - ${renderDate(range.end)}`;
 }
 
 function CaseDetails(props: CaseDetailsProps): JSX.Element {
@@ -394,7 +385,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
                         <Grid container className={classes.grid}>
                             <RowHeader title="Confirmed case date" />
                             <RowContent
-                                content={dateRange(
+                                content={renderDateRange(
                                     props.c.events?.find(
                                         (e) => e.name === 'confirmed',
                                     )?.dateRange,
@@ -412,7 +403,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
 
                             <RowHeader title="Symptom onset date" />
                             <RowContent
-                                content={dateRange(
+                                content={renderDateRange(
                                     props.c.events?.find(
                                         (e) => e.name === 'onsetSymptoms',
                                     )?.dateRange,
@@ -421,7 +412,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
 
                             <RowHeader title="First clinical consultation" />
                             <RowContent
-                                content={dateRange(
+                                content={renderDateRange(
                                     props.c.events?.find(
                                         (e) =>
                                             e.name ===
@@ -432,7 +423,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
 
                             <RowHeader title="Date of self isolation" />
                             <RowContent
-                                content={dateRange(
+                                content={renderDateRange(
                                     props.c.events?.find(
                                         (e) => e.name === 'selfIsolation',
                                     )?.dateRange,
@@ -450,7 +441,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
 
                             <RowHeader title="Hospital admission date" />
                             <RowContent
-                                content={dateRange(
+                                content={renderDateRange(
                                     props.c.events?.find(
                                         (e) => e.name === 'hospitalAdmission',
                                     )?.dateRange,
@@ -459,7 +450,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
 
                             <RowHeader title="Date admitted to isolation unit" />
                             <RowContent
-                                content={dateRange(
+                                content={renderDateRange(
                                     props.c.events?.find(
                                         (e) => e.name === 'icuAdmission',
                                     )?.dateRange,
@@ -477,7 +468,7 @@ function CaseDetails(props: CaseDetailsProps): JSX.Element {
 
                             <RowHeader title="Outcome date" />
                             <RowContent
-                                content={dateRange(
+                                content={renderDateRange(
                                     props.c.events?.find(
                                         (e) => e.name === 'outcome',
                                     )?.dateRange,
@@ -725,7 +716,7 @@ function TravelRow(props: { travel: Travel }): JSX.Element {
             <RowContent content={props.travel.methods?.join(', ') || ''} />
 
             <RowHeader title="Travel dates" />
-            <RowContent content={dateRange(props.travel.dateRange)} />
+            <RowContent content={renderDateRange(props.travel.dateRange)} />
 
             <RowHeader title="Primary reason of travel" />
             <RowContent content={props.travel.purpose || ''} />

--- a/verification/curator-service/ui/src/components/util/date.test.tsx
+++ b/verification/curator-service/ui/src/components/util/date.test.tsx
@@ -1,9 +1,29 @@
-import renderDate from './date';
+import renderDate, { renderDateRange } from './date';
 
 describe('Dates', () => {
     it('are padded', () => {
         expect(renderDate(new Date(Date.UTC(2020, 6, 9)))).toEqual(
             '2020-07-09',
         );
+    });
+});
+
+describe('Date ranges', () => {
+    it('are shown as one date if start and end are identical', () => {
+        expect(
+            renderDateRange({
+                start: new Date(Date.UTC(2020, 5, 7)).toString(),
+                end: new Date(Date.UTC(2020, 5, 7)).toString(),
+            }),
+        ).toEqual('2020-06-07');
+    });
+
+    it('are shown as range if start and end are different', () => {
+        expect(
+            renderDateRange({
+                start: new Date(Date.UTC(2020, 5, 7)).toString(),
+                end: new Date(Date.UTC(2020, 10, 17)).toString(),
+            }),
+        ).toEqual('2020-06-07 - 2020-11-17');
     });
 });

--- a/verification/curator-service/ui/src/components/util/date.tsx
+++ b/verification/curator-service/ui/src/components/util/date.tsx
@@ -21,3 +21,15 @@ export function toUTCDate(dateString: string): string {
     );
     return utcDate.toString();
 }
+
+export function renderDateRange(range?: {
+    start?: string;
+    end?: string;
+}): string {
+    if (!range || !range.start || !range.end) {
+        return '';
+    }
+    return range.start === range.end
+        ? renderDate(range.start)
+        : `${renderDate(range.start)} - ${renderDate(range.end)}`;
+}


### PR DESCRIPTION
**What:**
The list view now shows latitude and longitude and hospitalisation date/period along with symptoms onset date (where applicable). 

**Why:**
Per global.health team request

Checklist:
- [x]  Add latitude and longitude to table with proper rounding
- [x]  Add hospitalisation period and symptoms onset date to table 
- [x]  Add unit tests for this particular use case to check if the correct page number is set.
- [x]  Internally reviewed (HTD)