### PR TITLE
1488 large data ingestion

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -315,7 +315,7 @@ def format_source_url(url: str) -> str:
     return url
 
 
-def lambda_handler(event, context):
+def lambda_handler(event, context, tempdir=EFS_PATH):
     """Global ingestion retrieval function.
 
     Parameters
@@ -331,6 +331,10 @@ def lambda_handler(event, context):
         Lambda Context runtime methods and attributes.
         For more information, see:
           https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html
+
+    tempdir: str, optional
+        Temporary folder to store retrieve content in. Should be /tmp for test runs
+        and EFS_PATH for actual runs (the default)
 
     Returns
     ------
@@ -353,7 +357,7 @@ def lambda_handler(event, context):
         env, source_id, upload_id, auth_headers, cookies)
     url = format_source_url(url)
     file_names_s3_object_keys = retrieve_content(
-        env, source_id, upload_id, url, source_format, auth_headers, cookies)
+        env, source_id, upload_id, url, source_format, auth_headers, cookies, tempdir=tempdir)
     for file_name, s3_object_key in file_names_s3_object_keys:
         upload_to_s3(file_name, s3_object_key, env,
                      source_id, upload_id, auth_headers, cookies)

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -4,7 +4,6 @@ import json
 import mimetypes
 import os
 import sys
-import csv
 import tempfile
 import zipfile
 from chardet import detect
@@ -14,6 +13,7 @@ import requests
 
 from datetime import datetime, timezone
 
+EFS_PATH = "/mnt/efs"
 ENV_FIELD = "env"
 OUTPUT_BUCKET = "epid-sources-raw"
 SOURCE_ID_FIELD = "sourceId"
@@ -85,14 +85,14 @@ def get_source_details(env, source_id, upload_id, api_headers, cookies):
             api_headers, cookies)
 
 
-def raw_content(url: str, content: bytes) -> io.BytesIO:
+def raw_content(url: str, content: bytes, tempdir: str = EFS_PATH) -> io.BytesIO:
     # Detect the mimetype of a given URL.
     print(f'Guessing mimetype of {url}')
     mimetype, _ = mimetypes.guess_type(url)
     if mimetype == "application/zip":
         print('File seems to be a zip file, decompressing it now')
         # Writing the zip file to temp dir.
-        with tempfile.NamedTemporaryFile("wb", delete=False) as temp:
+        with tempfile.NamedTemporaryFile("wb", delete=False, dir=tempdir) as temp:
             temp.write(content)
             temp.flush()
             # Opening the zip file, extracting its first file.
@@ -106,7 +106,7 @@ def raw_content(url: str, content: bytes) -> io.BytesIO:
 
 
 def retrieve_content_csv(
-        env, source_id, upload_id, url, api_headers, cookies, chunk_bytes=CSV_CHUNK_BYTES, header=True):
+        env, source_id, upload_id, url, api_headers, cookies, chunk_bytes=CSV_CHUNK_BYTES, header=True, tempdir=EFS_PATH):
     """ Retrieves and locally persists the content in CSV format at the provided URL.
 
     This method chunks the CSV file to avoid timeouts in the ingestion functions.
