### PR TITLE
data-service: Ignore case revision insert errors

### DIFF
--- a/data-serving/data-service/src/controllers/preprocessor.ts
+++ b/data-serving/data-service/src/controllers/preprocessor.ts
@@ -361,14 +361,19 @@ export const createBatchUpsertCaseRevisions = async (
         },
     );
 
-    await CaseRevision.insertMany(casesToUpsert, {
-        ordered: false,
-        rawResult: true,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore Mongoose types don't include the `lean` option from its
-        // documentation: https://mongoosejs.com/docs/api.html#model_Model.insertMany
-        lean: true,
-    });
+    try {
+        await CaseRevision.insertMany(casesToUpsert, {
+            ordered: false,
+            rawResult: true,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore Mongoose types don't include the `lean` option from its
+            // documentation: https://mongoosejs.com/docs/api.html#model_Model.insertMany
+            lean: true,
+        });
+    } catch(err) {
+        console.log('Failed to insert some case revisions');
+        console.log(err);
+    }
 
     next();
 };
@@ -392,14 +397,19 @@ export const createBatchUpdateCaseRevisions = async (
         };
     });
 
-    await CaseRevision.insertMany(casesToUpdate, {
-        ordered: false,
-        rawResult: true,
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore Mongoose types don't include the `lean` option from its
-        // documentation: https://mongoosejs.com/docs/api.html#model_Model.insertMany
-        lean: true,
-    });
+    try {
+        await CaseRevision.insertMany(casesToUpdate, {
+            ordered: false,
+            rawResult: true,
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore Mongoose types don't include the `lean` option from its
+            // documentation: https://mongoosejs.com/docs/api.html#model_Model.insertMany
+            lean: true,
+        });
+    } catch(err) {
+        console.log('Failed to insert some case revisions');
+        console.log(err);
+    }
 
     next();
 };


### PR DESCRIPTION
Case revision inserts fail intermittently when trying to
write a case revision with the same ID and revision number to
the caserevisions collection which enforces uniqueness on
these two fields. An exception is raised even if one insert
fails.

As case revisions are not exposed to the UI, and we save the
original data files for each source (which can be used to recreate
older versions of cases), this commit ignores the exception but
logs it.

This only affects UUID sources; non-UUID sources are always
ingested in full and do not update case revisions.

This is the second attempted fix for #2005, previous attempt
at c7a21c5a002369f822b906426e3cb00bffdb1cc9 did not fix.
