### PR TITLE
#1866 no early abort upsert

### DIFF
--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -637,10 +637,11 @@ describe('POST', () => {
         expect(await CaseRevision.collection.countDocuments()).toEqual(0);
     });
     it('batch upsert with any invalid case should return 207', async () => {
-        await request(app)
+        const res = await request(app)
             .post('/api/cases/batchUpsert')
             .send({ cases: [minimalCase, invalidRequest], ...curatorMetadata })
-            .expect(207, /VALIDATE/);
+            .expect(207, /Case validation failed/);
+        expect(res.body.numCreated).toEqual(1);
     });
     it('batch upsert with empty cases should return 400', async () => {
         return request(app)

--- a/ingestion/functions/common/parsing_lib_test.py
+++ b/ingestion/functions/common/parsing_lib_test.py
@@ -347,7 +347,10 @@ def test_write_to_server_raises_error_for_failed_batch_upsert_with_validation_er
     os.environ["SOURCE_API_URL"] = _SOURCE_API_URL
     full_source_url = f"{_SOURCE_API_URL}/cases/batchUpsert"
     requests_mock.register_uri(
-        "POST", full_source_url, json={}, status_code=207),
+        "POST", full_source_url, json={ 
+            'numCreated': 0,
+            'numUpdated': 0,
+        }, status_code=207),
     upload_id = "123456789012345678901234"
     update_upload_url = f"{_SOURCE_API_URL}/sources/{_SOURCE_ID}/uploads/{upload_id}"
     requests_mock.register_uri("PUT", update_upload_url, json={})
@@ -382,6 +385,8 @@ def test_write_to_server_records_input_for_failed_batch_upsert_with_validation_e
                     'message': 'You done goofed.',
                 },
             ],
+            'numCreated': 0,
+            'numUpdated': 0,
         }, status_code=207),
     upload_id = "123456789012345678901234"
     update_upload_url = f"{_SOURCE_API_URL}/sources/{_SOURCE_ID}/uploads/{upload_id}"


### PR DESCRIPTION
This changes the validation handling in the data service such that if a validation failure happens, the data service tries to insert any valid cases and reports a mixed status rather than giving up. It also changes the ingestion library to interpret responses sent in this case.