### PR TITLE
1537 Apply search filters automatically after delay

### DIFF
--- a/verification/curator-service/ui/src/components/App.tsx
+++ b/verification/curator-service/ui/src/components/App.tsx
@@ -356,7 +356,6 @@ export default function App(): JSX.Element {
         setCreateNewButtonAnchorEl,
     ] = useState<Element | null>();
     const [selectedMenuIndex, setSelectedMenuIndex] = React.useState<number>();
-    const [searchLoading, setSearchLoading] = React.useState<boolean>(false);
     const [listPage, setListPage] = React.useState<number>(0);
     const [listPageSize, setListPageSize] = React.useState<number>(50);
     const [searchQuery, setSearchQuery] = React.useState<string>('');
@@ -510,14 +509,12 @@ export default function App(): JSX.Element {
                             <>
                                 <div className={classes.searchBar}>
                                     <SearchBar
-                                        searchQuery={location.search ?? ''}
                                         onSearchChange={(searchQuery): void => {
                                             history.push({
                                                 pathname: '/cases',
                                                 search: searchQuery,
                                             });
                                         }}
-                                        loading={searchLoading}
                                         rootComponentRef={rootRef}
                                     ></SearchBar>
                                 </div>
@@ -695,7 +692,6 @@ export default function App(): JSX.Element {
                             <Route exact path="/cases">
                                 <LinelistTable
                                     user={user}
-                                    setSearchLoading={setSearchLoading}
                                     page={listPage}
                                     pageSize={listPageSize}
                                     onChangePage={setListPage}

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -106,7 +106,6 @@ interface Props
     extends RouteComponentProps<never, never, LocationState>,
         WithStyles<typeof styles> {
     user: User;
-    setSearchLoading: (a: boolean) => void;
     page: number;
     pageSize: number;
 
@@ -895,7 +894,6 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 listUrl += '&q=' + this.state.searchQuery;
                             }
                             this.setState({ isLoading: true, error: '' });
-                            this.props.setSearchLoading(true);
                             const response = axios.get<ListResponse>(listUrl);
 
                             response
@@ -984,7 +982,6 @@ class LinelistTable extends React.Component<Props, LinelistTableState> {
                                 })
                                 .finally(() => {
                                     this.setState({ isLoading: false });
-                                    this.props.setSearchLoading(false);
                                 });
                         })
                     }

--- a/verification/curator-service/ui/src/components/SearchBar.tsx
+++ b/verification/curator-service/ui/src/components/SearchBar.tsx
@@ -84,7 +84,7 @@ export default function SearchBar({
 
     const guideButtonRef = React.useRef<HTMLButtonElement>(null);
 
-    // Set search query debounce to 2000ms
+    // Set search query debounce to 1000ms
     const debouncedSearch = useDebounce(search, 1000);
 
     // Apply filter parameters after delay

--- a/verification/curator-service/ui/src/hooks/useDebounce.tsx
+++ b/verification/curator-service/ui/src/hooks/useDebounce.tsx
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react';
+
+// Custom hook for debouncing
+export const useDebounce = (value: string, delay: number) => {
+    const [debouncedValue, setDebouncedValue] = useState(value);
+
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => clearTimeout(handler);
+    }, [value, delay]);
+
+    return debouncedValue;
+};


### PR DESCRIPTION
**Changes**

* When search query is typed into SearchBar filters are automatically applied after given duration (1 second for now)
* Created custom hook `useDebounce`
* Stopped setting SearchBar as disabled when data is loading