### PR TITLE
#1375 Add status change endpoint (incl. excluding)

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -470,6 +470,41 @@ paths:
           $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
+  /excludedCaseIds:
+    post:
+      summary: Exclude cases using their Mongo IDs
+      tags: [Case]
+      operationId: excludeCases
+      requestBody:
+        description: Cases to exclude along with note with reasoning
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                cases:
+                  description: >
+                    Cases having IDs provided here will be excluded
+                    from future source fetches.
+                  type: array
+                  items:
+                    type: string
+                note:
+                  description: >
+                    The reason behind exclusion (or other important info).
+                  type: string
+              required:
+                - cases
+                - note
+      responses:
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "422":
+          $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
   /geocode/seed:
     post:
       tags: [Geocode]

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -308,8 +308,6 @@ paths:
                   type: string
                   pattern: \S+
                 case:
-                  description: >
-                    The case fields that all matching cases will be updated to.
                   $ref: "#/components/schemas/Case"
               required:
                 - curator
@@ -470,32 +468,37 @@ paths:
           $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
-  /excludedCaseIds:
+  /cases/batchStatusChange:
     post:
-      summary: Exclude cases using their Mongo IDs
+      summary: Changes status for a list of cases
       tags: [Case]
-      operationId: excludeCases
+      operationId: batchStatusChange
       requestBody:
-        description: Cases to exclude along with note with reasoning
+        description: Case IDs are passed through an array of strings, note may be provided as well.
         required: true
         content:
           application/json:
             schema:
               properties:
-                cases:
+                caseIds:
                   description: >
-                    Cases having IDs provided here will be excluded
-                    from future source fetches.
+                    Cases having IDs provided here will have their
+                    status changed to one specified in status field.
                   type: array
                   items:
                     type: string
+                status:
+                  $ref: "#/components/schemas/CaseStatus"
                 note:
                   description: >
                     The reason behind exclusion (or other important info).
+                    This field is ignored if a status is not "Excluded".
                   type: string
+                curator:
+                  $ref: "#/components/schemas/Curator"
               required:
-                - cases
-                - note
+                - caseIds
+                - status
       responses:
         "200":
           $ref: "#/components/responses/200"
@@ -785,6 +788,9 @@ components:
             $ref: "#/components/schemas/Case"
       required:
         - cases
+    CaseStatus:
+      type: string
+      enum: [Unverified, Verified, Excluded]
     SymptomArray:
       type: object
       properties:

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -636,6 +636,7 @@ components:
               enum:
                 - UNVERIFIED
                 - VERIFIED
+                - EXCLUDED
             additionalSources:
               type: array
               items:

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -474,7 +474,10 @@ paths:
       tags: [Case]
       operationId: batchStatusChange
       requestBody:
-        description: Case IDs are passed through an array of strings, note may be provided as well.
+        description: >
+          Case IDs are passed through an array of strings, note may be provided as well.
+          A query may be provided instead of list of IDs, this will change status for all
+          cases matching the query.
         required: true
         content:
           application/json:
@@ -489,6 +492,12 @@ paths:
                     type: string
                 status:
                   $ref: "#/components/schemas/CaseStatus"
+                query:
+                  description: >
+                    Cases matching this query will have their status
+                    changed. Must contain non-whitespace characters.
+                  type: string
+                  pattern: \S+
                 note:
                   description: >
                     The reason behind exclusion (or other important info).
@@ -496,8 +505,10 @@ paths:
                   type: string
                 curator:
                   $ref: "#/components/schemas/Curator"
+              oneOf:
+                - required: [caseIds]
+                - required: [query]
               required:
-                - caseIds
                 - status
       responses:
         "200":
@@ -791,7 +802,7 @@ components:
         - cases
     CaseStatus:
       type: string
-      enum: [Unverified, Verified, Excluded]
+      enum: [UNVERIFIED, VERIFIED, EXCLUDED]
     SymptomArray:
       type: object
       properties:

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -47,6 +47,18 @@
           }
         }
       },
