### PR TITLE
Don't attempt to collate non-'Hospitalized' cases in covid19india data.

### DIFF
--- a/ingestion/functions/parsing/india/india_test.py
+++ b/ingestion/functions/parsing/india/india_test.py
@@ -9,52 +9,6 @@ _PARSED_CASES = [
     {
         "caseReference": {
             "sourceId": _SOURCE_ID,
-            "sourceEntryId": "OR-A-123-1",
-            "sourceUrl": _SOURCE_URL,
-            "additionalSources": [
-                {
-                    "sourceUrl": "https://twitter.com/HFWOdisha/status/1308286422281977856"
-                }
-            ]
-        },
-        "location": {
-            "limitToResolution": "Admin2,Admin1,Country",
-            "query": "Balasore, Odisha, India"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange":
-                        {
-                            "start": "09/22/2020Z",
-                            "end": "09/22/2020Z"
-                        }
-            },
-            {
-                "name": "outcome",
-                "dateRange":
-                {
-                    "start": "09/22/2020Z",
-                    "end": "09/22/2020Z",
-                },
-                "value": "Death"
-            }
-        ],
-        "demographics": {
-            "ageRange": {
-                "start": 0.5,
-                "end": 0.5
-            },
-            "gender": "Male",
-            "nationalities": [
-                "Bengladeshi"
-            ]
-        },
-        "notes": "was also suffering from Diabetes, hypertension."
-    },
-    {
-        "caseReference": {
-            "sourceId": _SOURCE_ID,
             "sourceEntryId": "Entry-297649-1",
             "sourceUrl": _SOURCE_URL,
             "additionalSources": [
@@ -75,15 +29,6 @@ _PARSED_CASES = [
                             "start": "09/22/2020Z",
                             "end": "09/22/2020Z"
                         }
-            },
-            {
-                "name": "hospitalAdmission",
-                "dateRange":
-                        {
-                            "start": "09/22/2020Z",
-                            "end": "09/22/2020Z"
-                        },
-                "value": "Yes"
             }
         ],
         "demographics": {
@@ -117,15 +62,6 @@ _PARSED_CASES = [
                             "start": "09/22/2020Z",
                             "end": "09/22/2020Z"
                         }
-            },
-            {
-                "name": "hospitalAdmission",
-                "dateRange":
-                        {
-                            "start": "09/22/2020Z",
-                            "end": "09/22/2020Z"
-                        },
-                "value": "Yes"
             }
         ],
         "demographics": {

--- a/ingestion/functions/parsing/india/input_event.json
+++ b/ingestion/functions/parsing/india/input_event.json
@@ -1,11 +1,7 @@
 {
     "env": "local",
     "s3Bucket": "epid-sources-raw",
-    "s3Key": "5f6a9df8310dcb0a1156782c/2020/09/28/2358/content.csv",
+    "s3Key": "5f6a9df8310dcb0a1156782c/2020/12/14/2350/content.csv",
     "sourceUrl": "https://foo.bar",
-    "sourceId": "5f6a9df8310dcb0a1156782c",
-    "dateFilter": {
-        "numDaysBeforeToday": 4,
-        "op": "GT"
-    }
+    "sourceId": "5f6a9df8310dcb0a1156782c"
 }


### PR DESCRIPTION
Per title, limit ingesting `covid19india` data to rows with the `Hospitalized` `currentStatus`.

We'd previously hoped to get data with other statuses by deduping on a state-specific UUID (in other words, allowing non-`Hospitalized` cases to be ingested on the basis that they'd be folded into an existing row with the same state-specific UUID), but that doesn't appear to have held up.

We'll get a slightly lower quantity of detailed information this way, but the data we get will be solid. There's one last hitch, which is that we can't reliably process rows with negative `numCases`. This is mostly a wash, however -- for the `raw_data16.csv` file, out of ~1.3M cases, the total of negative case counts for hospitalizations is 571.

On the whole, the linelist style data is a bit all over the place from this source. This is probably the best we can do without some sort of multi-file processing pipeline (or at least an offline pipeline where it's feasible to store and inspect an entire file's worth of data while we're processing the data).