### PR TITLE
#1374 Handle cases exclusion in parsers

### DIFF
--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib.py
@@ -88,7 +88,6 @@ def retrieve_excluded_case_ids(source_id: str, date_filter: Dict, date_range: Di
     res = requests.get(excluded_case_ids_endpoint_url)
     if res and res.status_code == 200:
         res_json = res.json()
-        print(res_json["cases"])
         res_json["cases"]
 
 def prepare_cases(cases: Generator[Dict, None, None], upload_id: str, excluded_case_ids: list):

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -524,3 +524,15 @@ def test_remove_nested_none_and_empty_removes_only_nones_and_empty_str():
                 "multi": {"multikeep": "ok"},
                 "emptyobject": {}}
     assert parsing_lib.remove_nested_none_and_empty(data) == expected
+
+def test_excluded_case_are_removed_from_cases():
+    from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
+
+    valid_case = _PARSED_CASE
+    excluded_case = copy.deepcopy(_PARSED_CASE)
+    excluded_case["caseReference"]["sourceEntryId"] = "999"
+
+    cases = parsing_lib.prepare_cases([excluded_case, valid_case], "0")
+
+    assert next(cases) == valid_case
+    assert next(cases) != excluded_case

--- a/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
+++ b/ingestion/functions/parsing/common/python/parsing_lib/parsing_lib_test.py
@@ -262,28 +262,34 @@ def test_extract_event_fields_errors_if_missing_env_field(input_event):
 
 def test_prepare_cases_adds_upload_id():
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
+    case = copy.deepcopy(_PARSED_CASE)
     upload_id = "123456789012345678901234"
     result = parsing_lib.prepare_cases(
-        [_PARSED_CASE],
-        upload_id)
+        [case],
+        upload_id,
+        [])
     assert next(result)["caseReference"]["uploadIds"] == [upload_id]
 
 
 def test_prepare_cases_removes_nones():
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
-    _PARSED_CASE["demographics"] = None
+    case = copy.deepcopy(_PARSED_CASE)
+    case["demographics"] = None
     result = parsing_lib.prepare_cases(
-        [_PARSED_CASE],
-        "123456789012345678901234")
+        [case],
+        "123456789012345678901234",
+        [])
     assert "demographics" not in next(result).keys()
 
 
 def test_prepare_cases_removes_empty_strings():
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
-    _PARSED_CASE["notes"] = ""
+    case = copy.deepcopy(_PARSED_CASE)
+    case["notes"] = ""
     result = parsing_lib.prepare_cases(
-        [_PARSED_CASE],
-        "123456789012345678901234")
+        [case],
+        "123456789012345678901234",
+        [])
     assert "notes" not in next(result).keys()
 
 
@@ -528,11 +534,10 @@ def test_remove_nested_none_and_empty_removes_only_nones_and_empty_str():
 def test_excluded_case_are_removed_from_cases():
     from parsing_lib import parsing_lib  # Import locally to avoid superseding mock
 
-    valid_case = _PARSED_CASE
+    valid_case = copy.deepcopy(_PARSED_CASE)
     excluded_case = copy.deepcopy(_PARSED_CASE)
     excluded_case["caseReference"]["sourceEntryId"] = "999"
 
-    cases = parsing_lib.prepare_cases([excluded_case, valid_case], "0")
+    cases = parsing_lib.prepare_cases([excluded_case, valid_case], "0", ["999"])
 
-    assert next(cases) == valid_case
-    assert next(cases) != excluded_case
+    assert next(cases)["caseReference"]["sourceEntryId"] == valid_case["caseReference"]["sourceEntryId"]

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -944,6 +944,44 @@ paths:
           $ref: "#/components/responses/403"
         "500":
           $ref: "#/components/responses/500"
+  /excludedCaseIds:
+    get:
+      summary: Lists IDs of excluded cases for a specified source
+      tags: [Case]
+      operationId: listExcludedCaseIds
+      parameters:
+        - name: sourceId
+          in: query
+          description: ID of source to filter out only excluded cases from.
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-f\d]{24}$'
+        - name: dateFrom
+          in: query
+          description: Start date for excluded cases lookup
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: dateTo
+          in: query
+          description: Start date for excluded cases lookup
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          $ref: "#/components/responses/200CaseIdsArray"
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+        "422":
+          $ref: "#/components/responses/422"
+        "500":
+          $ref: "#/components/responses/500"
 components:
   schemas:
     Parser:
@@ -1390,6 +1428,15 @@ components:
             $ref: "#/components/schemas/Case"
       required:
         - cases
+    CaseIdsArray:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            type: string
+      required:
+        - cases
     SymptomArray:
       type: object
       properties:
@@ -1660,6 +1707,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/CaseArray"
+    "200CaseIdsArray":
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CaseIdsArray"
     "200CasesDownload":
       description: OK
       content:

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -353,4 +353,27 @@ export default class CasesController {
             res.status(500).send(err);
         }
     };
+
+    /**
+     * batchStatusChange forwards the query to the data service.
+     * It does set the curator in the request to the data service based on the
+     * currently logged-in user.
+     */
+    listExcludedCaseIds = async (
+        req: Request,
+        res: Response,
+    ): Promise<void> => {
+        try {
+            const response = await axios.get(
+                this.dataServerURL + '/api' + req.url,
+            );
+            res.status(response.status).json(response.data);
+        } catch (err) {
+            if (err.response?.status && err.response?.data) {
+                res.status(err.response.status).send(err.response.data);
+                return;
+            }
+            res.status(500).send(err);
+        }
+    };
 }

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -312,6 +312,9 @@ new EmailClient(env.EMAIL_USER_ADDRESS, env.EMAIL_USER_PASSWORD)
         apiRouter.post('/geocode/seed', geocodeProxy.seed);
         apiRouter.post('/geocode/clear', geocodeProxy.clear);
 
+        // Forward excluded case IDs fetching to data service
+        apiRouter.get('/excludedCaseIds', casesController.listExcludedCaseIds);
+
         app.use('/api', apiRouter);
 
         // Basic health check handler.


### PR DESCRIPTION
Closes #1374.

This is the final part of the bigger task: #1013. This PR introduces handling of case exclusion in the parsing process (via `parsing_lib`).

Checklist:

- [x] Retrieve excluded cases by `sourceId`
- [x] Allow filtering of excluded cases retrieval by date limits
- [x] Add unit tests
- [x] Review internally (HTD)