@@ -127,7 +127,7 @@ def retrieve_content_csv(
         # sources.
         # Make the encoding of retrieved content consistent (UTF-8) for all
         # parsers as per https://github.com/globaldothealth/list/issues/867.
-        bytesio = raw_content(url, r.content)
+        bytesio = raw_content(url, r.content, tempdir)
         print('detecting encoding of retrieved content.')
         # Read 2MB to be quite sure about the encoding.
         detected_enc = detect(bytesio.read(2 << 20))
@@ -158,7 +158,7 @@ def retrieve_content_csv(
         chunk_s3 = []
         while content:
             lines = content.split("\n")
-            with codecs.open(f"/tmp/{key_filename_part}.{chunk_n}", "w", 'utf-8') as outfile:
+            with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=tempdir) as outfile:
                 if csv_header:
                     outfile.write(csv_header)
                 outfile.write(unwritten_chunk + "\n".join(lines[:-1]) + "\n")
@@ -172,7 +172,7 @@ def retrieve_content_csv(
             content = text_stream.read(chunk_bytes)
 
         if unwritten_chunk:
-            with codecs.open(f"/tmp/{key_filename_part}.{chunk_n}", "w", 'utf-8') as outfile:
+            with codecs.open(outfile.name, "w", 'utf-8') as outfile:
                 outfile.write(unwritten_chunk)
 
         return chunk_s3
@@ -188,7 +188,7 @@ def retrieve_content_csv(
 
 
 def retrieve_content(
-        env, source_id, upload_id, url, source_format, api_headers, cookies, chunk_bytes=CSV_CHUNK_BYTES):
+        env, source_id, upload_id, url, source_format, api_headers, cookies, chunk_bytes=CSV_CHUNK_BYTES, tempdir=EFS_PATH):
     """ Retrieves and locally persists the content at the provided URL. """
     try:
         if (
@@ -201,7 +201,7 @@ def retrieve_content(
                 source_id, upload_id, api_headers, cookies)
         if source_format == "CSV":
             return retrieve_content_csv(env, source_id, upload_id, url,
-                                        api_headers, cookies, chunk_bytes=chunk_bytes)
+                                        api_headers, cookies, chunk_bytes=chunk_bytes, tempdir=tempdir)
         print(f"Downloading {source_format} content from {url}")
         headers = {"user-agent": "GHDSI/1.0 (http://ghdsi.org)"}
         r = requests.get(url, headers=headers)
@@ -215,13 +215,13 @@ def retrieve_content(
         # sources.
         # Make the encoding of retrieved content consistent (UTF-8) for all
         # parsers as per https://github.com/globaldothealth/list/issues/867.
-        bytesio = raw_content(url, r.content)
+        bytesio = raw_content(url, r.content, tempdir)
         print('detecting encoding of retrieved content.')
         # Read 2MB to be quite sure about the encoding.
         detected_enc = detect(bytesio.read(2 << 20))
         bytesio.seek(0)
         print(f'Source encoding is presumably {detected_enc}')
-        with codecs.open(f"/tmp/{key_filename_part}", "w", 'utf-8') as outfile:
+        with tempfile.NamedTemporaryFile("w", encoding='utf-8', delete=False, dir=tempdir) as outfile:
             text_stream = codecs.getreader(detected_enc['encoding'])(bytesio)
             # Write the output file as utf-8 in chunks because decoding the
             # whole data in one shot becomes really slow with big files.
@@ -253,6 +253,7 @@ def upload_to_s3(
             file_name, OUTPUT_BUCKET, s3_object_key)
         print(
             f"Uploaded source content to s3://{OUTPUT_BUCKET}/{s3_object_key}")
+        os.unlink(file_name)
     except Exception as e:
         common_lib.complete_with_error(
             e, env, common_lib.UploadError.INTERNAL_ERROR, source_id, upload_id,

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -236,11 +236,11 @@ def test_retrieve_content_persists_downloaded_json_locally(requests_mock):
     content_url = "http://foo.bar/"
     format = "JSON"
     requests_mock.get(content_url, json={"data": "yes"})
-    retrieval.retrieve_content(
+    files_s3_keys = retrieval.retrieve_content(
         "env", source_id, "upload_id", content_url, format, {}, {}, tempdir="/tmp")
     assert requests_mock.request_history[0].url == content_url
     assert "GHDSI" in requests_mock.request_history[0].headers["user-agent"]
-    with open("/tmp/content.json", "r") as f:
+    with open(files_s3_keys[0][0], "r") as f:
         assert json.load(f)["data"] == "yes"
 
 

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -77,7 +77,7 @@ def test_format_url(mock_today):
 
 
 def test_lambda_handler_e2e(valid_event, requests_mock, s3,
-                            mock_source_api_url_fixture):
+                            mock_source_api_url_fixture, tempdir="/tmp"):
     from retrieval import retrieval  # Import locally to avoid superseding mock
 
     # Mock/stub retrieving credentials, invoking the parser lambda, and S3.
@@ -113,7 +113,7 @@ def test_lambda_handler_e2e(valid_event, requests_mock, s3,
     # Mock the request to retrieve source content.
     requests_mock.get(origin_url, json={"data": "yes"})
 
-    response = retrieval.lambda_handler(valid_event, "")
+    response = retrieval.lambda_handler(valid_event, "", tempdir=tempdir)
 
     common_lib.obtain_api_credentials.assert_called_once()
     retrieval.invoke_parser.assert_called_once_with(

--- a/ingestion/functions/template.yaml
+++ b/ingestion/functions/template.yaml
@@ -11,6 +11,11 @@ Globals:
     Layers:
       - !Ref CommonLibLayer
 
+Parameters:
+  EFSpath:
+    Type: String
+    Default: /mnt/efs
+
 Resources:
   RawSourcesBucket:
     Type: AWS::S3::Bucket
@@ -23,9 +28,14 @@ Resources:
       Handler: retrieval.lambda_handler
       Description: Retrieve raw source content
       MemorySize: 2048
+      FileSystemConfigs:
+        - Arn: covid19DataIngestionEFS
+          LocalMountPath: !Ref EFSpath
       # Function's execution role
       Policies:
         - AWSLambdaFullAccess
+        - AWSLambdaVPCAccessExecutionRole
+        - AmazonElasticFileSystemClientReadWriteAccess
         - S3WritePolicy:
             BucketName: !Ref RawSourcesBucket
   ParsingLibLayer:


### PR DESCRIPTION
This PR adds large file ingestion support by saving temporary files to a EFS volume which is attached to the retrieval function.

**Note**: At the moment tests **do not** check whether the EFS is mounted properly, as I wasn't sure whether that would work in the Github CI environment. There is a `tempdir` parameter that controls where temporary files are saved that is set to `/tmp` for Github CI.