### PR TITLE
Build ingestion image from stable branch #1954

### DIFF
--- a/.github/workflows/ingestion-functions-deploy.yml
+++ b/.github/workflows/ingestion-functions-deploy.yml
@@ -2,7 +2,7 @@ name: Ingestion functions deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, 1.6-stable]
     paths:
     - '.github/workflows/ingestion-functions-python.yml'
     - 'ingestion/functions/**'
@@ -25,6 +25,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Build, tag, and push image to Amazon ECR
+      if: ${{ github.ref == 'refs/heads/main' }}
       working-directory: ingestion/functions
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -34,3 +35,15 @@ jobs:
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+    - name: Build, tag, and push image to Amazon ECR
+      if: ${{ github.ref == 'refs/heads/1.6-stable' }}
+      working-directory: ingestion/functions
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: gdh-ingestor
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:stable

--- a/.github/workflows/ingestion-functions-deploy.yml
+++ b/.github/workflows/ingestion-functions-deploy.yml
@@ -2,7 +2,7 @@ name: Ingestion functions deploy
 
 on:
   push:
-    branches: [main, 1.6-stable]
+    branches: [main, *-stable]
     paths:
     - '.github/workflows/ingestion-functions-python.yml'
     - 'ingestion/functions/**'
@@ -37,7 +37,7 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
     - name: Build, tag, and push image to Amazon ECR
-      if: ${{ github.ref == 'refs/heads/1.6-stable' }}
+      if: ${{ endsWith(github.ref, '-stable') }}
       working-directory: ingestion/functions
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/ingestion/functions/aws.py
+++ b/ingestion/functions/aws.py
@@ -11,7 +11,10 @@ import boto3
 import common.common_lib as common_lib
 
 AWS_REGION = "us-east-1"
-AWS_IMAGE = "612888738066.dkr.ecr.us-east-1.amazonaws.com/gdh-ingestor:latest"
+AWS_IMAGE = {
+    'dev': "612888738066.dkr.ecr.us-east-1.amazonaws.com/gdh-ingestor:latest",
+    'prod': "612888738066.dkr.ecr.us-east-1.amazonaws.com/gdh-ingestor:stable"
+}
 AWS_JOB_ROLE_ARN = "arn:aws:iam::612888738066:role/gdh-ingestion-job-role"
 AWS_EVENT_ROLE_ARN = "arn:aws:iam::612888738066:role/service-role/AWS_Events_Invoke_Batch_Job_Queue_1312384119"
 AWS_JOB_QUEUE_ARN = "arn:aws:batch:us-east-1:612888738066:job-queue/ingestion-queue"
@@ -49,7 +52,7 @@ def job_definition(
             "attemptDurationSeconds": timeout * 60
         },
         "containerProperties": {
-            "image": AWS_IMAGE,
+            "image": AWS_IMAGE[env],
             "vcpus": vcpu,
             "jobRoleArn": AWS_JOB_ROLE_ARN,
             "memory": memory,


### PR DESCRIPTION
The latest stable branch is used to build a :stable image
for gdh-ingestor. Also updates the job definition section
in aws.py to use stable images from prod environment.