+      "exclusionData": {
+        "bsonType": "object",
+        "additionalProperties": false,
+        "properties": {
+          "sourceEntryId": {
+            "bsonType": "string"
+          },
+          "sourceUrl": {
+            "bsonType": "string"
+          }
+        }
+      },
       "demographics": {
         "bsonType": "object",
         "additionalProperties": false,

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -523,11 +523,14 @@ export class CasesController {
     /**
      * Excludes multiple cases.
      *
-     * Handles HTTP POST /api/excludedCaseIds.
+     * Handles HTTP POST /api/batchStatusChange.
+     * Receives an array of MongoDB IDs, status to be set for them and optional note.
+     * Note is used only when excluding cases (status set to "Excluded").
      */
-    exclude = async (req: Request, res: Response): Promise<void> => {
+    batchStatusChange = async (req: Request, res: Response): Promise<void> => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         // if (!req.body.cases.every((c: any) => c._id)) {
+        console.log('Got batch status change req!');
         res.status(422).json(req.body.cases);
         return;
         // }

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -521,6 +521,40 @@ export class CasesController {
     };
 
     /**
+     * Excludes multiple cases.
+     *
+     * Handles HTTP POST /api/excludedCaseIds.
+     */
+    exclude = async (req: Request, res: Response): Promise<void> => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // if (!req.body.cases.every((c: any) => c._id)) {
+        res.status(422).json(req.body.cases);
+        return;
+        // }
+        try {
+            const bulkWriteResult = await Case.bulkWrite(
+                // Consider defining a type for the request-format cases.
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                req.body.cases.map((c: any) => {
+                    return {
+                        updateOne: {
+                            filter: {
+                                _id: c._id,
+                            },
+                            update: c,
+                        },
+                    };
+                }),
+                { ordered: false },
+            );
+            res.json({ numModified: bulkWriteResult.modifiedCount });
+        } catch (err) {
+            res.status(500).json(err);
+            return;
+        }
+    };
+
+    /**
      * Geocodes a single location.
      * @returns The geocoded location.
      * @throws GeocodeNotFoundError if no geocode could be found.

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -528,30 +528,24 @@ export class CasesController {
      * Note is used only when excluding cases (status set to "Excluded").
      */
     batchStatusChange = async (req: Request, res: Response): Promise<void> => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        // if (!req.body.cases.every((c: any) => c._id)) {
-        console.log('Got batch status change req!');
-        res.status(422).json(req.body.cases);
-        return;
-        // }
         try {
-            const bulkWriteResult = await Case.bulkWrite(
-                // Consider defining a type for the request-format cases.
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                req.body.cases.map((c: any) => {
-                    return {
-                        updateOne: {
-                            filter: {
-                                _id: c._id,
-                            },
-                            update: c,
-                        },
-                    };
-                }),
-                { ordered: false },
+            const updateManyResult = await Case.updateMany(
+                { _id: { $in: req.body.caseIds } },
+                {
+                    $set: {
+                        'caseReference.verificationStatus': req.body.status.toUpperCase(),
+                    },
+                },
             );
-            res.json({ numModified: bulkWriteResult.modifiedCount });
+            console.log(
+                `${
+                    updateManyResult.modifiedCount
+                } rows updated to ${req.body.status.toUpperCase()}`,
+            );
+            res.status(200).end();
+            return;
         } catch (err) {
+            console.error('ERROR', err);
             res.status(500).json(err);
             return;
         }

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -176,9 +176,8 @@ new OpenApiValidator({
             caseController.del,
         );
         apiRouter.post(
-            '/excludedCaseIds',
-            setRevisionMetadata,
-            caseController.exclude,
+            '/cases/batchStatusChange',
+            caseController.batchStatusChange,
         );
 
         // Suggest locations based on the request's "q" query param.

--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -175,6 +175,11 @@ new OpenApiValidator({
             createCaseRevision,
             caseController.del,
         );
+        apiRouter.post(
+            '/excludedCaseIds',
+            setRevisionMetadata,
+            caseController.exclude,
+        );
 
         // Suggest locations based on the request's "q" query param.
         const geocodeSuggester = new GeocodeSuggester(geocoders);

--- a/data-serving/data-service/src/model/case.ts
+++ b/data-serving/data-service/src/model/case.ts
@@ -22,6 +22,7 @@ import { TravelHistoryDocument, travelHistorySchema } from './travel-history';
 import { ObjectId } from 'mongodb';
 import _ from 'lodash';
 import mongoose from 'mongoose';
+import { ExclusionDataDocument, exclusionDataSchema } from './exclusion-data';
 
 export const caseSchema = new mongoose.Schema(
     {
@@ -39,6 +40,7 @@ export const caseSchema = new mongoose.Schema(
                 message: 'Must include an event with name "confirmed"',
             },
         },
+        exclusionData: exclusionDataSchema,
         genomeSequences: [genomeSequenceSchema],
         importedCase: {
             _id: false,
@@ -88,6 +90,7 @@ caseSchema.methods.equalsJSON = function (jsonCase: any): boolean {
     return (
         _.isEqual(thisJson.demographics, other.demographics) &&
         _.isEqual(thisJson.events, other.events) &&
+        _.isEqual(thisJson.exclusionData, other.exclusionData) &&
         _.isEqual(thisJson.genomeSequences, other.genomeSequences) &&
         _.isEqual(thisJson.location, other.location) &&
         _.isEqual(thisJson.notes, other.notes) &&
@@ -107,6 +110,7 @@ export type CaseDocument = mongoose.Document & {
     caseReference: CaseReferenceDocument;
     demographics: DemographicsDocument;
     events: [EventDocument];
+    exclusionData: ExclusionDataDocument;
     genomeSequences: [GenomeSequenceDocument];
     importedCase: unknown;
     location: LocationDocument;

--- a/data-serving/data-service/src/model/exclusion-data.ts
+++ b/data-serving/data-service/src/model/exclusion-data.ts
@@ -1,0 +1,18 @@
+import mongoose from 'mongoose';
+import { dateFieldInfo } from './date';
+
+export const exclusionDataSchema = new mongoose.Schema(
+    {
+        date: dateFieldInfo,
+        note: String,
+    },
+    { _id: false },
+);
+
+export type ExclusionDataDocument = mongoose.Document & {
+    /** Foreign key to the sources collection. */
+    date: Date;
+
+    /** The original id of the case in the source.  */
+    note: string;
+};

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -761,7 +761,7 @@ describe('POST', () => {
                 .post('/api/cases/batchStatusChange')
                 .send({
                     caseIds: [''],
-                    status: 'Excluded',
+                    status: 'EXCLUDED',
                     ...curatorMetadata,
                 })
                 .expect(422);
@@ -775,7 +775,7 @@ describe('POST', () => {
                 .post('/api/cases/batchStatusChange')
                 .send({
                     caseIds: [existingCase._id],
-                    status: 'Excluded',
+                    status: 'EXCLUDED',
                     note: 'Duplicate',
                     ...curatorMetadata,
                 })
@@ -792,7 +792,7 @@ describe('POST', () => {
                 .post('/api/cases/batchStatusChange')
                 .send({
                     caseIds: [firstExistingCase._id, secondExistingCase._id],
-                    status: 'Excluded',
+                    status: 'EXCLUDED',
                     note: 'Duplicate',
                     ...curatorMetadata,
                 })
@@ -820,7 +820,7 @@ describe('POST', () => {
                 .post('/api/cases/batchStatusChange')
                 .send({
                     caseIds: [firstExistingCase._id, secondExistingCase._id],
-                    status: 'Excluded',
+                    status: 'EXCLUDED',
                     note: 'Duplicate',
                     ...curatorMetadata,
                 })
@@ -846,7 +846,7 @@ describe('POST', () => {
                 .post('/api/cases/batchStatusChange')
                 .send({
                     caseIds: [firstExistingCase._id, secondExistingCase._id],
-                    status: 'Excluded',
+                    status: 'EXCLUDED',
                     note: 'Duplicate',
                     ...curatorMetadata,
                 })
@@ -856,7 +856,7 @@ describe('POST', () => {
                 .post('/api/cases/batchStatusChange')
                 .send({
                     caseIds: [firstExistingCase._id, secondExistingCase._id],
-                    status: 'Unverified',
+                    status: 'UNVERIFIED',
                     ...curatorMetadata,
                 })
                 .expect(200);
@@ -871,6 +871,32 @@ describe('POST', () => {
             );
             expect(firstCaseInDb?.exclusionData).not.toBeDefined();
             expect(secondCaseInDb?.exclusionData).not.toBeDefined();
+        });
+
+        it('should allow query instead of list of case IDs', async () => {
+            const firstExistingCase = new Case(fullCase);
+            await firstExistingCase.save();
+            const secondExistingCase = new Case(fullCase);
+            await secondExistingCase.save();
+
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    query: 'country:France',
+                    status: 'EXCLUDED',
+                    note: 'Duplicate',
+                    ...curatorMetadata,
+                })
+                .expect(200);
+
+            const firstCaseInDb = await Case.findById(firstExistingCase._id);
+            const secondCaseInDb = await Case.findById(secondExistingCase._id);
+            expect(firstCaseInDb?.caseReference.verificationStatus).toEqual(
+                'EXCLUDED',
+            );
+            expect(secondCaseInDb?.caseReference.verificationStatus).toEqual(
+                'EXCLUDED',
+            );
         });
     });
 });

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -23,8 +23,11 @@ const invalidRequest = {
     demographics: { ageRange: { start: 400 } },
 };
 
+const realDate = Date.now;
+
 beforeAll(async () => {
     mongoServer = new MongoMemoryServer();
+    global.Date.now = jest.fn(() => new Date('2020-12-12T12:12:37Z').getTime());
 });
 
 beforeEach(async () => {
@@ -33,6 +36,7 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
+    global.Date.now = realDate;
     return mongoServer.stop();
 });
 
@@ -738,6 +742,135 @@ describe('POST', () => {
             expect(res.text).toContain('Germany');
             expect(res.text).toContain(matchedCase._id);
             expect(res.text).not.toContain(unmatchedCase._id);
+        });
+    });
+    describe('batch status change', () => {
+        it('should not accept invalid statuses', async () => {
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    caseIds: [''],
+                    status: 'xxx',
+                    ...curatorMetadata,
+                })
+                .expect(400);
+        });
+
+        it('should require note when excluding cases', async () => {
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    caseIds: [''],
+                    status: 'Excluded',
+                    ...curatorMetadata,
+                })
+                .expect(422);
+        });
+
+        it('should return 200 OK when excluding cases with note', async () => {
+            const existingCase = new Case(fullCase);
+            await existingCase.save();
+
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    caseIds: [existingCase._id],
+                    status: 'Excluded',
+                    note: 'Duplicate',
+                    ...curatorMetadata,
+                })
+                .expect(200);
+        });
+
+        it('should save note when excluding cases with note', async () => {
+            const firstExistingCase = new Case(fullCase);
+            await firstExistingCase.save();
+            const secondExistingCase = new Case(fullCase);
+            await secondExistingCase.save();
+
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    caseIds: [firstExistingCase._id, secondExistingCase._id],
+                    status: 'Excluded',
+                    note: 'Duplicate',
+                    ...curatorMetadata,
+                })
+                .expect(200);
+
+            const firstCaseInDb = await Case.findById(firstExistingCase._id);
+            const secondCaseInDb = await Case.findById(secondExistingCase._id);
+            expect(firstCaseInDb?.caseReference.verificationStatus).toEqual(
+                'EXCLUDED',
+            );
+            expect(secondCaseInDb?.caseReference.verificationStatus).toEqual(
+                'EXCLUDED',
+            );
+            expect(firstCaseInDb?.exclusionData.note).toEqual('Duplicate');
+            expect(secondCaseInDb?.exclusionData.note).toEqual('Duplicate');
+        });
+
+        it('should save current date when excluding cases', async () => {
+            const firstExistingCase = new Case(fullCase);
+            await firstExistingCase.save();
+            const secondExistingCase = new Case(fullCase);
+            await secondExistingCase.save();
+
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    caseIds: [firstExistingCase._id, secondExistingCase._id],
+                    status: 'Excluded',
+                    note: 'Duplicate',
+                    ...curatorMetadata,
+                })
+                .expect(200);
+
+            const firstCaseInDb = await Case.findById(firstExistingCase._id);
+            const secondCaseInDb = await Case.findById(secondExistingCase._id);
+            expect(firstCaseInDb?.exclusionData.date).toEqual(
+                new Date('2020-12-12T12:12:37.000Z'),
+            );
+            expect(secondCaseInDb?.exclusionData.date).toEqual(
+                new Date('2020-12-12T12:12:37.000Z'),
+            );
+        });
+
+        it('should remove exclusion data when unexcluding cases', async () => {
+            const firstExistingCase = new Case(fullCase);
+            await firstExistingCase.save();
+            const secondExistingCase = new Case(fullCase);
+            await secondExistingCase.save();
+
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    caseIds: [firstExistingCase._id, secondExistingCase._id],
+                    status: 'Excluded',
+                    note: 'Duplicate',
+                    ...curatorMetadata,
+                })
+                .expect(200);
+
+            await request(app)
+                .post('/api/cases/batchStatusChange')
+                .send({
+                    caseIds: [firstExistingCase._id, secondExistingCase._id],
+                    status: 'Unverified',
+                    ...curatorMetadata,
+                })
+                .expect(200);
+
+            const firstCaseInDb = await Case.findById(firstExistingCase._id);
+            const secondCaseInDb = await Case.findById(secondExistingCase._id);
+            expect(firstCaseInDb?.caseReference.verificationStatus).toEqual(
+                'UNVERIFIED',
+            );
+            expect(secondCaseInDb?.caseReference.verificationStatus).toEqual(
+                'UNVERIFIED',
+            );
+            expect(firstCaseInDb?.exclusionData).not.toBeDefined();
+            expect(secondCaseInDb?.exclusionData).not.toBeDefined();
         });
     });
 });

