### PR TITLE
Ensure pymongo knows how to authenticate

### DIFF
--- a/geocoding/location-service/poetry.lock
+++ b/geocoding/location-service/poetry.lock
@@ -508,7 +508,7 @@ locale = ["Babel (>=1.3)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "dd6601b9dba0b35b811e409eb236334b30a849403358321c1acc90b03cbf74a6"
+content-hash = "b0698169c2b88c1b840bf7447c498f51b372b89a37d9b73487b39d438d0d459c"
 
 [metadata.files]
 atomicwrites = [

--- a/geocoding/location-service/src/app/admins_fetcher.py
+++ b/geocoding/location-service/src/app/admins_fetcher.py
@@ -10,7 +10,7 @@ class AdminsFetcher:
     def __init__(self, access_token, db, rate_limit=600):
         self.rate_limit = ratelimiter.RateLimiter(max_calls=rate_limit, period=60)
         self.access_token = access_token
-        self.admins = db['admins']
+        self.admins = db.get_collection('admins')
         self.cache = LRU(500)
 
     def fill_admins(self, geocode):

--- a/geocoding/location-service/src/app/main.py
+++ b/geocoding/location-service/src/app/main.py
@@ -34,7 +34,7 @@ if 'MAPBOX_TOKEN' in environ:
     access_token = environ['MAPBOX_TOKEN']
     mongo_client = None
     if 'DB_CONNECTION_STRING' in environ:
-        mongo_client = pymongo.MongoClient(environ['DB_CONNECTION_STRING'])
+        mongo_client = pymongo.MongoClient(environ['DB_CONNECTION_STRING'], appname='location-service', authSource='admin')
     rate_limit = int(environ.get('MAPBOX_GEOCODE_RATE_LIMIT_PER_MIN', 600))
     admins_fetcher = AdminsFetcher(access_token, mongo_client[environ['DB']], rate_limit=rate_limit)
     mapbox_geocoder = Geocoder(access_token, admins_fetcher, rate_limit=rate_limit)

--- a/geocoding/location-service/src/app/main.py
+++ b/geocoding/location-service/src/app/main.py
@@ -34,9 +34,9 @@ if 'MAPBOX_TOKEN' in environ:
     access_token = environ['MAPBOX_TOKEN']
     mongo_client = None
     if 'DB_CONNECTION_STRING' in environ:
-        mongo_client = pymongo.MongoClient(environ['DB_CONNECTION_STRING'], appname='location-service', authSource='admin')
+        mongo_client = pymongo.MongoClient(environ['DB_CONNECTION_STRING'])
     rate_limit = int(environ.get('MAPBOX_GEOCODE_RATE_LIMIT_PER_MIN', 600))
-    admins_fetcher = AdminsFetcher(access_token, mongo_client[environ['DB']], rate_limit=rate_limit)
+    admins_fetcher = AdminsFetcher(access_token, mongo_client.get_database(environ['DB']), rate_limit=rate_limit)
     mapbox_geocoder = Geocoder(access_token, admins_fetcher, rate_limit=rate_limit)
     geocoders.append(mapbox_geocoder)
 


### PR DESCRIPTION
The problem in dev and prod for the geocoding service is a failure to authenticate for a mongodb operation. I have gone through the workflow manually in the python command line using the dev secret and have found the commands I've switched to here to work, so I'm hoping this change works in deployment too!