### PR TITLE
Hard-code USA location

### DIFF
--- a/ingestion/functions/parsing/USA/USA.py
+++ b/ingestion/functions/parsing/USA/USA.py
@@ -142,7 +142,13 @@ def parse_cases(raw_data_file: str, source_id: str, source_url: str):
                     case = {
                         "caseReference": {"sourceId": source_id, "sourceUrl": source_url},
                         "location": {
-                            "query": "United States"
+                            "country": "United States",
+                            "geoResolution": "Point",
+                            "name": "United States",
+                            "geometry": {
+                                "latitude": 37.0902,
+                                "longitude": 95.7129
+                            }
                         },
                         "events": convert_events(
                             row[_DATE_CONFIRMED],

--- a/ingestion/functions/parsing/USA/USA_test.py
+++ b/ingestion/functions/parsing/USA/USA_test.py
@@ -22,7 +22,15 @@ class USATest(unittest.TestCase):
                     "sourceId": "abc123",
                     "sourceUrl": "https://data.cdc.gov/api/views/vbim-akqf/rows.csv?accessType=DOWNLOAD",
                 },
-                "location": {"query": "United States"},
+                "location": {
+                    "country": "United States",
+                    "geoResolution": "Point",
+                    "name": "United States",
+                    "geometry": {
+                        "latitude": 37.0902,
+                        "longitude": 95.7129
+                    }
+                },
                 "events": [
                     {
                         "name": "confirmed",


### PR DESCRIPTION
using 'query: Unites States' in mapbox was returning Cloud, Cloud, Kansas. We want only United States to be the name. 