### PR TITLE
Use the value of excluded cases returned by the backend

### DIFF
--- a/ingestion/functions/common/parsing_lib.py
+++ b/ingestion/functions/common/parsing_lib.py
@@ -88,7 +88,8 @@ def retrieve_excluded_case_ids(source_id: str, date_filter: Dict, date_range: Di
     res = requests.get(excluded_case_ids_endpoint_url)
     if res and res.status_code == 200:
         res_json = res.json()
-        res_json["cases"]
+        return res_json["cases"]
+    return None
 
 def prepare_cases(cases: Generator[Dict, None, None], upload_id: str, excluded_case_ids: list):
     """


### PR DESCRIPTION
I noticed that the list returned by the API is never used (and the tests mock this function so hadn't picked up on that)