### PR TITLE
db: Re-add creation metadata date index

### DIFF
--- a/data-serving/data-service/schemas/cases.indexes.json
+++ b/data-serving/data-service/schemas/cases.indexes.json
@@ -207,6 +207,16 @@
         }
     },
     {
+        "name": "revisionMetadataCreationMetadataDate",
+        "key": {
+            "revisionMetadata.creationMetadata.date": -1
+        },
+        "collation": {
+            "locale": "en_US",
+            "strength": 2
+        }
+    },
+    {
         "name": "countryAndDate",
         "key": {
             "location.country": -1,


### PR DESCRIPTION
Without the date index, the initial page of data after logging
in gives a 504, as no country is selected.