--- a/data-serving/scripts/export-data/case_fields.yaml
+++ b/data-serving/scripts/export-data/case_fields.yaml
@@ -7,7 +7,8 @@
     the data that got ingested corresponds to the data that was present in an
     source outside the system.
     It does not mean that the curators verified that the case really existed.
-    Values can be VERIFIED or UNVERIFIED.
+    Values can be VERIFIED, UNVERIFIED or EXCLUDED. EXCLUDED cases contain a note
+    describing the reason for exclusion and when it was done.
 - name: caseReference.sourceId
   description: Unique ID of the source for this case
 - name: caseReference.sourceUrl

--- a/data-serving/scripts/export-data/case_fields.yaml
+++ b/data-serving/scripts/export-data/case_fields.yaml
@@ -110,3 +110,7 @@
   description: Date an update was made to the case
 - name: revisionMetadata.updateMetadata.notes
   description: Update notes from curator
+- name: exclusionData.note
+  description: Note that was entered by curator when marking the case as excluded
+- name: exclusionData.date
+  description: Date this case was marked as excluded

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1141,6 +1141,7 @@ components:
               enum:
                 - UNVERIFIED
                 - VERIFIED
+                - EXCLUDED
             additionalSources:
               type: array
               description: List of additional URLs that described a case

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -765,6 +765,41 @@ paths:
           $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
