### PR TITLE
retrieval: Use awsLambdaArn before #1880 is fixed

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -78,7 +78,7 @@ def get_source_details(env, source_id, upload_id, api_headers, cookies):
             return api_json["origin"]["url"], api_json["format"], api_json.get(
                 "automation", {}).get(
                 "parser", {}).get(
-                "awsBatchJobDefinitionArn", ""), api_json.get(
+                "awsLambdaArn", ""), api_json.get(
                 'dateFilter', {})
         upload_error = (
             common_lib.UploadError.SOURCE_CONFIGURATION_NOT_FOUND

--- a/ingestion/functions/retrieval/retrieval_test.py
+++ b/ingestion/functions/retrieval/retrieval_test.py
@@ -103,7 +103,7 @@ def test_e2e(valid_event, requests_mock, mock_source_api_url_fixture, tempdir="/
     requests_mock.get(
         full_source_url,
         json={"origin": {"url": origin_url, "license": "MIT"}, "format": "JSON",
-              "automation": {"parser": {"awsBatchJobDefinitionArn": "example.example"}},
+              "automation": {"parser": {"awsLambdaArn": "example.example"}},
               "dateFilter": date_filter})
 
     # Mock the request to retrieve source content.
@@ -179,7 +179,7 @@ def test_get_source_details_returns_parser_arn_if_present(
         f"{_SOURCE_API_URL}/sources/{source_id}",
         json={"origin": {"url": content_url, "license": "MIT"},
               "format": "JSON",
-              "automation": {"parser": {"awsBatchJobDefinitionArn": job_def_arn}}})
+              "automation": {"parser": {"awsLambdaArn": job_def_arn}}})
     result = retrieval.get_source_details(
         "env", source_id, "upload_id", {}, {})
     assert result[2] == job_def_arn


### PR DESCRIPTION
Relates to #1881, which is blocked by #1880
