### PR TITLE
add UUIDs to Mexico parser

### DIFF
--- a/ingestion/functions/parsing/mexico/mexico.py
+++ b/ingestion/functions/parsing/mexico/mexico.py
@@ -163,7 +163,10 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
         for row in reader:
             try:
                 case = {
-                    "caseReference": {"sourceId": source_id, "sourceUrl": source_url},
+                    "caseReference": {
+                        "sourceId": source_id, 
+                        "sourceUrl": source_url,
+                        "sourceEntryId": row["ID_REGISTRO"]},
                     "location": convert_location(
                         row["ENTIDAD_RES"], row["MUNICIPIO_RES"]
                     ),

--- a/ingestion/functions/parsing/mexico/mexico_test.py
+++ b/ingestion/functions/parsing/mexico/mexico_test.py
@@ -6,7 +6,7 @@ from mexico import mexico
 _SOURCE_ID = "abc123"
 _SOURCE_URL = "https://mex.ico"
 _PARSED_CASE = {
-    "caseReference": {"sourceId": "abc123", "sourceUrl": "https://mex.ico"},
+    "caseReference": {"sourceId": "abc123", "sourceUrl": "https://mex.ico", "sourceEntryId": "147685"},
     "location": {'query': 'ATIZAPÁN DE ZARAGOZA, MÉXICO, MÉXICO'},
     "events": [
         {


### PR DESCRIPTION
This PR adds `ID_REGISTRO` as the UUID for the Mexico parser.