+  /excludedCaseIds:
+    post:
+      summary: Exclude cases using their Mongo IDs
+      tags: [Case]
+      operationId: excludeCases
+      requestBody:
+        description: Cases to exclude along with note with reasoning
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                cases:
+                  description: >
+                    Cases having IDs provided here will be excluded
+                    from future source fetches.
+                  type: array
+                  items:
+                    type: string
+                note:
+                  description: >
+                    The reason behind exclusion (or other important info).
+                  type: string
+              required:
+                - cases
+                - note
+      responses:
+        "200":
+          $ref: "#/components/responses/200BatchCaseUpdateResponse"
+        "400":
+          $ref: "#/components/responses/400"
+        "422":
+          $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
   /geocode/seed:
     post:
       tags: [Geocode]

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -632,7 +632,10 @@ paths:
       tags: [Case]
       operationId: batchStatusChange
       requestBody:
-        description: Case IDs are passed through an array of strings, note may be provided as well.
+        description: >
+          Case IDs are passed through an array of strings, note may be provided as well.
+          A query may be provided instead of list of IDs, this will change status for all
+          cases matching the query.
         required: true
         content:
           application/json:
@@ -647,13 +650,21 @@ paths:
                     type: string
                 status:
                   $ref: "#/components/schemas/CaseStatus"
