### PR TITLE
geocoding: Pass database to AdminsFetcher

### DIFF
--- a/aws/location.yaml
+++ b/aws/location.yaml
@@ -30,6 +30,8 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
           env:
+            - name: DB
+              value: covid19
             - name: DB_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
@@ -90,6 +92,8 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
           env:
+            - name: DB
+              value: covid19
             - name: DB_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:

--- a/geocoding/location-service/src/app/main.py
+++ b/geocoding/location-service/src/app/main.py
@@ -36,7 +36,7 @@ if 'MAPBOX_TOKEN' in environ:
     if 'DB_CONNECTION_STRING' in environ:
         mongo_client = pymongo.MongoClient(environ['DB_CONNECTION_STRING'])
     rate_limit = int(environ.get('MAPBOX_GEOCODE_RATE_LIMIT_PER_MIN', 600))
-    admins_fetcher = AdminsFetcher(access_token, mongo_client, rate_limit=rate_limit)
+    admins_fetcher = AdminsFetcher(access_token, mongo_client[environ['DB']], rate_limit=rate_limit)
     mapbox_geocoder = Geocoder(access_token, admins_fetcher, rate_limit=rate_limit)
     geocoders.append(mapbox_geocoder)
 


### PR DESCRIPTION
Pass database from DB environment variable to AdminsFetcher
instead of the client, which raises an exception because
.find_one() gets called on a database instead of a collection
in admins_fetcher.py:47
