### PR TITLE
data-service: Attempted fix for duplicate caserevisions insertion

### DIFF
--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -1082,7 +1082,7 @@ export const casesMatchingSearchQuery = (opts: {
  */
 export const findCasesWithCaseReferenceData = async (
     req: Request,
-    fieldsToSelect = {},
+    fieldsToSelect: any = undefined,
 ): Promise<CaseDocument[]> => {
     const providedCaseReferenceData = req.body.cases
         .filter(
@@ -1100,12 +1100,17 @@ export const findCasesWithCaseReferenceData = async (
             };
         });
 
-    return providedCaseReferenceData.length > 0
-        ? Case.find()
-              .or(providedCaseReferenceData)
-              .select(fieldsToSelect)
-              .exec()
-        : [];
+    if (providedCaseReferenceData.length > 0) {
+        if(fieldsToSelect === undefined)
+            return Case.find().or(providedCaseReferenceData).exec();
+        else
+            return Case.find()
+                       .or(providedCaseReferenceData)
+                       .select(fieldsToSelect)
+                       .exec();
+    } else {
+        return [];
+    }
 };
 
 /**


### PR DESCRIPTION
batchUpsert for UUID sources is randomly failing with the error
that duplicate caserevision (same case ID and revision) is being
inserted into the caserevisions collection (issue #2005, but
seen in other UUID sources as well).

The responsibility for making sure that a case with the same
revision is not upserted again is in batchUpsertDropUnchangedCases()
which drops unchanged cases, by using findCasesWithCaseReferenceData().
As findCasesWithCaseReferenceData() calls select({}) which
only returns _id (if fieldsToSelect is not specified), this would not
be able to match against an entire case (existingCase.equalsJSON(c))

This commit drops .select() if fieldsToSelected is undefined
which should include all fields, allowing matches against existing
cases to succeed.