+                query:
+                  description: >
+                    Cases matching this query will have their status
+                    changed. Must contain non-whitespace characters.
+                  type: string
+                  pattern: \S+
                 note:
                   description: >
                     The reason behind exclusion (or other important info).
                     This field is ignored if a status is not "Excluded".
                   type: string
+              oneOf:
+                - required: [caseIds]
+                - required: [query]
               required:
-                - caseIds
                 - status
       responses:
         "200":
@@ -1369,7 +1380,7 @@ components:
               $ref: "#/components/schemas/EditMetadata"
     CaseStatus:
       type: string
-      enum: [Unverified, Verified, Excluded]
+      enum: [UNVERIFIED, VERIFIED, EXCLUDED]
     CaseArray:
       type: object
       properties:

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -626,6 +626,44 @@ paths:
           $ref: "#/components/responses/403"
         "500":
           $ref: "#/components/responses/500"
+  /cases/batchStatusChange:
+    post:
+      summary: Changes status for a list of cases
+      tags: [Case]
+      operationId: batchStatusChange
+      requestBody:
+        description: Case IDs are passed through an array of strings, note may be provided as well.
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                caseIds:
+                  description: >
+                    Cases having IDs provided here will have their
+                    status changed to one specified in status field.
+                  type: array
+                  items:
+                    type: string
+                status:
+                  $ref: "#/components/schemas/CaseStatus"
+                note:
+                  description: >
+                    The reason behind exclusion (or other important info).
+                    This field is ignored if a status is not "Excluded".
+                  type: string
+              required:
+                - caseIds
+                - status
+      responses:
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "422":
+          $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
   /cases/batchUpsert:
     post:
       tags: [Case]
