### PR TITLE
#1015: Adjust downloaded CSV file structure

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -8,6 +8,7 @@ import axios from 'axios';
 import { logger } from '../util/logger';
 import stringify from 'csv-stringify';
 import yaml from 'js-yaml';
+import { parseDownloadedCase } from '../util/case';
 
 class GeocodeNotFoundError extends Error {}
 
@@ -76,6 +77,7 @@ export class CasesController {
                     }>).map((datum) => datum.name);
                     casesQuery
                         .cursor()
+                        .map(parseDownloadedCase)
                         .pipe(
                             stringify({
                                 header: true,

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -3,12 +3,12 @@ import { DocumentQuery, Query } from 'mongoose';
 import { GeocodeOptions, Geocoder, Resolution } from '../geocoding/geocoder';
 import { NextFunction, Request, Response } from 'express';
 import parseSearchQuery, { ParsingError } from '../util/search';
+import { parseDownloadedCase } from '../util/case';
 
 import axios from 'axios';
 import { logger } from '../util/logger';
 import stringify from 'csv-stringify';
 import yaml from 'js-yaml';
-import { parseDownloadedCase } from '../util/case';
 
 class GeocodeNotFoundError extends Error {}
 

--- a/data-serving/data-service/src/util/case.ts
+++ b/data-serving/data-service/src/util/case.ts
@@ -29,15 +29,35 @@ export const parseCaseEvents = (
 /**
  * Converts case to fulfill CSV file structure requirements.
  */
-export const parseDownloadedCase = (caseDocument: CaseDocument) => ({
-    ...caseDocument,
-    events: parseCaseEvents(caseDocument.events),
-    demographics: {
-        ...caseDocument.demographics,
-        nationalities: caseDocument.demographics.nationalities.join(','),
-    },
-    symptoms: {
-        ...caseDocument.symptoms,
-        values: caseDocument.symptoms.values.join(','),
-    },
-});
+export const parseDownloadedCase = (caseDocument: CaseDocument) => {
+    const { demographics, symptoms } = caseDocument;
+
+    const parsedDemographics = demographics?.nationalities
+        ? {
+              demographics: {
+                  ...demographics,
+                  nationalities: demographics.nationalities?.length
+                      ? demographics.nationalities.join(',')
+                      : '',
+              },
+          }
+        : {};
+
+    const parsedSymptoms = symptoms?.values
+        ? {
+              symptoms: {
+                  ...symptoms,
+                  values: symptoms.values?.length
+                      ? symptoms.values.join(',')
+                      : '',
+              },
+          }
+        : {};
+
+    return {
+        ...caseDocument,
+        ...parsedDemographics,
+        ...parsedSymptoms,
+        events: parseCaseEvents(caseDocument.events),
+    };
+};

--- a/data-serving/data-service/src/util/case.ts
+++ b/data-serving/data-service/src/util/case.ts
@@ -1,0 +1,43 @@
+import { CaseDocument } from '../model/case';
+import { EventDocument } from '../model/event';
+
+/**
+ * Converts event list to object to make a column for every event in csv file.
+ *
+ * Input: [{ name: 'confirmed', value: 'PCR test', dateRange: { start: '2020-11-19T00:00:00.000Z', end: '2020-11-19T00:00:00.000Z' } }]
+ * Output: { confirmed: { value: 'PCR test', date: '2020-11-19T00:00:00.000Z' } }
+ */
+export const parseCaseEvents = (
+    events: EventDocument[],
+): {
+    [name: string]: {
+        value?: string;
+        date: Date;
+    };
+} =>
+    events.reduce(
+        (agg, { name, value, dateRange }: EventDocument) => ({
+            ...agg,
+            [name]: {
+                value: value ?? '',
+                date: dateRange.start, // dateRange.start and dateRange.end have always the same values
+            },
+        }),
+        {},
+    );
+
+/**
+ * Converts case to fulfill CSV file structure requirements.
+ */
+export const parseDownloadedCase = (caseDocument: CaseDocument) => ({
+    ...caseDocument,
+    events: parseCaseEvents(caseDocument.events),
+    demographics: {
+        ...caseDocument.demographics,
+        nationalities: caseDocument.demographics.nationalities.join(','),
+    },
+    symptoms: {
+        ...caseDocument.symptoms,
+        values: caseDocument.symptoms.values.join(','),
+    },
+});

--- a/data-serving/data-service/test/model/data/case.events.json
+++ b/data-serving/data-service/test/model/data/case.events.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name": "onsetSymptoms",
+        "dateRange": {
+            "start": "2020-11-14T00:00:00.000Z",
+            "end": "2020-11-14T00:00:00.000Z"
+        }
+    },
+    {
+        "name": "confirmed",
+        "value": "PCR test",
+        "dateRange": {
+            "start": "2020-11-19T00:00:00.000Z",
+            "end": "2020-11-19T00:00:00.000Z"
+        }
+    },
+    {
+        "name": "hospitalAdmission",
+        "dateRange": {
+            "start": "2020-11-20T00:00:00.000Z",
+            "end": "2020-11-20T00:00:00.000Z"
+        }
+    },
+    {
+        "name": "outcome",
+        "value": "Recovered",
+        "dateRange": {
+            "start": "2020-12-01T00:00:00.000Z",
+            "end": "2020-12-01T00:00:00.000Z"
+        }
+    }
+]

--- a/data-serving/data-service/test/util/case.test.ts
+++ b/data-serving/data-service/test/util/case.test.ts
@@ -1,0 +1,64 @@
+import { CaseDocument } from '../../src/model/case';
+import { EventDocument } from '../../src/model/event';
+import { parseCaseEvents, parseDownloadedCase } from '../../src/util/case';
+import events from '../model/data/case.events.json';
+import demographics from '../model/data/demographics.full.json';
+import symptoms from '../model/data/symptoms.full.json';
+
+describe('Case', () => {
+    it('is parsed properly for download', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore Not necessary to mock full Mongoose type in JSON file
+        const res = parseDownloadedCase({
+            events,
+            demographics,
+            symptoms,
+        } as CaseDocument);
+
+        expect(res.events).toEqual({
+            onsetSymptoms: {
+                value: '',
+                date: '2020-11-14T00:00:00.000Z',
+            },
+            confirmed: {
+                value: 'PCR test',
+                date: '2020-11-19T00:00:00.000Z',
+            },
+            hospitalAdmission: {
+                value: '',
+                date: '2020-11-20T00:00:00.000Z',
+            },
+            outcome: {
+                value: 'Recovered',
+                date: '2020-12-01T00:00:00.000Z',
+            },
+        });
+
+        expect(res.demographics.nationalities).toEqual('American,Swedish');
+        expect(res.symptoms.values).toEqual('Cough,Pneumonia');
+    });
+    it('events are parsed properly for download', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore Not necessary to mock full Mongoose type in JSON file
+        const res = parseCaseEvents(events as EventDocument[]);
+
+        expect(res).toEqual({
+            onsetSymptoms: {
+                value: '',
+                date: '2020-11-14T00:00:00.000Z',
+            },
+            confirmed: {
+                value: 'PCR test',
+                date: '2020-11-19T00:00:00.000Z',
+            },
+            hospitalAdmission: {
+                value: '',
+                date: '2020-11-20T00:00:00.000Z',
+            },
+            outcome: {
+                value: 'Recovered',
+                date: '2020-12-01T00:00:00.000Z',
+            },
+        });
+    });
+});

