### PR TITLE
prune-uploads: Prune older accepted uploads

### DIFF
--- a/data-serving/scripts/prune-uploads/test_prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/test_prune_uploads.py
@@ -70,7 +70,8 @@ S2_expected = (
     ],
 )
 
-S2_accepted_expected = ["60f7343a6e50eb2592992fb2"], ["60f7343a6e50eb2592992fc2"]
+# acceptance status doesn't matter for whether to prune an upload
+S2_accepted_expected = S2_expected
 
 S3 = {
     "_id": ObjectId("123456789012345678901233"),


### PR DESCRIPTION
Previously older, accepted uploads were not pruned. This was
incorrect behaviour for non-UUID sources (UUID sources don't get
pruned) as only the latest successful upload should be present
in the database, with older accepted uploads being deleted as well.