@@ -685,8 +723,6 @@ paths:
                   type: string
                   pattern: \S+
                 case:
-                  description: >
-                    The case fields that all matching cases will be updated to.
                   $ref: "#/components/schemas/Case"
               required:
                 - query
@@ -763,41 +799,6 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-  /excludedCaseIds:
-    post:
-      summary: Exclude cases using their Mongo IDs
-      tags: [Case]
-      operationId: excludeCases
-      requestBody:
-        description: Cases to exclude along with note with reasoning
-        required: true
-        content:
-          application/json:
-            schema:
-              properties:
-                cases:
-                  description: >
-                    Cases having IDs provided here will be excluded
-                    from future source fetches.
-                  type: array
-                  items:
-                    type: string
-                note:
-                  description: >
-                    The reason behind exclusion (or other important info).
-                  type: string
-              required:
-                - cases
-                - note
-      responses:
-        "200":
-          $ref: "#/components/responses/200BatchCaseUpdateResponse"
-        "400":
-          $ref: "#/components/responses/400"
-        "422":
-          $ref: "#/components/responses/422"
         "500":
           $ref: "#/components/responses/500"
   /geocode/seed:
@@ -945,7 +946,6 @@ components:
     ParsersArray:
       type: array
       items:
-        description: An array of parsers
         $ref: "#/components/schemas/Parser"
     Upload:
       description: An instance of case data being written to the server.
@@ -1366,6 +1366,9 @@ components:
               $ref: "#/components/schemas/EditMetadata"
             editMetadata:
               $ref: "#/components/schemas/EditMetadata"
+    CaseStatus:
+      type: string
+      enum: [Unverified, Verified, Excluded]
     CaseArray:
       type: object
       properties:

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -329,4 +329,29 @@ export default class CasesController {
             res.status(500).send(err);
         }
     };
+
+    /**
+     * exclude forwards the query to the data service.
+     * It does set the curator in the request to the data service based on the
+     * currently logged-in user.
+     */
+    exclude = async (req: Request, res: Response): Promise<void> => {
+        try {
+            console.log("EXCLUDE")
+            const response = await axios.post(
+                this.dataServerURL + '/api/excludedCaseIds',
+                {
+                    ...req.body,
+                    curator: { email: (req.user as UserDocument).email },
+                },
+            );
+            res.status(response.status).json(response.data);
+        } catch (err) {
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
+            res.status(500).send(err);
+        }
+    };
 }

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -321,7 +321,7 @@ export default class CasesController {
                     curator: { email: (req.user as UserDocument).email },
                 },
             );
