### PR TITLE
Remove regex features that Safari does not support #1976

### DIFF
--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -48,12 +48,6 @@ interface Props {
     onModalClose: () => void;
 }
 
-interface State {
-    case?: Case;
-    errorMessage?: string;
-    loading: boolean;
-}
-
 export default function ViewCase(props: Props): JSX.Element {
     const [c, setCase] = useState<Case>();
     const [loading, setLoading] = useState<boolean>(false);
@@ -92,10 +86,6 @@ export default function ViewCase(props: Props): JSX.Element {
             {c && <CaseDetails enableEdit={props.enableEdit} c={c} />}
         </AppModal>
     );
-}
-
-interface LocationState {
-    search: string;
 }
 interface CaseDetailsProps {
     c: Case;
@@ -833,7 +823,17 @@ function RowHeader(props: { title: string }): JSX.Element {
 
 function RowContent(props: { content: string; isLink?: boolean }): JSX.Element {
     const searchQuery = useSelector(selectSearchQuery);
-    const searchQueryArray = searchQuery.match(/"([^"]+)"|\w{3,}/g) ?? [];
+    const searchQueryArray: any[] = [];
+
+    function words(s: string) {
+        const regex = /"([^"]+)"|(\w{3,})/g;
+        let match;
+        while ((match = regex.exec(s))) {
+            searchQueryArray.push(match[match[1] ? 1 : 2]);
+        }
+        return searchQueryArray;
+    }
+    words(searchQuery);
 
     return (
         <Grid item xs={8}>

--- a/verification/curator-service/ui/src/components/ViewCase.tsx
+++ b/verification/curator-service/ui/src/components/ViewCase.tsx
@@ -753,9 +753,7 @@ function VariantRows(props: { variant: Variant }): JSX.Element {
     );
 }
 
-function LocationRows(props: {
-    loc?: Location;
-}): JSX.Element {
+function LocationRows(props: { loc?: Location }): JSX.Element {
     return (
         <>
             <RowHeader title="Location" />
@@ -835,8 +833,7 @@ function RowHeader(props: { title: string }): JSX.Element {
 
 function RowContent(props: { content: string; isLink?: boolean }): JSX.Element {
     const searchQuery = useSelector(selectSearchQuery);
-    const searchQueryArray =
-        searchQuery.match(/(?<=")[^"]+(?=")|\w{3,}/g) ?? [];
+    const searchQueryArray = searchQuery.match(/"([^"]+)"|\w{3,}/g) ?? [];
 
     return (
         <Grid item xs={8}>


### PR DESCRIPTION
Safari doesn't support lookahead/lookbehind in regex, so the syntax highlighting had broken Safari support. I've changed the regex so it doesn't use them, which obviously means it doesn't match the same things any more so I've basically broken syntax highlighting. @sergioloporto hoping your regex skills can help design a highlight implementation that will work, any ideas?

Here's the compatibility matrix: https://caniuse.com/js-regexp-lookbehind