### PR TITLE
No location in travel history

### DIFF
--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -803,11 +803,7 @@ components:
                                     dateRange:
                                         $ref: '#/components/schemas/DateRange'
                                     location:
-                                        description: A location object, or the string "unknown".
-                                        oneOf:
-                                            - $ref: '#/components/schemas/Location'
-                                            - type: string
-                                              enum: [ unknown ]
+                                        $ref: '#/components/schemas/FuzzyLocation'
                                     purpose:
                                         type: string
                                         enum:
@@ -966,6 +962,56 @@ components:
                     required:
                         - latitude
                         - longitude
+        FuzzyLocation:
+            description: A geo location that can be unspecific. It may not be geocoded if it lacks information.
+            type: object
+            properties:
+                country:
+                    type: string
+                    description: English full name of a country
+                    example: Costa Rica
+                administrativeAreaLevel1:
+                    type: string
+                    description: First administrative subdivision of a country
+                    example: Any province in Costa Rica
+                administrativeAreaLevel2:
+                    type: string
+                    description: Second administrative subdivision of a country
+                    example: Any canton in Costa Rica
+                administrativeAreaLevel3:
+                    type: string
+                    description: Third administrative subdivision of a country
+                    example: Any district in Costa Rica
+                place:
+                    type: string
+                    description: Name of the place this location refers to
+                    example: Boston Children's Hospital
+                name:
+                    type: string
+                    description: >
+                        Full name of the location
+                    example: Lyon, Auvergne-Rhône-Alpes, France
+                geoResolution:
+                    type: string
+                    description: How granular the location is
+                    enum:
+                        - undefined
+                        - Point
+                        - Admin3
+                        - Admin2
+                        - Admin1
+                        - Country
+                geometry:
+                    type: object
+                    properties:
+                        latitude:
+                            type: number
+                            minimum: -90
+                            maximum: 90
+                        longitude:
+                            type: number
+                            minimum: -180
+                            maximum: 180
         Curator:
             description: The logged-in user who submitted the case.
             type: object

--- a/data-serving/data-service/api/openapi.yaml
+++ b/data-serving/data-service/api/openapi.yaml
@@ -803,7 +803,11 @@ components:
                                     dateRange:
                                         $ref: '#/components/schemas/DateRange'
                                     location:
-                                        $ref: '#/components/schemas/Location'
+                                        description: A location object, or the string "unknown".
+                                        oneOf:
+                                            - $ref: '#/components/schemas/Location'
+                                            - type: string
+                                              enum: [ unknown ]
                                     purpose:
                                         type: string
                                         enum:

