### PR TITLE
data-service: Add collation to sourceId index

### DIFF
--- a/data-serving/data-service/schemas/cases.indexes.json
+++ b/data-serving/data-service/schemas/cases.indexes.json
@@ -21,6 +21,10 @@
         "name": "sourceIdIdx",
         "key": {
             "caseReference.sourceId": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
         }
     },
     {


### PR DESCRIPTION
MongoDB requires indices to have the same collation as the query
for string indices. As queries in the data service use en_US collation,
all string indices in the schema require the collation to be set.

This fixes the issue of sourceId searches taking too long that was
introduced in 1415d75dc7ae7d73d95996086098ef61b7e8bf2e.
