### PR TITLE
ingestion: Fix reauthentication during finalize_upload()

### DIFF
--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -77,9 +77,7 @@ def finalize_upload(
                        json=update,
                        headers=headers,
                        cookies=cookies)
-    if not res or res.status_code != 200:
-        raise RuntimeError(
-            f'Error updating upload record, status={res.status_code}, response={res.text}')
+    return res.status_code, res.text
 
 
 def complete_with_error(

--- a/ingestion/functions/common/common_lib_test.py
+++ b/ingestion/functions/common/common_lib_test.py
@@ -92,9 +92,8 @@ def test_finalize_upload_raises_error_for_failed_request(
         update_upload_url,
         [{"status_code": 500}])
 
-    try:
-        common_lib.finalize_upload("env", _SOURCE_ID, upload_id, {}, {}, 42, 0)
-    except RuntimeError:
+    status, _ = common_lib.finalize_upload("env", _SOURCE_ID, upload_id, {}, {}, 42, 0)
+    if status == 500:
         assert len(requests_mock.request_history) == 1
         assert requests_mock.request_history[0].url == update_upload_url
         return


### PR DESCRIPTION
This updates the fix in 1b0659347624eae79692ebb1baf2dd488c9ef7d6

In a nested try-except the outer exception is always called, but
we do not want to raise an exception for a 401.

This changes the return type of common_lib.finalize_upload() to a
tuple of (status, text) that is checked in parsing_lib which
raises a RuntimeError if required.
