### PR TITLE
#1360 Fix blank page after using search in certain cases

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LinelistTableTest.spec.ts
@@ -361,4 +361,28 @@ describe('Linelist table', function () {
         cy.contains('6-7 of 7').should('exist');
         cy.contains('5 rows').should('exist');
     });
+
+    it('Searching from a different page than first flips back to page one', function () {
+        for (let i = 0; i < 7; i++) {
+            cy.addCase({
+                country: 'France',
+                notes: 'some notes',
+                sourceUrl: 'foo.bar',
+            });
+        }
+        cy.server();
+        cy.route('GET', '/api/cases/*').as('getCases');
+        cy.visit('/cases');
+        cy.wait('@getCases');
+        cy.contains('rows').click();
+        cy.route('GET', '/api/cases/?limit=5&page=1').as('getFirstPage');
+        cy.get('li').contains('5').click();
+        cy.wait('@getFirstPage');
+
+        cy.contains('chevron_right').click();
+
+        cy.get('input[id="search-field"]').type('France{enter}');
+
+        cy.contains('1-5 of 7').should('exist');
+    });
 });

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -313,14 +313,17 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
         );
     }
 
-    componentDidMount(): void {
-        // history.location.state can be updated with new values on which we
-        // must refresh the table
-        this.unlisten = this.props.history.listen(({ state }, _) => {
-            this.tableRef.current?.onQueryChange();
-        });
+    componentDidUpdate(
+        prevProps: Readonly<Props>,
+        prevState: Readonly<LinelistTableState>,
+    ): void {
+        if (
+            this.props.location.state?.search !==
+            prevProps.location.state?.search
+        ) {
+            this.setState({ page: 0 }, this.tableRef.current?.onQueryChange);
+        }
     }
-
     componentWillUnmount(): void {
         this.unlisten();
     }


### PR DESCRIPTION
What:
Using search after switching the page or viewing a case details would result in blank page. This was caused by an infinite loop trigged on search query change in those cases. Search is now done using a different approach and flips back to page one after query change - regardless of whether the result includes the page a user was on when doing the search.

![Hnet-image](https://user-images.githubusercontent.com/803232/99938392-f62da500-2d67-11eb-98a6-9a9467e5bdd0.gif)

Why:
To improve user experience, as this situation occurred quite often during our tests of the application (#1360)

Checklist:

- [x] Fix crash when using search after page change 
- [x] Add Cypress tests
- [ ] Review internally (HTD)