--- a/data-serving/data-service/test/util/case.test.ts
+++ b/data-serving/data-service/test/util/case.test.ts
@@ -2,8 +2,6 @@ import { CaseDocument } from '../../src/model/case';
 import { EventDocument } from '../../src/model/event';
 import { parseCaseEvents, parseDownloadedCase } from '../../src/util/case';
 import events from '../model/data/case.events.json';
-import demographics from '../model/data/demographics.full.json';
-import symptoms from '../model/data/symptoms.full.json';
 
 describe('Case', () => {
     it('is parsed properly for download', () => {
@@ -11,8 +9,12 @@ describe('Case', () => {
         // @ts-ignore Not necessary to mock full Mongoose type in JSON file
         const res = parseDownloadedCase({
             events,
-            demographics,
-            symptoms,
+            symptoms: {
+                values: ['Cough', 'Pneumonia'],
+            },
+            demographics: {
+                nationalities: [],
+            },
         } as CaseDocument);
 
         expect(res.events).toEqual({
@@ -34,8 +36,8 @@ describe('Case', () => {
             },
         });
 
-        expect(res.demographics.nationalities).toEqual('American,Swedish');
         expect(res.symptoms.values).toEqual('Cough,Pneumonia');
+        expect(res.demographics.nationalities).toEqual('');
     });
     it('events are parsed properly for download', () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/data-serving/scripts/export-data/case_fields.yaml
+++ b/data-serving/scripts/export-data/case_fields.yaml
@@ -25,7 +25,7 @@
 - name: demographics.occupation
   description: Primary occupation of the case if any
 - name: demographics.nationalities
-  descriptionn: Nationalities of the case in English.
+  description: Nationalities of the case in English.
 - name: demographics.ethnicity
   description: >
     Ethnicity of the case, Asian, Caucasian, etc. Social group that has a common
@@ -49,12 +49,28 @@
   description: Latitude of the centroid of the location
 - name: location.geometry.longitude
   description: Longitude of the centroid of the location
-- name: events
-  description: >
-    Series of events known about this case. At least an event with the name
-    "confirmed" will always be present, other event names can include
-    confirmed, firstClinicalConsultation, hospitalAdmission, icuAdmission,
-    onsetSymptoms, outcome, selfIsolation
+- name: events.confirmed.value
+  description: Confirmation method
+- name: events.confirmed.date
+  description: Confirmed case date
+- name: events.onsetSymptoms.date
+  description: Symptom onset date
+- name: events.firstClinicalConsultation.date
+  description: First clinical consultation
+- name: events.selfIsolation.date
+  description: Date of self isolation
+- name: events.hospitalAdmission.value
+  description: Hospital admission
+- name: events.hospitalAdmission.date
+  description: Hospital admission date
+- name: events.icuAdmission.value
+  description: Admission to isolation unit
+- name: events.icuAdmission.date
+  description: Date admitted to isolation unit
+- name: events.outcome.value
+  description: Outcome
+- name: events.outcome.date
+  description: Outcome date
 - name: symptoms.status
   description: >
     Symptom status if known: Asymptomatic, Symptomatic or Presymptomatic


### PR DESCRIPTION
This PR covers issue #1015

**What:**
As we agreed, I've made the following changes to the downloaded csv file:

- For both fields: **symptoms** and **nationalities**.
  - Changed array to comma-separated values for the following fields:  
   For example: `["chest pain","cough"] -> "chest pain, cough"`
  - If the array is empty, return an empty string: `[] -> ''`

- **Events** are now separated to the following columns:
  - _events.confirmed.value_
  - _events.confirmed.date_
  - _events.onsetSymptoms.date_
  - _events.firstClinicalConsultation.date_
  - _events.selfIsolation.date_
  - _events.hospitalAdmission.value_
  - _events.hospitalAdmission.date_
  - _events.icuAdmission.value_
  - _events.icuAdmission.date_
  - _events.outcome.value_
  - _events.outcome.date_
  
**Comment:**
A single **event** has the date range, but the start & end dates are always exactly the same. At least for now. That's the reason I've decided to go with one output date for each event. Of course, I can split them into separate columns if necessary.

**Why:**
#1015: The current CSV file structure needs improvement

**Checklist:**
- [x] Meet all the requirements mentioned above
- [x] Add unit tests
- [ ] Review internally (HTD)