### PR TITLE
bumped y18n and ran npm audit

### DIFF
--- a/verification/curator-service/api/package-lock.json
+++ b/verification/curator-service/api/package-lock.json
@@ -11749,9 +11749,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {


### PR DESCRIPTION
I wanted to just update the y18n version, but running `npm install --package-lock-only y18n@4.0.3` recreated the entire lock file...so I also ran `npm audit` since it seemed relatively low-impact.

EDIT: that broke mongoose somehow...copy/pasted y18n section from package-lock.json and left the rest alone.