### PR TITLE
prune-uploads: Skip accepted uploads

### DIFF
--- a/data-serving/scripts/prune-uploads/prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/prune_uploads.py
@@ -54,6 +54,7 @@ def is_acceptable(upload: Dict[str, Any], threshold: float) -> bool:
         and created > 0
         and updated == 0  # non-UUID sources should never update a case
         and errors / (errors + created) <= threshold
+        and "accepted" not in upload  # skip already accepted cases
     )
 
 

--- a/data-serving/scripts/prune-uploads/test_prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/test_prune_uploads.py
@@ -92,7 +92,22 @@ S3 = {
     ],
 }
 
-T = [(S1, None), (S2, S2_expected), (S2_accepted, S2_accepted_expected), (S3, None)]
+# Skip accepted uploads
+S4 = {
+    "_id": ObjectId("123456789012345678901233"),
+    "hasStableIdentifiers": False,
+    "uploads": [
+        _u("60f734296e50eb2592992fb0", Status.SUCCESS, "2020-12-31", 20, 1, accepted=True),
+    ],
+}
+
+T = [
+    (S1, None),
+    (S2, S2_expected),
+    (S2_accepted, S2_accepted_expected),
+    (S3, None),
+    (S4, None),
+]
 
 
 @pytest.mark.parametrize("source,expected", T)


### PR DESCRIPTION
Previously, prune-uploads would re-mark existing accepted cases
again unnecessarily.
