### PR TITLE
parsing: Fix crash with missing country code in Argentina

### DIFF
--- a/ingestion/functions/parsing/argentina/argentina.py
+++ b/ingestion/functions/parsing/argentina/argentina.py
@@ -136,17 +136,20 @@ def convert_travel(entry):
         travel = {}
         travel_countries = []
         country = entry
-        
-        country_ISO2 = _COUNTRY_ISO2_MAP[country.lower()]
 
-        location["country"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["name_english"]
-        location["geoResolution"] = "Country"
-        location["name"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["name_english"]
-        geometry["latitude"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["latitude"]
-        geometry["longitude"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["longitude"]
-        location["geometry"] = geometry
-        
-        travel_countries.append({"location": location})
+        if country.lower() in _COUNTRY_ISO2_MAP:
+            country_ISO2 = _COUNTRY_ISO2_MAP[country.lower()]
+
+            location["country"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["name_english"]
+            location["geoResolution"] = "Country"
+            location["name"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["name_english"]
+            geometry["latitude"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["latitude"]
+            geometry["longitude"] = _COUNTRY_LAT_LONG_MAP[country_ISO2]["longitude"]
+            location["geometry"] = geometry
+
+            travel_countries.append({"location": location})
+        else:
+            print(f"Country code not found for: {country.lower()}")
         travel["traveledPrior30Days"] = True
         travel["travel"] = travel_countries
         if travel:

--- a/ingestion/functions/parsing/argentina/dictionaries.json
+++ b/ingestion/functions/parsing/argentina/dictionaries.json
@@ -51,6 +51,7 @@
         "congo": "CG",
         "corea del norte": "KP",
         "corea del sur": "KR",
+        "corea republicana": "KR",
         "costa rica": "CR",
         "côte d’ivoire": "CI",
         "croacia": "HR",


### PR DESCRIPTION
Argentina parser was crashing with missing 'corea republicana'.
Fix by adding entry to country code list, and fixes the error class
of missing country codes to log an error instead of crashing.

Fixes: #1922