--- a/data-serving/data-service/schemas/cases.schema.json
+++ b/data-serving/data-service/schemas/cases.schema.json
@@ -247,7 +247,7 @@
         "properties": {
           "travel": {
             "bsonType": "array",
-            "uniqueItems": true,
+            "uniqueItems": false,
             "items": {
               "bsonType": "object",
               "additionalProperties": false,
@@ -283,10 +283,6 @@
                     "geometry": {
                       "bsonType": "object",
                       "additionalProperties": false,
-                      "required": [
-                        "latitude",
-                        "longitude"
-                      ],
                       "properties": {
                         "latitude": {
                           "bsonType": "number",

--- a/data-serving/data-service/src/model/location.ts
+++ b/data-serving/data-service/src/model/location.ts
@@ -47,6 +47,23 @@ export const locationSchema = new mongoose.Schema(
     { _id: false },
 );
 
+export const fuzzyLocationSchema = new mongoose.Schema(
+    {
+        country: String,
+        administrativeAreaLevel1: String,
+        administrativeAreaLevel2: String,
+        administrativeAreaLevel3: String,
+        // Place represents a precise location, such as an establishment or POI.
+        place: String,
+        // A human-readable name of the location.
+        name: String,
+        geoResolution: String,
+        geometry: geometrySchema,
+        query: String,
+    },
+    { _id: false },
+);
+
 interface Geometry {
     latitude: number;
     longitude: number;
@@ -60,6 +77,18 @@ export type LocationDocument = mongoose.Document & {
     place?: string;
     name: string;
     geoResolution: string;
+    geometry?: Geometry;
+    query?: string;
+};
+
+export type FuzzyLocationDocument = mongoose.Document & {
+    country?: string;
+    administrativeAreaLevel1?: string;
+    administrativeAreaLevel2?: string;
+    administrativeAreaLevel3?: string;
+    place?: string;
+    name?: string;
+    geoResolution?: string;
     geometry?: Geometry;
     query?: string;
 };

--- a/data-serving/data-service/src/model/travel.ts
+++ b/data-serving/data-service/src/model/travel.ts
@@ -1,12 +1,12 @@
 import { DateRangeDocument, dateRangeSchema } from './date-range';
-import { LocationDocument, locationSchema } from './location';
+import { FuzzyLocationDocument, fuzzyLocationSchema } from './location';
 
 import mongoose from 'mongoose';
 
 export const travelSchema = new mongoose.Schema(
     {
         dateRange: dateRangeSchema,
-        location: locationSchema,
+        location: fuzzyLocationSchema,
         methods: [String],
         purpose: String,
     },
@@ -15,7 +15,7 @@ export const travelSchema = new mongoose.Schema(
 
 export type TravelDocument = mongoose.Document & {
     dateRange: DateRangeDocument;
-    location: LocationDocument;
+    location: FuzzyLocationDocument;
     methods: [string];
     purpose: string;
 };

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -1103,6 +1103,30 @@ describe('PUT', () => {
 
         expect(res.body.notes).toEqual(newNotes);
     });
+    it('update present item with unknown travel locations should be 200 OK', async () => {
+        const c = new Case(minimalCase);
+        await c.save();
+
+        const travelHistory = {
+            traveledPrior30Days: true,
+            travel: [
+                {
+                    methods: ['Flight'],
+                    dateRange: {
+                        start: '2020-11-24T00:00:00.000Z',
+                        end: '2020-11-24T00:00:00.000Z',
+                    },
+                },
+            ],
+        };
+        const res = await request(app)
+            .put(`/api/cases/${c._id}`)
+            .send({ ...curatorMetadata, travelHistory })
+            .expect('Content-Type', /json/)
+            .expect(200);
+
+        expect(res.body.travelHistory).toEqual(travelHistory);
+    });
     it('update present item should result in update metadata', async () => {
         const c = new Case(minimalCase);
         await c.save();
@@ -1179,6 +1203,42 @@ describe('PUT', () => {
         const cases = await Case.find();
         expect(cases[0].notes).toEqual(newNotes);
         expect(cases[1].notes).toEqual(newNotes2);
+    });
+    it('update many items without locations in travel history should return 200 OK', async () => {
+        const c = new Case(minimalCase);
+        await c.save();
+        const c2 = new Case(minimalCase);
+        await c2.save();
+        await new Case(minimalCase).save();
+
+        const newNotes = 'abc';
+        const date = '2020-11-24T00:00:00.000Z';
+        const travelHistory = {
+            traveledPrior30Days: true,
+            travel: [
+                {
+                    methods: ['Flight'],
+                    dateRange: { start: date, end: date },
+                },
+            ],
+        };
+
+        const res = await request(app)
+            .post('/api/cases/batchUpdate')
+            .send({
+                ...curatorMetadata,
+                cases: [
+                    { _id: c._id, notes: newNotes },
+                    { _id: c2._id, travelHistory },
+                ],
+            })
+            .expect('Content-Type', /json/)
+            .expect(200);
+
+        expect(res.body.numModified).toEqual(2);
+        const cases = await Case.find();
+        expect(cases[0].notes).toEqual(newNotes);
+        expect(cases[1].travelHistory.travel[0].methods[0]).toEqual('Flight');
     });
     it('update many items without _id should return 422', async () => {
         const c = new Case(minimalCase);

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1379,11 +1379,7 @@ components:
                                     dateRange:
                                         $ref: '#/components/schemas/DateRange'
                                     location:
-                                        description: A location object, or the string "unknown".
-                                        oneOf:
-                                            - $ref: '#/components/schemas/Location'
-                                            - type: string
-                                              enum: [ unknown ]
+                                        $ref: '#/components/schemas/FuzzyLocation'
                                     purpose:
                                         type: string
                                     methods:
@@ -1678,6 +1674,56 @@ components:
                     required:
                         - latitude
                         - longitude
+        FuzzyLocation:
+            description: A geo location that can be unspecific.
+            type: object
+            properties:
+                country:
+                    type: string
+                    description: English full name of a country
+                    example: Costa Rica
+                administrativeAreaLevel1:
+                    type: string
+                    description: First administrative subdivision of a country
+                    example: Any province in Costa Rica
+                administrativeAreaLevel2:
+                    type: string
+                    description: Second administrative subdivision of a country
+                    example: Any canton in Costa Rica
+                administrativeAreaLevel3:
+                    type: string
+                    description: Third administrative subdivision of a country
+                    example: Any district in Costa Rica
+                place:
+                    type: string
+                    description: Name of the place this location refers to
+                    example: Boston Children's Hospital
+                name:
+                    type: string
+                    description: >
+                        Full name of the location
+                    example: Lyon, Auvergne-Rhône-Alpes, France
+                geoResolution:
+                    type: string
+                    description: How granular the location is
+                    enum:
+                        - undefined
+                        - Point
+                        - Admin3
+                        - Admin2
+                        - Admin1
+                        - Country
+                geometry:
+                    type: object
+                    properties:
+                        latitude:
+                            type: number
+                            minimum: -90
+                            maximum: 90
+                        longitude:
+                            type: number
+                            minimum: -180
+                            maximum: 180
         LocationArray:
             description: A list of geo locations
             type: array

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1379,7 +1379,11 @@ components:
                                     dateRange:
                                         $ref: '#/components/schemas/DateRange'
                                     location:
-                                        $ref: '#/components/schemas/Location'
+                                        description: A location object, or the string "unknown".
+                                        oneOf:
+                                            - $ref: '#/components/schemas/Location'
+                                            - type: string
+                                              enum: [ unknown ]
                                     purpose:
                                         type: string
                                     methods:


### PR DESCRIPTION
This unblocks the VoC ingestion because not all the VoC reports have detailed travel history, but it was decided that we should keep as much incomplete info as possible.