### PR TITLE
Deal with non-standard date format

### DIFF
--- a/ingestion/functions/parsing/germany/germany.py
+++ b/ingestion/functions/parsing/germany/germany.py
@@ -31,7 +31,7 @@ def convert_date(raw_date):
     """
     Convert raw date field into a value interpretable by the dataserver.
     """
-    date = datetime.strptime(raw_date, "%Y/%m/%d %H:%M:%S")
+    date = datetime.strptime(raw_date.split(" ")[0], "%Y/%m/%d")
     return date.strftime("%m/%d/%YZ")
 
 


### PR DESCRIPTION
This should solve [ERROR] ValueError: Unhandled data: time data '2020/11/23 0' does not match format '%Y/%m/%d %H:%M:%S'

Also will make the parser more resistant to future errors.