### PR TITLE
Upgrade docker publish action to v2

### DIFF
--- a/.github/workflows/curator-service-package.yml
+++ b/.github/workflows/curator-service-package.yml
@@ -17,15 +17,34 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
+      -
+        name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=${{github.repository}}/curatorservice
+          VERSION=edge
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - uses: docker/login-action@v2
         with:
           username: ${{ github.actor }}
           # https://github.com/globaldothealth/list/settings/secrets
           # https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry
           password: ${{ secrets.CR_PAT }}
           registry: ghcr.io
-          repository: ${{github.repository}}/curatorservice
+      - uses: docker/build-push-action@v2
+        with:
           dockerfile: verification/curator-service/Dockerfile
-          add_git_labels: true
-          tag_with_ref: true
-          tag_with_sha: true
+          tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/data-service-package.yml
+++ b/.github/workflows/data-service-package.yml
@@ -17,15 +17,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
+      -
+        name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=${{github.repository}}/dataservice
+          VERSION=edge
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+      - uses: docker/login-action@v2
         with:
           username: ${{ github.actor }}
           # https://github.com/globaldothealth/list/settings/secrets
           # https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry
           password: ${{ secrets.CR_PAT }}
           registry: ghcr.io
-          repository: ${{github.repository}}/dataservice
+      - uses: docker/build-push-action@v2
+        with:
           dockerfile: data-serving/data-service/Dockerfile
-          add_git_labels: true
-          tag_with_ref: true
-          tag_with_sha: true
+          tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/geocoding-service-package.yml
+++ b/.github/workflows/geocoding-service-package.yml
@@ -17,15 +17,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
+      -
+        name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=${{github.repository}}/locationservice
+          VERSION=edge
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+      - uses: docker/login-action@v2
         with:
           username: ${{ github.actor }}
           # https://github.com/globaldothealth/list/settings/secrets
           # https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry
           password: ${{ secrets.CR_PAT }}
           registry: ghcr.io
-          repository: ${{github.repository}}/locationservice
+      - uses: docker/build-push-action@v2
+        with:
           dockerfile: geocoding/location-service/Dockerfile
-          add_git_labels: true
-          tag_with_ref: true
-          tag_with_sha: true
+          tags: ${{ steps.prep.outputs.tags }}


### PR DESCRIPTION
Followed migration instructions at https://github.com/docker/build-push-action/blob/master/UPGRADE.md

I didn't touch the ingestion functions deployment as that's using a different workflow. Not sure how to test this without tagging or merging though.