### PR TITLE
1508 - Fix text field alignment on email signup form

### DIFF
--- a/verification/curator-service/ui/src/components/landing-page/LandingPage.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/LandingPage.tsx
@@ -58,7 +58,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     emailField: {
         display: 'block',
         width: '240px',
-        marginBottom: '15px',
+    },
+    divider: {
+        marginTop: '15px',
     },
     signInButton: {
         margin: '15px 0',
@@ -351,6 +353,7 @@ export default function LandingPage({
                     isSubmitting={isSubmitting}
                     classes={{
                         emailField: classes.emailField,
+                        divider: classes.divider,
                         loader: classes.loader,
                         signInButton: classes.signInButton,
                     }}

--- a/verification/curator-service/ui/src/components/landing-page/SignInForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/SignInForm.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { Formik, Form, Field } from 'formik';
-import { TextField, CheckboxWithLabel } from 'formik-material-ui';
-import { FormHelperText, LinearProgress, Button } from '@material-ui/core';
+import { Formik, Form, Field, FieldProps } from 'formik';
+import { CheckboxWithLabel } from 'formik-material-ui';
+import {
+    FormHelperText,
+    LinearProgress,
+    Button,
+    TextField,
+} from '@material-ui/core';
 
 interface Props {
     handleSubmit: (email: string, resetForm: () => void) => void;
@@ -10,7 +15,12 @@ interface Props {
     isSubmitting: boolean;
     isAgreementChecked: boolean;
     isAgreementMessage: boolean;
-    classes: { emailField: any; loader: any; signInButton: any };
+    classes: {
+        emailField: any;
+        divider: any;
+        loader: any;
+        signInButton: any;
+    };
 }
 
 interface FormValues {
@@ -53,16 +63,30 @@ export default function SignInForm({
         >
             {({ errors, touched, submitForm }) => (
                 <Form>
-                    <Field
-                        className={classes.emailField}
-                        variant="outlined"
-                        fullWidth={true}
-                        component={TextField}
-                        disabled={isSubmitting}
-                        name="email"
-                        type="email"
-                        label="Email"
-                    />
+                    <Field name="email">
+                        {({ field, meta }: FieldProps<FormValues>) => (
+                            <>
+                                <TextField
+                                    className={classes.emailField}
+                                    label="Email"
+                                    type="email"
+                                    variant="outlined"
+                                    disabled={isSubmitting}
+                                    error={
+                                        meta.error !== undefined && meta.touched
+                                    }
+                                    fullWidth
+                                    {...field}
+                                />
+                                {meta.touched && meta.error && (
+                                    <FormHelperText error>
+                                        {meta.error}
+                                    </FormHelperText>
+                                )}
+                            </>
+                        )}
+                    </Field>
+                    <div className={classes.divider} />
                     <Field
                         component={CheckboxWithLabel}
                         type="checkbox"

--- a/verification/curator-service/ui/src/components/landing-page/VerificationCodeForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/VerificationCodeForm.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { Formik, Form, Field } from 'formik';
-import { TextField } from 'formik-material-ui';
-import { FormHelperText, LinearProgress, Button } from '@material-ui/core';
+import { Formik, Form, Field, FieldProps } from 'formik';
+import {
+    FormHelperText,
+    LinearProgress,
+    Button,
+    TextField,
+} from '@material-ui/core';
 
 interface Props {
     handleSubmit: (code: string) => void;
@@ -42,16 +46,31 @@ export default function VerificationCodeForm({
         >
             {({ submitForm }) => (
                 <Form>
-                    <Field
-                        className={classes.emailField}
-                        variant="outlined"
-                        fullWidth={true}
-                        component={TextField}
-                        disabled={isSubmitting}
-                        name="code"
-                        type="text"
-                        label="Verification code"
-                    />
+                    <Field name="code">
+                        {({ field, meta }: FieldProps<FormProps>) => (
+                            <>
+                                <TextField
+                                    className={classes.emailField}
+                                    label="Verification code"
+                                    type="text"
+                                    variant="outlined"
+                                    disabled={isSubmitting}
+                                    error={
+                                        (meta.error !== undefined &&
+                                            meta.touched) ||
+                                        wrongCodeMessage
+                                    }
+                                    fullWidth
+                                    {...field}
+                                />
+                                {meta.touched && meta.error && (
+                                    <FormHelperText error>
+                                        {meta.error}
+                                    </FormHelperText>
+                                )}
+                            </>
+                        )}
+                    </Field>
                     {wrongCodeMessage && (
                         <FormHelperText error>
                             Wrong verification code entered


### PR DESCRIPTION
Bugs fixed:

- [x] Fix text field alignment on email signup form (crops a bit at the bottom)

Screenshots: 

<img width="839" alt="Screen Shot 2021-02-08 at 13 20 27" src="https://user-images.githubusercontent.com/44740625/107218830-7632e500-6a10-11eb-8176-624a98be66b1.png">

<img width="609" alt="Screen Shot 2021-02-08 at 13 20 46" src="https://user-images.githubusercontent.com/44740625/107218834-78953f00-6a10-11eb-809b-39b01b07ff57.png">
