### PR TITLE
Fix integration tests due to too general cypress selectors

### DIFF
--- a/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/AppTest.spec.ts
@@ -170,7 +170,7 @@ describe('App', function () {
         cy.contains('Line list');
 
         cy.contains('Global.health Terms of Use').should('not.exist');
-        cy.contains('Terms of use').click();
+        cy.contains('Terms of use').click({ force: true });
         cy.url().should('eq', 'http://localhost:3002/terms');
         cy.contains('Global.health Terms of Use');
     });

--- a/verification/curator-service/ui/cypress/integration/components/EditCase.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/EditCase.spec.ts
@@ -22,7 +22,8 @@ describe('Edit case', function () {
             // Check that we have something from the original case.
             cy.contains('France');
             cy.contains('Female').should('not.exist');
-            cy.contains('21').should('not.exist');
+            cy.contains('td', '21').should('not.exist');
+            cy.contains('input', '21').should('not.exist');
             // Change a few things.
             cy.get('div[data-testid="gender"]').click();
             cy.get('li[data-value="Female"]').click();
@@ -37,7 +38,7 @@ describe('Edit case', function () {
             cy.contains(`Case ${resp.body.cases[0]._id} edited`);
             cy.contains('No records to display').should('not.exist');
             cy.contains('Female');
-            cy.contains('21');
+            cy.contains('td', '21');
             // What's untouched should stay as is.
             cy.contains('France');
         });

--- a/verification/curator-service/ui/cypress/integration/components/UploadsTableTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UploadsTableTest.spec.ts
@@ -84,7 +84,7 @@ describe('Uploads table', function () {
             },
         ]);
         cy.visit('/uploads');
-        cy.contains('a', '5').click();
+        cy.contains('a[href="/cases"]', '5').click();
         cy.url().should('eq', 'http://localhost:3002/cases');
         cy.get('input[id="search-field"]').should(
             'have.value',
@@ -96,7 +96,7 @@ describe('Uploads table', function () {
         cy.contains('Germany').should('not.exist');
 
         cy.visit('/uploads');
-        cy.contains('a', '2').click();
+        cy.contains('a[href="/cases"]', '2').click();
         cy.url().should('eq', 'http://localhost:3002/cases');
         cy.get('input[id="search-field"]').should(
             'have.value',


### PR DESCRIPTION
This fixes the problem with integration tests. Cypress selectors were too general and pointed to the wrong DOM elements.