### PR TITLE
data-service: Make uploadIds mandatory in batchValidate

### DIFF
--- a/data-serving/data-service/src/model/case-reference.ts
+++ b/data-serving/data-service/src/model/case-reference.ts
@@ -12,7 +12,10 @@ export const caseReferenceSchema = new mongoose.Schema(
             type: String,
             required: true,
         },
-        uploadIds: uniqueStringsArrayFieldInfo,
+        uploadIds: {
+            ...uniqueStringsArrayFieldInfo,
+            required: true
+        },
         verificationStatus: {
             type: String,
             default: 'UNVERIFIED',

--- a/data-serving/data-service/test/model/data/case.minimal.json
+++ b/data-serving/data-service/test/model/data/case.minimal.json
@@ -1,7 +1,8 @@
 {
     "caseReference": {
         "sourceId": "5ea86423bae6982635d2e1f8",
-        "sourceUrl": "cdc.gov"
+        "sourceUrl": "cdc.gov",
+        "uploadIds": ["5fabc12344aa09130affce91"]
     },
     "list": true,
     "events": [


### PR DESCRIPTION
prune-uploads requires uploadIds which are not mandatory at present.
This doesn't matter for UUID sources where all data is ingested,
but for non-UUID sources, not having an uploadId means the corresponding
data will never be deleted.

Fixes: #2056
