### PR TITLE
Removing longjohn from dev environment

### DIFF
--- a/data-serving/data-service/src/index.ts
+++ b/data-serving/data-service/src/index.ts
@@ -41,7 +41,8 @@ if (process.env.NODE_ENV !== 'test') {
 dotenv.config();
 const env = validateEnv();
 
-if (env.SERVICE_ENV !== 'prod') {
+const deployment_envs = ["prod", "dev"];
+if (!deployment_envs.includes(env.SERVICE_ENV)) {
     require('longjohn');
 }
 


### PR DESCRIPTION
From [data-dev logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252Fghdsi$252Fapplication/log-events/data-dev-58845ff9f7-2mjdl_default_data-042226c72ddc14d690c5acad6a597263453b7ae12474530b198ce6ab69d8ce70$3Fstart$3D1619014800000$26end$3D1619015100000) while running Estonia ingestion "Longjohn is known to cause CPU usage due to its extensive data collection during runtime"

[Longjohn] puts a lot of strain on V8's garbage collector and can greatly slow down heavily-loaded applications
https://www.npmjs.com/package/longjohn#production-use