-            res.status(response.status).json(response.data);
+            res.status(response.status).end();
         } catch (err) {
             if (err.response?.status && err.response?.data) {
                 res.status(err.response.status).send(err.response.data);

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -313,7 +313,6 @@ export default class CasesController {
      */
     batchStatusChange = async (req: Request, res: Response): Promise<void> => {
         try {
-            console.log('Passing on batch status change');
             const response = await axios.post(
                 this.dataServerURL + '/api/cases/batchStatusChange',
                 {

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -307,14 +307,15 @@ export default class CasesController {
     };
 
     /**
-     * create forwards the query to the data service.
+     * batchStatusChange forwards the query to the data service.
      * It does set the curator in the request to the data service based on the
      * currently logged-in user.
      */
-    create = async (req: Request, res: Response): Promise<void> => {
+    batchStatusChange = async (req: Request, res: Response): Promise<void> => {
         try {
+            console.log('Passing on batch status change');
             const response = await axios.post(
-                this.dataServerURL + '/api' + req.url,
+                this.dataServerURL + '/api/cases/batchStatusChange',
                 {
                     ...req.body,
                     curator: { email: (req.user as UserDocument).email },
@@ -331,15 +332,14 @@ export default class CasesController {
     };
 
     /**
-     * exclude forwards the query to the data service.
+     * create forwards the query to the data service.
      * It does set the curator in the request to the data service based on the
      * currently logged-in user.
      */
-    exclude = async (req: Request, res: Response): Promise<void> => {
+    create = async (req: Request, res: Response): Promise<void> => {
         try {
-            console.log("EXCLUDE")
             const response = await axios.post(
-                this.dataServerURL + '/api/excludedCaseIds',
+                this.dataServerURL + '/api' + req.url,
                 {
                     ...req.body,
                     curator: { email: (req.user as UserDocument).email },

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -280,6 +280,11 @@ new OpenApiValidator({
             mustHaveAnyRole(['curator']),
             casesController.del,
         );
+        apiRouter.post(
+            '/excludedCaseIds',
+            mustHaveAnyRole(['curator']),
+            casesController.exclude,
+        );
 
         // Configure users controller.
         apiRouter.get(

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -265,6 +265,11 @@ new OpenApiValidator({
             mustHaveAnyRole(['curator']),
             casesController.batchUpdateQuery,
         );
+        apiRouter.post(
+            '/cases/batchStatusChange',
+            mustHaveAnyRole(['curator']),
+            casesController.batchStatusChange,
+        );
         apiRouter.put(
             '/cases/:id([a-z0-9]{24})',
             mustHaveAnyRole(['curator']),
@@ -279,11 +284,6 @@ new OpenApiValidator({
             '/cases/:id([a-z0-9]{24})',
             mustHaveAnyRole(['curator']),
             casesController.del,
-        );
-        apiRouter.post(
-            '/excludedCaseIds',
-            mustHaveAnyRole(['curator']),
-            casesController.exclude,
         );
 
         // Configure users controller.


### PR DESCRIPTION
This would close #1375 
This is the backend part of the bigger task: #1013. Whole description available here: #1376.

Technical note:
As is mentioned in #1399,  a new endpoint for changing the case status and handling all logic has been introduced for consistency purposes. This will require additional work on the frontend to accommodate that change.

**Important**
Database schema update is needed for excluding (since we introduced a new subdocument in case schema). The appropriate command to be executed in Mongo shell can be found here: https://gist.github.com/AKorzeniowski/0337ca2573d33484b61526f55279466f

Checklist:

- [x] Allow changes of status via new endpoint
- [x] Save note and date when excluding case
- [x] Remove exclusion data when a case is marked as not excluded
- [x] Support case status updates through query (for marking cases from search results that span across multiple pages) 
- [x] Handle edge cases (wrong IDs, missing note for exclusion)
- [x] Add unit tests
- [x] Review internally (HTD)