### PR TITLE
prune-uploads: Use epoch and remove ERROR uploads

### DIFF
--- a/.github/workflows/prune-uploads-tests.yml
+++ b/.github/workflows/prune-uploads-tests.yml
@@ -5,11 +5,11 @@ on:
     branches: [main]
     paths:
     - '.github/workflows/prune-uploads-tests.yml'
-    - 'data-serving/data-service/scripts/prune-uploads/**'
+    - 'data-serving/scripts/prune-uploads/**'
   pull_request:
     paths:
     - '.github/workflows/prune-uploads-tests.yml'
-    - 'data-serving/data-service/scripts/prune-uploads/**'
+    - 'data-serving/scripts/prune-uploads/**'
 
 jobs:
   tests:

--- a/data-serving/scripts/prune-uploads/test_prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/test_prune_uploads.py
@@ -27,7 +27,8 @@ S2 = {
         _u("60f7343a6e50eb2592992fb1", Status.ERROR, "2020-12-25"),
         _u("60f7343a6e50eb2592992fb2", Status.SUCCESS, "2021-02-11"),
         _u("60f7343a6e50eb2592992fb3", Status.ERROR, "2020-05-05"),
-        _u("60f7343a6e50eb2592992fb2", Status.IN_PROGRESS, "2021-02-12"),
+        _u("60f7343a6e50eb2592992fb4", Status.ERROR, "2020-02-12"),
+        _u("60f7343a6e50eb2592992fb5", Status.IN_PROGRESS, "2021-02-14"),
     ],
 }
 
@@ -38,6 +39,7 @@ S2_expected = (
         "60f734296e50eb2592992fb0",
         "60f7343a6e50eb2592992fb1",
         "60f7343a6e50eb2592992fb3",
+        "60f7343a6e50eb2592992fb4",
     ],
 )
 
@@ -58,3 +60,8 @@ T = [(S1, None), (S2, S2_expected), (S3, None)]
 @pytest.mark.parametrize("source,expected", T)
 def test_find_successful_upload(source, expected):
     assert find_successful_upload(source) == expected
+
+
+@pytest.mark.parametrize("source,expected", [(x, None) for x in [S1, S2, S3]])
+def test_find_successful_upload_with_epoch(source, expected):
+    assert find_successful_upload(source, datetime(2021, 3, 1)) == expected


### PR DESCRIPTION
Epoch date specified using PRUNE_EPOCH is the date after which
successful uploads are considered for non-UUID sources. This is
to facilitate transition from the previous approach where non-UUID
sources were ingested over multiple, rather than single, uploads.
