### PR TITLE
Ingestion chunking [partial fix for #1434]

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -171,6 +171,10 @@ def retrieve_content_csv(
             chunk_n += 1
             content = text_stream.read(chunk_bytes)
 
+        if unwritten_chunk:
+            with codecs.open(f"/tmp/{key_filename_part}.{chunk_n}", "w", 'utf-8') as outfile:
+                outfile.write(unwritten_chunk)
+
         return chunk_s3
     except requests.exceptions.RequestException as e:
         upload_error = (
@@ -184,7 +188,7 @@ def retrieve_content_csv(
 
 
 def retrieve_content(
-        env, source_id, upload_id, url, source_format, api_headers, cookies):
+        env, source_id, upload_id, url, source_format, api_headers, cookies, chunk_bytes=CSV_CHUNK_BYTES):
     """ Retrieves and locally persists the content at the provided URL. """
     try:
         if (
@@ -197,7 +201,7 @@ def retrieve_content(
                 source_id, upload_id, api_headers, cookies)
         if source_format == "CSV":
             return retrieve_content_csv(env, source_id, upload_id, url,
-                                        api_headers, cookies)
+                                        api_headers, cookies, chunk_bytes=chunk_bytes)
         print(f"Downloading {source_format} content from {url}")
         headers = {"user-agent": "GHDSI/1.0 (http://ghdsi.org)"}
         r = requests.get(url, headers=headers)

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -109,7 +109,7 @@ def retrieve_content(
         if (
             source_format != "JSON"
             and source_format != "CSV"
-            and source_format != "XSLX"):
+            and source_format != "XLSX"):
             e = ValueError(f"Unsupported source format: {source_format}")
             common_lib.complete_with_error(
                 e, env, common_lib.UploadError.SOURCE_CONFIGURATION_ERROR,

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -263,10 +263,10 @@ def test_retrieve_content_returns_local_and_s3_object_names(requests_mock):
     source_id = "id"
     content_url = "http://foo.bar/"
     requests_mock.get(content_url, json={"data": "yes"})
-    result = retrieval.retrieve_content(
+    results = retrieval.retrieve_content(
         "env", source_id, "upload_id", content_url, "JSON", {}, {})
-    assert "/tmp/" in result[0]
-    assert source_id in result[1]
+    assert all("/tmp/" in fn for fn, s3key in results)
+    assert all(source_id in s3key for fn, s3key in results)
 
 
 def test_retrieve_content_raises_error_for_non_supported_format(

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -249,13 +249,13 @@ def test_retrieve_content_persists_downloaded_csv_locally(requests_mock):
     source_id = "id"
     content_url = "http://foo.bar/"
     format = "CSV"
-    requests_mock.get(content_url, content=b"foo,bar")
+    requests_mock.get(content_url, content=b"foo,bar\nbaz,quux")
     retrieval.retrieve_content(
         "env", source_id, "upload_id", content_url, format, {}, {})
     assert requests_mock.request_history[0].url == content_url
     assert "GHDSI" in requests_mock.request_history[0].headers["user-agent"]
     with open("/tmp/content.csv", "r") as f:
-        assert f.read() == "foo,bar"
+        assert f.read() == "foo,bar\nbaz,quux"
 
 
 def test_retrieve_content_returns_local_and_s3_object_names(requests_mock):

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -254,7 +254,7 @@ def test_retrieve_content_persists_downloaded_csv_locally(requests_mock):
         "env", source_id, "upload_id", content_url, format, {}, {})
     assert requests_mock.request_history[0].url == content_url
     assert "GHDSI" in requests_mock.request_history[0].headers["user-agent"]
-    with open("/tmp/content.csv", "r") as f:
+    with open("/tmp/content.csv.0", "r") as f:
         assert f.read() == "foo,bar\nbaz,quux"
 
 


### PR DESCRIPTION
This PR adds chunking support for CSV files to solve the backfill issue. Other file types (currently JSON and XLSX) are not chunked.

* Change return type of `retrieve_content()`. `retrieve_content()` now returns list of `(filename, s3 object key)`
    tuples instead of a single tuple corresponding to the chunks. Only for CSVs, `retrieve_content_csv()` is called which performs chunking, with each chunk limited to `CSV_CHUNK_BYTES`. No chunking is performed for JSON and XLSX.
 * `invoke_parser()` is called in a loop with the s3 object keys.
 
What's the best practice to test the output of retrieval_content_csv()? Currently there are no content tests (such as checking filetype). As I see it, one would need to have a fake local URL to pass to requests. Any pointers welcome!

Also, what happens if one particular chunk fails at some stage, say uploading to S3. Do we get missing data for that day? How would we know of this failure?

Currently CSV_CHUNK_BYTES is set to 100 MB. We need to test whether this is an appropriate value. @AnyaLindstromBattle mentioned S3 processing being variable speed, so we would need to adjust this.
