### PR TITLE
remove deprecated data export

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,3 +1,0 @@
-# Export of linelist data
-
-Please refer to the [documentation of the export job](/data-serving/scripts/export-data/README.md).


### PR DESCRIPTION
Remove data export from deprecated workflow. This workflow had been failing for a long time before being put on pause due to the data becoming too big for the job to complete.

Full data is now stored on S3, and requires acceptance of TOS and PP for access.