### PR TITLE
Ensure every sample case is listed in the UI

### DIFF
--- a/data-serving/samples/cases.json
+++ b/data-serving/samples/cases.json
@@ -1,5592 +1,5691 @@
 [
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f8",
-            "sourceUrl": "https://www.colorado.gov/pacific/cdphe/news/10-new-presumptive-positive-cases-colorado-cdphe-confirms-limited-community-spread-covid-19",
-            "verificationStatus": "UNVERIFIED"
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f8",
+      "sourceUrl": "https://www.colorado.gov/pacific/cdphe/news/10-new-presumptive-positive-cases-colorado-cdphe-confirms-limited-community-spread-covid-19",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 50,
+        "end": 59
+      },
+      "gender": "Female",
+      "occupation": "Horse trainer",
+      "nationalities": [
+        "Swedish"
+      ],
+      "ethnicity": "Other"
+    },
+    "genomeSequences": [
+      {
+        "sampleCollectionDate": {
+          "$date": "2019-12-30T00:00:00Z"
         },
-        "demographics": {
-            "ageRange": {
-                "start": 50,
-                "end": 59
-            },
-            "gender": "Female",
-            "occupation": "Horse trainer",
-            "nationalities": [
-                "Swedish"
-            ],
-            "ethnicity": "Other"
+        "repositoryUrl": "https://www.ncbi.nlm.nih.gov/nuccore/NC_045512",
+        "sequenceId": "NC_045512.2",
+        "sequenceName": "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
+        "sequenceLength": 33000
+      }
+    ],
+    "location": {
+      "country": "France",
+      "administrativeAreaLevel1": "Île-de-France",
+      "administrativeAreaLevel2": "Paris",
+      "administrativeAreaLevel3": "Paris",
+      "geoResolution": "Admin3",
+      "name": "Paris",
+      "geometry": {
+        "latitude": {
+          "$numberDouble": "2.3522219"
         },
-        "genomeSequences": [
-            {
-                "sampleCollectionDate": {
-                    "$date": "2019-12-30T00:00:00Z"
-                },
-                "repositoryUrl": "https://www.ncbi.nlm.nih.gov/nuccore/NC_045512",
-                "sequenceId": "NC_045512.2",
-                "sequenceName": "Severe acute respiratory syndrome coronavirus 2 isolate Wuhan-Hu-1, complete genome",
-                "sequenceLength": 33000
-            }
-        ],
-        "location": {
-            "country": "France",
-            "administrativeAreaLevel1": "Île-de-France",
-            "administrativeAreaLevel2": "Paris",
-            "administrativeAreaLevel3": "Paris",
-            "geoResolution": "Admin3",
-            "name": "Paris",
-            "geometry": {
-                "latitude": {
-                    "$numberDouble": "2.3522219"
-                },
-                "longitude": {
-                    "$numberDouble": "48.85661400000001"
-                }
-            }
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": {
-                            "$numberLong": "1578027600000"
-                        }
-                    },
-                    "end": {
-                        "$date": {
-                            "$numberLong": "1578027600000"
-                        }
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "value": "PCR test",
-                "dateRange": {
-                    "start": {
-                        "$date": {
-                            "$numberLong": "1578891600000"
-                        }
-                    },
-                    "end": {
-                        "$date": {
-                            "$numberLong": "1578891600000"
-                        }
-                    }
-                }
-            },
-            {
-                "name": "hospitalAdmission",
-                "dateRange": {
-                    "start": {
-                        "$date": {
-                            "$numberLong": "1579395600000"
-                        }
-                    },
-                    "end": {
-                        "$date": {
-                            "$numberLong": "1581469200000"
-                        }
-                    }
-                }
-            },
-            {
-                "name": "outcome",
-                "value": "Recovered",
-                "dateRange": {
-                    "start": {
-                        "$date": {
-                            "$numberLong": "1581483600000"
-                        }
-                    },
-                    "end": {
-                        "$date": {
-                            "$numberLong": "1581483600000"
-                        }
-                    }
-                }
-            }
-        ],
-        "list": true,
-        "symptoms": {
-            "values": [
-                "Severe pneumonia",
-                "Dyspnea",
-                "Weakness"
-            ],
-            "status": "Symptomatic"
-        },
-        "preexistingConditions": {
-            "values": [
-                "Hypertension",
-                "Type 2 diabetes",
-                "Coronary heart disease",
-                "Lung cancer"
-            ],
-            "hasPreexistingConditions": true
-        },
-        "travelHistory": {
-            "travel": [
-                {
-                    "dateRange": {
-                        "start": {
-                            "$date": {
-                                "$numberLong": "1576386000000"
-                            }
-                        },
-                        "end": {
-                            "$date": {
-                                "$numberLong": "1577682000000"
-                            }
-                        }
-                    },
-                    "location": {
-                        "country": "China",
-                        "administrativeAreaLevel1": "Hubei",
-                        "administrativeAreaLevel2": "Wuhan City",
-                        "geoResolution": "Admin2",
-                        "name": "Wuhan City",
-                        "geometry": {
-                            "latitude": {
-                                "$numberDouble": "30.592849"
-                            },
-                            "longitude": {
-                                "$numberDouble": "114.305539"
-                            }
-                        }
-                    },
-                    "methods": [
-                        "Plane"
-                    ],
-                    "purpose": "Family"
-                }
-            ],
-            "traveledPrior30Days": true
-        },
-        "pathogens": [
-            {
-                "name": "COVID-19",
-                "id": 304
-            },
-            {
-                "name": "Pneumonia",
-                "id": 104
-            }
-        ],
-        "notes": "Contact of a confirmed case at work.",
-        "revisionMetadata": {
-            "revisionNumber": 1,
-            "creationMetadata": {
-                "curator": "abc123",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                },
-                "notes": "initial data entry"
-            },
-            "updateMetadata": {
-                "curator": "xyz789",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587814400000"
-                    }
-                },
-                "notes": "fix source error"
-            }
-        },
-        "transmission": {
-            "routes": [
-                "Vector borne"
-            ],
-            "places": [
-                "Gym"
-            ],
-            "linkedCaseIds": [
-                "abc",
-                "def"
-            ]
-        },
-        "importedCase": {
-            "ID": "idk",
-            "chronic_disease_binary": "true",
-            "outcome": "discharge 2/12",
-            "admin_id": "291",
-            "lives_in_Wuhan": "false",
-            "reported_market_exposure": "true"
+        "longitude": {
+          "$numberDouble": "48.85661400000001"
         }
+      }
     },
-    {
-       "caseReference": {
-           "sourceId": "5ea86423bae6982635d2a116",
-           "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-           "verificationStatus": "UNVERIFIED"
-       },
-       "demographics": {
-           "ageRange": {
-               "start": 56.0,
-               "end": 56.0
-           },
-           "gender": "Female"
-       },
-       "location": {
-           "country": "Peru",
-           "geometry": {
-               "latitude": -12.071769999999958,
-               "longitude": -77.11783999999994
-           },
-           "name": "Non-empty name",
-           "geoResolution": "Point"
-       },
-       "events": [
-           {
-               "name": "confirmed",
-               "dateRange": {
-                   "start": {
-                       "$date": "2020-03-28T00:00:00Z"
-                   },
-                   "end": {
-                       "$date": "2020-03-28T00:00:00Z"
-                   }
-               }
-           }
-       ],
-       "variant": {
-           "name": "B.1.351"
-       },
-       "revisionMetadata": {
-           "revisionNumber": 0,
-           "creationMetadata": {
-               "curator": "TR",
-               "date": {
-                   "$date": {
-                       "$numberLong": "1587614400000"
-                   }
-               }
-           }
-       },
-       "importedCase": {
-           "ID": "010-751",
-           "city": "La Perla",
-           "province": "Callao",
-           "country": "Peru",
-           "date_confirmation": "28.03.2020",
-           "chronic_disease_binary": "False",
-           "admin_id": "15077.0",
-           "travel_history_binary": "False"
-       }
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": {
+              "$numberLong": "1578027600000"
+            }
+          },
+          "end": {
+            "$date": {
+              "$numberLong": "1578027600000"
+            }
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "value": "PCR test",
+        "dateRange": {
+          "start": {
+            "$date": {
+              "$numberLong": "1578891600000"
+            }
+          },
+          "end": {
+            "$date": {
+              "$numberLong": "1578891600000"
+            }
+          }
+        }
+      },
+      {
+        "name": "hospitalAdmission",
+        "dateRange": {
+          "start": {
+            "$date": {
+              "$numberLong": "1579395600000"
+            }
+          },
+          "end": {
+            "$date": {
+              "$numberLong": "1581469200000"
+            }
+          }
+        }
+      },
+      {
+        "name": "outcome",
+        "value": "Recovered",
+        "dateRange": {
+          "start": {
+            "$date": {
+              "$numberLong": "1581483600000"
+            }
+          },
+          "end": {
+            "$date": {
+              "$numberLong": "1581483600000"
+            }
+          }
+        }
+      }
+    ],
+    "list": true,
+    "symptoms": {
+      "values": [
+        "Severe pneumonia",
+        "Dyspnea",
+        "Weakness"
+      ],
+      "status": "Symptomatic"
     },
-    {
-        "demographics": {
-            "gender": "Male"
-        },
-        "location": {
-            "administrativeAreaLevel1": "Hong Kong",
+    "preexistingConditions": {
+      "values": [
+        "Hypertension",
+        "Type 2 diabetes",
+        "Coronary heart disease",
+        "Lung cancer"
+      ],
+      "hasPreexistingConditions": true
+    },
+    "travelHistory": {
+      "travel": [
+        {
+          "dateRange": {
+            "start": {
+              "$date": {
+                "$numberLong": "1576386000000"
+              }
+            },
+            "end": {
+              "$date": {
+                "$numberLong": "1577682000000"
+              }
+            }
+          },
+          "location": {
             "country": "China",
-            "geometry": {
-                "latitude": 22.3650193,
-                "longitude": 114.133808
-            },
-            "name": "Hong Kong",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-14T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-14T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "notes": "Case 55; mainland China travel via the Lok Ma Chau border crossing",
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f0",
-            "sourceUrl": "https://www.scmp.com/news/hong-kong/health-environment/article/3050681/coronavirus-hong-kong-confirms-three-news-cases",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "travelHistory": {
-            "travel": [
-                {
-                    "dateRange": {
-                        "start": {
-                            "$date": "2020-01-22T00:00:00Z"
-                        },
-                        "end": {
-                            "$date": "2020-01-22T00:00:00Z"
-                        }
-                    },
-                    "location": {
-                        "country": "China",
-                        "geometry": {
-                            "latitude": 37.59841,
-                            "longitude": 104.1868
-                        },
-                        "name": "China",
-                        "geoResolution": "Country"
-                    }
-                }
-            ]
-        },
-        "importedCase": {
-            "ID": "000-1-1",
-            "city": "Shek Lei",
-            "province": "Hong Kong",
-            "country": "China",
-            "date_confirmation": "14.02.2020",
-            "travel_history_dates": "22.01.2020",
-            "travel_history_location": "China",
-            "chronic_disease_binary": "False",
-            "outcome": "critical condition, intubated as of 14.02.2020",
-            "admin_id": "8051.0"
-        }
-    },
-    {
-        "location": {
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 54.37002,
-                "longitude": -2.95214
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-14T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-14T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f1",
-            "sourceUrl": "https://twitter.com/DHSCgovuk/status/1238837700943323136",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "000-1-34326",
-            "country": "United Kingdom",
-            "date_confirmation": "14.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "236.0"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Wuhan City",
             "administrativeAreaLevel1": "Hubei",
-            "country": "China",
-            "geometry": {
-                "latitude": 30.625059999999998,
-                "longitude": 114.3421
-            },
-            "name": "Hubei, Wuhan City",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-17T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-17T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f2",
-            "sourceUrl": "http://wjw.hubei.gov.cn/fbjd/dtyw/202002/t20200218_2091007.shtml",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "000-2-18700",
-            "city": "Wuhan City",
-            "province": "Hubei",
-            "country": "China",
-            "date_confirmation": "17.02.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "9390.0"
-        }
-    },
-    {
-        "location": {
-            "country": "South Africa",
-            "geometry": {
-                "latitude": -29.122,
-                "longitude": 25.031470000000002
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f3",
-            "sourceUrl": "github.com/dsfsi/covid19za",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "001-23950",
-            "country": "South Africa",
-            "date_confirmation": "07.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "207.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Egypt",
-            "geometry": {
-                "latitude": 26.667959999999997,
-                "longitude": 29.77867
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-06-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-06-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f4",
-            "sourceUrl": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_daily_reports/",
-            "verificationStatus": "UNVERIFIED",
-            "additionalSources": [
-                {
-                    "sourceUrl": "daily totals confirmed on https://www.worldometers.info/coronavirus/"
-                }
-            ]
-        },
-        "importedCase": {
-            "ID": "001-48275",
-            "country": "Egypt",
-            "date_confirmation": "03.06.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "66.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 64.0,
-                "end": 64.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Philippines",
-            "geometry": {
-                "latitude": 9.333330000000046,
-                "longitude": 123.66667000000007
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-06-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-06-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "notes": "C960191",
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f5",
-            "sourceUrl": "PH Data Drop",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-113677",
-            "province": "Cebu Province",
-            "country": "Philippines",
-            "date_confirmation": "08.06.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "14108.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 18.940170000000023,
-                "longitude": 72.83483000000007
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f6",
-            "sourceUrl": "https://covid19-phdmah.hub.arcgis.com/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-138000",
-            "city": "Mumbai",
-            "province": "Maharashtra",
-            "country": "India",
-            "date_confirmation": "05.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Hospitalized",
-            "admin_id": "10992.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 18.940170000000023,
-                "longitude": 72.83483000000007
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-11T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-11T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e1f7",
-            "sourceUrl": "https://t.me/indiacovid/4560",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-162325",
-            "city": "Mumbai",
-            "province": "Maharashtra",
-            "country": "India",
-            "date_confirmation": "11.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Hospitalized",
-            "admin_id": "10992.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 21.185780000000022,
-                "longitude": 72.83679000000006
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-16T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-16T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e100",
-            "sourceUrl": "https://twitter.com/PIBAhmedabad/status/1261669285484793857",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-186650",
-            "city": "Surat",
-            "province": "Gujarat",
-            "country": "India",
-            "date_confirmation": "16.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Hospitalized",
-            "admin_id": "11037.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 19.03681000000006,
-                "longitude": 73.01582000000008
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-19T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-19T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e101",
-            "sourceUrl": "https://www.deshgujarat.com/2020/05/22/gujarat-covid19-cases-update/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-210974",
-            "province": "Maharashtra",
-            "country": "India",
-            "date_confirmation": "19.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Recovered",
-            "admin_id": "10997.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 23.027760000000058,
-                "longitude": 72.60027000000008
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-22T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-22T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e101",
-            "sourceUrl": "https://www.deshgujarat.com/2020/05/22/gujarat-covid19-cases-update/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-235299",
-            "city": "Ahmedabad",
-            "province": "Gujarat",
-            "country": "India",
-            "date_confirmation": "22.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Recovered",
-            "admin_id": "11047.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 13.083620000000053,
-                "longitude": 80.28252000000003
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e102",
-            "sourceUrl": "https://stopcorona.tn.gov.in/wp-content/uploads/2020/03/Media-Bulletin-25-05-20-COVID-19-6-PM.pdf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-259623",
-            "city": "Chennai",
-            "province": "Tamil Nadu",
-            "country": "India",
-            "date_confirmation": "25.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Recovered",
-            "admin_id": "11023.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 20.826760000000036,
-                "longitude": 71.04510000000005
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-28T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-28T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e103",
-            "sourceUrl": "mohfw.gov.in",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-283948",
-            "city": "Unassigned",
-            "province": "State Unassigned",
-            "country": "India",
-            "date_confirmation": "28.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Hospitalized",
-            "admin_id": "12668.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 18.940170000000023,
-                "longitude": 72.83483000000007
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-29T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-29T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e104",
-            "sourceUrl": "https://arogya.maharashtra.gov.in/pdf/ncovidepressnotemay29.pdf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-308271",
-            "city": "Mumbai",
-            "province": "Maharashtra",
-            "country": "India",
-            "date_confirmation": "29.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Recovered",
-            "admin_id": "10992.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 19.200000000000045,
-                "longitude": 72.96667000000008
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-31T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-31T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e104",
-            "sourceUrl": "https://arogya.maharashtra.gov.in/pdf/ncovidepressnotemay31.pdf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-332596",
-            "city": "Thane",
-            "province": "Maharashtra",
-            "country": "India",
-            "date_confirmation": "31.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Recovered",
-            "admin_id": "11099.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 19.03681000000006,
-                "longitude": 73.01582000000008
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-26T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-26T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e105",
-            "sourceUrl": "https://twitter.com/ANI/status/1254410536969809922",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-47997",
-            "province": "Maharashtra",
-            "country": "India",
-            "date_confirmation": "26.04.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Hospitalized",
-            "admin_id": "10997.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 30.0,
-                "end": 30.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "India",
-            "geometry": {
-                "latitude": 12.682240000000036,
-                "longitude": 79.98008000000004
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-21T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-21T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e106",
-            "sourceUrl": "https://stopcorona.tn.gov.in/wp-content/uploads/2020/03/Media-Bulletin-21-05-20-COVID-19-6-PM.pdf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-72321",
-            "city": "Chengalpattu",
-            "province": "Tamil Nadu",
-            "country": "India",
-            "date_confirmation": "21.05.2020",
-            "chronic_disease_binary": "False",
-            "outcome": "Hospitalized",
-            "admin_id": "12555.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Nanyang City",
-            "administrativeAreaLevel1": "Henan",
-            "country": "China",
-            "geometry": {
-                "latitude": 33.04534,
-                "longitude": 112.2833
-            },
-            "name": "Henan, Nanyang City",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-02-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-02-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e107",
-            "sourceUrl": "https://m.weibo.cn/status/4468161329843481",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "002-9665",
-            "city": "Nanyang City",
-            "province": "Henan",
-            "country": "China",
-            "date_confirmation": "03.02.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6480.0",
-            "travel_history_binary": "True"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "Catalonia",
-            "country": "Spain",
-            "geometry": {
-                "latitude": 41.803774100000005,
-                "longitude": 1.530937
-            },
-            "name": "Catalonia",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e108",
-            "sourceUrl": "https://en.wikipedia.org/wiki/2020_coronavirus_pandemic_in_Spain",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "003-23162",
-            "province": "Catalonia",
-            "country": "Spain",
-            "date_confirmation": "22.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "354.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Staffordshire",
-            "administrativeAreaLevel1": "England",
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 52.833332999999996,
-                "longitude": -2.0
-            },
-            "name": "England, Staffordshire",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e109",
-            "sourceUrl": "https://www.arcgis.com/apps/opsdashboard/index.html#/f94c3c90da5b4e9f9a0b19484dd4bb14",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "003-47489",
-            "city": "Staffordshire",
-            "province": "England",
-            "country": "United Kingdom",
-            "date_confirmation": "25.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "8305.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 50.0,
-                "end": 59.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Belgium",
-            "geometry": {
-                "latitude": 51.222120000000075,
-                "longitude": 4.397690000000068
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "003-71812",
-            "city": "Antwerpen",
-            "province": "Flanders",
-            "country": "Belgium",
-            "date_confirmation": "26.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "11417.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "demographics": {
-            "ageRange": {
-                "start": 60.0,
-                "end": 69.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Belgium",
-            "geometry": {
-                "latitude": 50.99142331000007,
-                "longitude": 5.429156289000048
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "003-96137",
-            "city": "Limburg",
-            "province": "Flanders",
-            "country": "Belgium",
-            "date_confirmation": "15.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "11422.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 39.0,
-                "end": 39.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Mexico",
-            "geometry": {
-                "latitude": 20.566667000000002,
-                "longitude": -103.68333299999999
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-29T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-29T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-09T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-09T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "004-30461",
-            "province": "Jalisco",
-            "country": "Mexico",
-            "date_onset_symptoms": "29.03.2020",
-            "date_confirmation": "09.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "501.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "Illinois",
-            "country": "United States",
-            "geometry": {
-                "latitude": 41.8781,
-                "longitude": -87.6298
-            },
-            "name": "Illinois",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-22T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e111",
-            "sourceUrl": "http://www.dph.illinois.gov/topics-services/diseases-and-conditions/diseases-a-z-list/coronavirus",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "005-14468",
-            "city": "Chicago",
-            "province": "Illinois",
-            "country": "United States",
-            "date_confirmation": "22.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "2232.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Cook County",
-            "administrativeAreaLevel1": "Illinois",
-            "country": "United States",
-            "geometry": {
-                "latitude": 41.843684,
-                "longitude": -87.816737
-            },
-            "name": "Illinois, Cook County",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e111",
-            "sourceUrl": "http://www.dph.illinois.gov/topics-services/diseases-and-conditions/diseases-a-z-list/coronavirus",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "005-38804",
-            "city": "Cook County",
-            "province": "Illinois",
-            "country": "United States",
-            "date_confirmation": "26.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "2446.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Orange County",
-            "administrativeAreaLevel1": "New York",
-            "country": "United States",
-            "geometry": {
-                "latitude": 41.4022111,
-                "longitude": -74.305756
-            },
-            "name": "New York, Orange County",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e112",
-            "sourceUrl": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "006-10920",
-            "city": "Orange County",
-            "province": "New York",
-            "country": "United States",
-            "date_confirmation": "21.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6788.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "New York",
-            "country": "United States",
-            "geometry": {
-                "latitude": 43.0140874,
-                "longitude": -75.646457
-            },
-            "name": "New York",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e112",
-            "sourceUrl": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "006-35245",
-            "province": "New York",
-            "country": "United States",
-            "date_confirmation": "26.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "658.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 40.41955000000007,
-                "longitude": -3.6919599999999377
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e113",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-1002481",
-            "province": "Madrid",
-            "country": "Spain",
-            "date_confirmation": "24.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "583.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 40.41955000000007,
-                "longitude": -3.6919599999999377
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e113",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-1026806",
-            "province": "Madrid",
-            "country": "Spain",
-            "date_confirmation": "05.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "583.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 15.0,
-                "end": 34.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "geometry": {
-                "latitude": 49.30069000000003,
-                "longitude": 10.572080000000028
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-105113",
-            "city": "Ansbach",
-            "province": "Bayern",
-            "country": "Germany",
-            "date_onset_symptoms": "25.03.2020",
-            "date_confirmation": "25.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "11566.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "Pais Vasco",
-            "country": "Spain",
-            "geometry": {
-                "latitude": 43.04468920000001,
-                "longitude": -2.6168503
-            },
-            "name": "Pais Vasco",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e113",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-1075455",
-            "province": "Pais Vasco",
-            "country": "Spain",
-            "date_confirmation": "25.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "717.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Austria",
-            "geometry": {
-                "latitude": 47.30796174000005,
-                "longitude": 13.267656657000032
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e114",
-            "sourceUrl": "https://github.com/statistikat/coronaDAT/raw/master/archive/20200408/data/20200408_230000.rds",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-1099780",
-            "city": "Sankt Johann im Pongau",
-            "province": "Salzburg",
-            "country": "Austria",
-            "date_confirmation": "08.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "12151.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "Stockholm",
-            "country": "Sweden",
-            "geometry": {
-                "latitude": 59.6025,
-                "longitude": 18.1384
-            },
-            "name": "Stockholm",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-13T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-13T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e115",
-            "sourceUrl": "https://www.folkhalsomyndigheten.se/smittskydd-beredskap/utbrott/aktuella-utbrott/covid-19/bekraftade-fall-i-sverige",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-1124102",
-            "province": "Stockholm",
-            "country": "Sweden",
-            "date_confirmation": "13.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "845.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "administrativeAreaLevel2": "Mansfeld-Sudharz",
-            "administrativeAreaLevel1": "Sachsen-Anhalt",
-            "country": "Germany",
-            "geometry": {
-                "latitude": 51.53589,
-                "longitude": 11.35641
-            },
-            "name": "Sachsen-Anhalt, Mansfeld-Sudharz",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-18T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-18T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-127500",
-            "city": "Mansfeld-Sudharz",
-            "province": "Sachsen-Anhalt",
-            "country": "Germany",
-            "date_onset_symptoms": "18.03.2020",
-            "date_confirmation": "21.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "5939.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 35.88999000000007,
-                "longitude": -5.317839999999933
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e116",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-151825",
-            "province": "Ceuta",
-            "country": "Spain",
-            "date_confirmation": "16.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "12078.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Cremona",
-            "administrativeAreaLevel1": "Lombardia",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.220890000000004,
-                "longitude": 9.994373
-            },
-            "name": "Lombardia, Cremona",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-31T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-31T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200531.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-176150",
-            "city": "Cremona",
-            "province": "Lombardia",
-            "country": "Italy",
-            "date_confirmation": "31.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "2506.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Brescia",
-            "administrativeAreaLevel1": "Lombardia",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.70507,
-                "longitude": 10.31322
-            },
-            "name": "Lombardia, Brescia",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-16T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-16T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200316.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-200474",
-            "city": "Brescia",
-            "province": "Lombardia",
-            "country": "Italy",
-            "date_confirmation": "16.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "1743.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Varese",
-            "administrativeAreaLevel1": "Lombardia",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.80526,
-                "longitude": 8.776143
-            },
-            "name": "Lombardia, Varese",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200328.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-2248",
-            "city": "Varese",
-            "province": "Lombardia",
-            "country": "Italy",
-            "date_confirmation": "28.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "8915.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.165410000000065,
-                "longitude": 10.79242000000005
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-26T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200326.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-249123",
-            "city": "Mantova",
-            "province": "Lombardia",
-            "country": "Italy",
-            "date_confirmation": "26.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "10799.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Frosinone",
-            "administrativeAreaLevel1": "Lazio",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 41.616609999999994,
-                "longitude": 13.53626
-            },
-            "name": "Lazio, Frosinone",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-31T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-31T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200331.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-273448",
-            "city": "Frosinone",
-            "province": "Lazio",
-            "country": "Italy",
-            "date_confirmation": "31.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "3401.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Pavia",
-            "administrativeAreaLevel1": "Lombardia",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.110490000000006,
-                "longitude": 9.037306
-            },
-            "name": "Lombardia, Pavia",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200405.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-297773",
-            "city": "Pavia",
-            "province": "Lombardia",
-            "country": "Italy",
-            "date_confirmation": "05.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6932.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Pisa",
-            "administrativeAreaLevel1": "Toscana",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 43.50391,
-                "longitude": 10.6677
-            },
-            "name": "Toscana, Pisa",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-11T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-11T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200411.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-322096",
-            "city": "Pisa",
-            "province": "Toscana",
-            "country": "Italy",
-            "date_confirmation": "11.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "7093.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Bryansk Oblast",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 53.0409,
-                "longitude": 33.2691
-            },
-            "name": "Central, Bryansk Oblast",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e118",
-            "sourceUrl": "stopcoronavirus.rf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-346420",
-            "city": "Bryansk Oblast",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "15.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "1788.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Moscow",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            },
-            "name": "Central, Moscow",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-20T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e118",
-            "sourceUrl": "stopcoronavirus.rf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-370745",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "20.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 60.0,
-                "end": 79.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "geometry": {
-                "latitude": 51.98134561000006,
-                "longitude": 8.950931642000057
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-21T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-29T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-29T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-39507",
-            "city": "Lippe",
-            "province": "Nordrhein-Westfalen",
-            "country": "Germany",
-            "date_onset_symptoms": "21.03.2020",
-            "date_confirmation": "29.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "11771.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Moscow",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            },
-            "name": "Central, Moscow",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-29T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-29T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e118",
-            "sourceUrl": "stopcoronavirus.rf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-419394",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "29.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 60.0,
-                "end": 79.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "administrativeAreaLevel2": "Tubingen",
-            "administrativeAreaLevel1": "Baden-Wurttemberg",
-            "country": "Germany",
-            "geometry": {
-                "latitude": 48.481840000000005,
-                "longitude": 8.98765
-            },
-            "name": "Baden-Wurttemberg, Tubingen",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-443718",
-            "city": "Tubingen",
-            "province": "Baden-Wurttemberg",
-            "country": "Germany",
-            "date_onset_symptoms": "24.03.2020",
-            "date_confirmation": "24.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "8778.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Moscow",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            },
-            "name": "Central, Moscow",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-01T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-01T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e118",
-            "sourceUrl": "stopcoronavirus.rf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-468042",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "01.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Russia",
-            "geometry": {
-                "latitude": 43.04282494800003,
-                "longitude": 46.87255601000004
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e118",
-            "sourceUrl": "stopcoronavirus.rf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-492367",
-            "city": "Dagestan",
-            "province": "North Caucasian",
-            "country": "Russia",
-            "date_confirmation": "03.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "10860.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Moscow",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            },
-            "name": "Central, Moscow",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-06T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-06T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e118",
-            "sourceUrl": "stopcoronavirus.rf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-516691",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "06.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Moscow",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            },
-            "name": "Central, Moscow",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e118",
-            "sourceUrl": "stopcoronavirus.rf",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-541014",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "08.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 80.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Germany",
-            "geometry": {
-                "latitude": 49.45299347400004,
-                "longitude": 8.110168411000075
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-08T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-09T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-09T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-56534",
-            "city": "Bad Durkheim",
-            "province": "Rheinland-Pfalz",
-            "country": "Germany",
-            "date_onset_symptoms": "08.04.2020",
-            "date_confirmation": "09.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "11837.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Pavia",
-            "administrativeAreaLevel1": "Lombardia",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.110490000000006,
-                "longitude": 9.037306
-            },
-            "name": "Lombardia, Pavia",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200415.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-589665",
-            "city": "Pavia",
-            "province": "Lombardia",
-            "country": "Italy",
-            "date_confirmation": "15.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6932.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Torino",
-            "administrativeAreaLevel1": "Piemonte",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.14739,
-                "longitude": 7.443546
-            },
-            "name": "Piemonte, Torino",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200423.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-613989",
-            "city": "Torino",
-            "province": "Piemonte",
-            "country": "Italy",
-            "date_confirmation": "23.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "8737.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Lecco",
-            "administrativeAreaLevel1": "Lombardia",
-            "country": "Italy",
-            "geometry": {
-                "latitude": 45.904379999999996,
-                "longitude": 9.387806
-            },
-            "name": "Lombardia, Lecco",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e117",
-            "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200507.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-638312",
-            "city": "Lecco",
-            "province": "Lombardia",
-            "country": "Italy",
-            "date_confirmation": "07.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "5344.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "location": {
-            "administrativeAreaLevel2": "Moscow",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            },
-            "name": "Central, Moscow",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-11T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-11T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-662637",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "11.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "location": {
-            "administrativeAreaLevel2": "Moscow",
-            "administrativeAreaLevel1": "Central",
-            "country": "Russia",
-            "geometry": {
-                "latitude": 55.7558,
-                "longitude": 37.6173
-            },
-            "name": "Central, Moscow",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-13T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-13T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-686962",
-            "city": "Moscow",
-            "province": "Central",
-            "country": "Russia",
-            "date_confirmation": "13.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6363.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "location": {
-            "country": "Russia",
-            "geometry": {
-                "latitude": 60.00000000000006,
-                "longitude": 100.00000000000006
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-711285",
-            "city": "Khakassia",
-            "province": "Siberia",
-            "country": "Russia",
-            "date_confirmation": "15.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "10852.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 35.0,
-                "end": 59.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Germany",
-            "geometry": {
-                "latitude": 48.420540542000026,
-                "longitude": 8.017447066000045
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-25T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "007-73561",
-            "city": "Ortenaukreis",
-            "province": "Baden-Wurttemberg",
-            "country": "Germany",
-            "date_onset_symptoms": "25.03.2020",
-            "date_confirmation": "04.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "11861.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Bouches-du-Rhone",
-            "administrativeAreaLevel1": "Provence-Alpes-Cote d'Azur",
-            "country": "France",
-            "geometry": {
-                "latitude": 43.543479999999995,
-                "longitude": 5.085989
-            },
-            "name": "Provence-Alpes-Cote d'Azur, Bouches-du-Rhone",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "hospitalAdmission",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e119",
-            "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-759935",
-            "city": "Bouches-du-Rhone",
-            "province": "Provence-Alpes-Cote d'Azur",
-            "country": "France",
-            "date_admission_hospital": "12.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "1694.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Nord",
-            "administrativeAreaLevel1": "Hauts-de-France",
-            "country": "France",
-            "geometry": {
-                "latitude": 50.45028,
-                "longitude": 3.212466
-            },
-            "name": "Hauts-de-France, Nord",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "hospitalAdmission",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e119",
-            "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-784259",
-            "city": "Nord",
-            "province": "Hauts-de-France",
-            "country": "France",
-            "date_admission_hospital": "05.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6645.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Paris",
-            "administrativeAreaLevel1": "Ile-de-France",
-            "country": "France",
-            "geometry": {
-                "latitude": 48.85666,
-                "longitude": 2.342325
-            },
-            "name": "Ile-de-France, Paris",
-            "geoResolution": "Admin2"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "hospitalAdmission",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e119",
-            "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-808583",
-            "city": "Paris",
-            "province": "Ile-de-France",
-            "country": "France",
-            "date_admission_hospital": "07.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "6904.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel2": "Seine-Saint-Denis",
-            "administrativeAreaLevel1": "Ile-de-France",
-            "country": "France",
-            "geometry": {
-                "latitude": 48.917559999999995,
-                "longitude": 2.47795
-            },
-            "name": "Ile-de-France, Seine-Saint-Denis",
-            "geoResolution": "Admin2"
-        },
-        "list": true,
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-12T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "hospitalAdmission",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e119",
-            "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-832907",
-            "city": "Seine-Saint-Denis",
-            "province": "Ile-de-France",
-            "country": "France",
-            "date_admission_hospital": "27.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "7935.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 37.463095115000044,
-                "longitude": -4.576205755999979
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-24T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e120",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-857231",
-            "province": "Andalucia",
-            "country": "Spain",
-            "date_confirmation": "24.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "12075.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "Castilla-La Mancha",
-            "country": "Spain",
-            "geometry": {
-                "latitude": 39.5934269,
-                "longitude": -3.0036282
-            },
-            "name": "Castilla-La Mancha",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e120",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-881556",
-            "province": "Castilla La Mancha",
-            "country": "Spain",
-            "date_confirmation": "02.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "350.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "Castilla y Leon",
-            "country": "Spain",
-            "geometry": {
-                "latitude": 41.767612299999996,
-                "longitude": -4.7805168
-            },
-            "name": "Castilla y Leon",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-04T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e120",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-905880",
-            "province": "Castilla y Leon",
-            "country": "Spain",
-            "date_confirmation": "04.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "351.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 41.79850998500007,
-                "longitude": 1.5289057830000274
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e120",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-930203",
-            "province": "Cataluna",
-            "country": "Spain",
-            "date_confirmation": "28.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "12077.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 41.79850998500007,
-                "longitude": 1.5289057830000274
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-17T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-17T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e120",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-954529",
-            "province": "Cataluna",
-            "country": "Spain",
-            "date_confirmation": "17.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "12077.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Spain",
-            "geometry": {
-                "latitude": 41.43312000000003,
-                "longitude": 1.8611000000000217
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e120",
-            "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "007-978854",
-            "province": "C. Valenciana",
-            "country": "Spain",
-            "date_confirmation": "02.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "12079.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Turkey",
-            "geometry": {
-                "latitude": 39.10205,
-                "longitude": 35.17355
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-20T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e121",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-103177",
-            "country": "Turkey",
-            "date_confirmation": "20.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "229.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Turkey",
-            "geometry": {
-                "latitude": 39.10205,
-                "longitude": 35.17355
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-28T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-28T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e121",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-127501",
-            "country": "Turkey",
-            "date_confirmation": "28.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "229.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Turkey",
-            "geometry": {
-                "latitude": 39.10205,
-                "longitude": 35.17355
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-10T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-10T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e121",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-151826",
-            "country": "Turkey",
-            "date_confirmation": "10.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "229.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Belarus",
-            "geometry": {
-                "latitude": 53.59231,
-                "longitude": 28.065179999999998
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-12T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e121",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/belarus/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-176150",
-            "country": "Belarus",
-            "date_confirmation": "12.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "21.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Belarus",
-            "geometry": {
-                "latitude": 53.59231,
-                "longitude": 28.065179999999998
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e121",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/belarus/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-200474",
-            "country": "Belarus",
-            "date_confirmation": "15.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "21.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel3": "Birmingham",
-            "administrativeAreaLevel2": "West Midlands",
-            "administrativeAreaLevel1": "England",
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 52.48,
-                "longitude": -1.9025
-            },
-            "name": "England, West Midlands, Birmingham",
-            "geoResolution": "Admin3"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-10T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-10T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-2248",
-            "city": "Birmingham,West Midlands",
-            "province": "England",
-            "country": "United Kingdom",
-            "date_confirmation": "10.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "1593.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel3": "Enfield",
-            "administrativeAreaLevel2": "Greater London",
-            "administrativeAreaLevel1": "England",
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 51.645,
-                "longitude": -0.06
-            },
-            "name": "England, Greater London, Enfield",
-            "geoResolution": "Admin3"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-249123",
-            "city": "Enfield,Greater London",
-            "province": "England",
-            "country": "United Kingdom",
-            "date_confirmation": "02.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "3149.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel3": "Brighton and Hove",
-            "administrativeAreaLevel2": "East Sussex",
-            "administrativeAreaLevel1": "England",
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 50.827778,
-                "longitude": -0.152778
-            },
-            "name": "England, East Sussex, Brighton and Hove",
-            "geoResolution": "Admin3"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-273448",
-            "city": "Brighton and Hove,East Sussex",
-            "province": "England",
-            "country": "United Kingdom",
-            "date_confirmation": "08.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "1749.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Serbia",
-            "geometry": {
-                "latitude": 44.24848,
-                "longitude": 20.7733
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-09T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-09T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e123",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/serbia/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-297773",
-            "country": "Serbia",
-            "date_confirmation": "09.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "198.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 54.37002,
-                "longitude": -2.95214
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-12T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-12T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-322096",
-            "country": "United Kingdom",
-            "date_confirmation": "12.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "236.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel3": "Brent",
-            "administrativeAreaLevel2": "Greater London",
-            "administrativeAreaLevel1": "England",
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 51.566111,
-                "longitude": -0.273889
-            },
-            "name": "England, Greater London, Brent",
-            "geoResolution": "Admin3"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-18T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-18T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-346420",
-            "city": "Brent,Greater London",
-            "province": "England",
-            "country": "United Kingdom",
-            "date_confirmation": "18.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "1742.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel3": "Enfield",
-            "administrativeAreaLevel2": "Greater London",
-            "administrativeAreaLevel1": "England",
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 51.645,
-                "longitude": -0.06
-            },
-            "name": "England, Greater London, Enfield",
-            "geoResolution": "Admin3"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-370745",
-            "city": "Enfield,Greater London",
-            "province": "England",
-            "country": "United Kingdom",
-            "date_confirmation": "23.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "3149.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Turkey",
-            "geometry": {
-                "latitude": 39.10205,
-                "longitude": 35.17355
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-05T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e125",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-39507",
-            "country": "Turkey",
-            "date_confirmation": "05.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "229.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 54.37002,
-                "longitude": -2.95214
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-03T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-419394",
-            "country": "United Kingdom",
-            "date_confirmation": "03.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "236.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 54.37002,
-                "longitude": -2.95214
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-443718",
-            "country": "United Kingdom",
-            "date_confirmation": "08.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "236.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 54.37002,
-                "longitude": -2.95214
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-15T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-15T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-468042",
-            "country": "United Kingdom",
-            "date_confirmation": "15.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "236.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "administrativeAreaLevel1": "England",
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 52.65185,
-                "longitude": -1.46183
-            },
-            "name": "England",
-            "geoResolution": "Admin1"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-492367",
-            "province": "England",
-            "country": "United Kingdom",
-            "date_confirmation": "25.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "411.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "United Kingdom",
-            "geometry": {
-                "latitude": 54.37002,
-                "longitude": -2.95214
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-06-08T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-06-08T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e122",
-            "sourceUrl": "https://coronavirus.data.gov.uk/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-516691",
-            "country": "United Kingdom",
-            "date_confirmation": "08.06.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "236.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Ukraine",
-            "geometry": {
-                "latitude": 49.09008,
-                "longitude": 31.36637
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-07T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e127",
-            "sourceUrl": "https://www.kyivpost.com/ukraine-politics/covid-19-in-ukraine-340-dead-13691-cases-507-new-infections.html",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-541014",
-            "country": "Ukraine",
-            "date_confirmation": "07.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "234.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Turkey",
-            "geometry": {
-                "latitude": 39.10205,
-                "longitude": 35.17355
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-10T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-10T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e125",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-56534",
-            "country": "Turkey",
-            "date_confirmation": "10.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "229.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "location": {
-            "country": "Turkey",
-            "geometry": {
-                "latitude": 39.10205,
-                "longitude": 35.17355
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Country"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-14T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-14T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "ZW",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e125",
-            "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "importedCase": {
-            "ID": "008-75891",
-            "country": "Turkey",
-            "date_confirmation": "14.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "229.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 55.0,
-                "end": 55.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Colombia",
-            "geometry": {
-                "latitude": 6.3464100000000485,
-                "longitude": -75.50799999999998
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-16T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-17T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-17T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "009-10214",
-            "city": "Copacabana",
-            "province": "Antioquia",
-            "country": "Colombia",
-            "date_onset_symptoms": "16.04.2020",
-            "date_confirmation": "17.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "14484.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 20.0,
-                "end": 20.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Peru",
-            "geometry": {
-                "latitude": -12.066669999999931,
-                "longitude": -77.13332999999994
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-06-06T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-06-06T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "009-3454",
-            "city": "Bellavista",
-            "province": "Callao",
-            "country": "Peru",
-            "date_confirmation": "06.06.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "14486.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 22.0,
-                "end": 22.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Argentina",
-            "geometry": {
-                "latitude": -34.610859,
-                "longitude": -58.486392
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "onsetSymptoms",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-27T00:00:00Z"
-                    }
-                }
-            },
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-27T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-27T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "009-58865",
-            "city": "COMUNA 1",
-            "province": "CABA",
-            "country": "Argentina",
-            "date_onset_symptoms": "27.05.2020",
-            "date_confirmation": "27.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "15865.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 28.0,
-                "end": 28.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Peru",
-            "geometry": {
-                "latitude": -11.93297999999993,
-                "longitude": -77.04084999999998
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-20T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-20T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "010-111367",
-            "city": "Comas",
-            "province": "Lima",
-            "country": "Peru",
-            "date_confirmation": "20.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "14426.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 37.0,
-                "end": 37.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Peru",
-            "geometry": {
-                "latitude": -13.40199999999993,
-                "longitude": -76.15811999999994
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-25T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-25T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "010-135692",
-            "city": "GROCIO PRADO",
-            "province": "Chincha",
-            "country": "Peru",
-            "date_confirmation": "25.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "15126.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 45.0,
-                "end": 45.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Peru",
-            "geometry": {
-                "latitude": -12.038179999999954,
-                "longitude": -76.89317999999997
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-29T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-29T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "010-160015",
-            "city": "Ate",
-            "province": "Lima",
-            "country": "Peru",
-            "date_confirmation": "29.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "14418.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 68.0,
-                "end": 68.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Peru",
-            "geometry": {
-                "latitude": -6.548049999999932,
-                "longitude": -79.86393999999996
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-04-23T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "010-26450",
-            "city": "MOCHUMI",
-            "province": "Lambayeque",
-            "country": "Peru",
-            "date_confirmation": "23.04.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "14671.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 52.0,
-                "end": 52.0
-            },
-            "gender": "Male"
-        },
-        "location": {
-            "country": "Peru",
-            "geometry": {
-                "latitude": -8.081809999999962,
-                "longitude": -79.02201999999994
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-05-02T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-05-02T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "010-50775",
-            "city": "Florencia de Mora",
-            "province": "Trujillo",
-            "country": "Peru",
-            "date_confirmation": "02.05.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "15043.0",
-            "travel_history_binary": "False"
-        }
-    },
-    {
-        "caseReference": {
-            "sourceId": "5ea86423bae6982635d2e110",
-            "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
-            "verificationStatus": "UNVERIFIED"
-        },
-        "demographics": {
-            "ageRange": {
-                "start": 56.0,
-                "end": 56.0
-            },
-            "gender": "Female"
-        },
-        "location": {
-            "country": "Peru",
-            "geometry": {
-                "latitude": -12.071769999999958,
-                "longitude": -77.11783999999994
-            },
-            "name": "Non-empty name",
-            "geoResolution": "Point"
-        },
-        "events": [
-            {
-                "name": "confirmed",
-                "dateRange": {
-                    "start": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    },
-                    "end": {
-                        "$date": "2020-03-28T00:00:00Z"
-                    }
-                }
-            }
-        ],
-        "revisionMetadata": {
-            "revisionNumber": 0,
-            "creationMetadata": {
-                "curator": "TR",
-                "date": {
-                    "$date": {
-                        "$numberLong": "1587614400000"
-                    }
-                }
-            }
-        },
-        "importedCase": {
-            "ID": "010-751",
-            "city": "La Perla",
-            "province": "Callao",
-            "country": "Peru",
-            "date_confirmation": "28.03.2020",
-            "chronic_disease_binary": "False",
-            "admin_id": "15077.0",
-            "travel_history_binary": "False"
-        }
+            "administrativeAreaLevel2": "Wuhan City",
+            "geoResolution": "Admin2",
+            "name": "Wuhan City",
+            "geometry": {
+              "latitude": {
+                "$numberDouble": "30.592849"
+              },
+              "longitude": {
+                "$numberDouble": "114.305539"
+              }
+            }
+          },
+          "methods": [
+            "Plane"
+          ],
+          "purpose": "Family"
+        }
+      ],
+      "traveledPrior30Days": true
+    },
+    "pathogens": [
+      {
+        "name": "COVID-19",
+        "id": 304
+      },
+      {
+        "name": "Pneumonia",
+        "id": 104
+      }
+    ],
+    "notes": "Contact of a confirmed case at work.",
+    "revisionMetadata": {
+      "revisionNumber": 1,
+      "creationMetadata": {
+        "curator": "abc123",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        },
+        "notes": "initial data entry"
+      },
+      "updateMetadata": {
+        "curator": "xyz789",
+        "date": {
+          "$date": {
+            "$numberLong": "1587814400000"
+          }
+        },
+        "notes": "fix source error"
+      }
+    },
+    "transmission": {
+      "routes": [
+        "Vector borne"
+      ],
+      "places": [
+        "Gym"
+      ],
+      "linkedCaseIds": [
+        "abc",
+        "def"
+      ]
+    },
+    "importedCase": {
+      "ID": "idk",
+      "chronic_disease_binary": "true",
+      "outcome": "discharge 2/12",
+      "admin_id": "291",
+      "lives_in_Wuhan": "false",
+      "reported_market_exposure": "true"
     }
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2a116",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 56,
+        "end": 56
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -12.071769999999958,
+        "longitude": -77.11783999999994
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-28T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-28T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "variant": {
+      "name": "B.1.351"
+    },
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "010-751",
+      "city": "La Perla",
+      "province": "Callao",
+      "country": "Peru",
+      "date_confirmation": "28.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "15077.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "demographics": {
+      "gender": "Male"
+    },
+    "location": {
+      "administrativeAreaLevel1": "Hong Kong",
+      "country": "China",
+      "geometry": {
+        "latitude": 22.3650193,
+        "longitude": 114.133808
+      },
+      "name": "Hong Kong",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-02-14T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-02-14T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "notes": "Case 55; mainland China travel via the Lok Ma Chau border crossing",
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f0",
+      "sourceUrl": "https://www.scmp.com/news/hong-kong/health-environment/article/3050681/coronavirus-hong-kong-confirms-three-news-cases",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "travelHistory": {
+      "travel": [
+        {
+          "dateRange": {
+            "start": {
+              "$date": "2020-01-22T00:00:00Z"
+            },
+            "end": {
+              "$date": "2020-01-22T00:00:00Z"
+            }
+          },
+          "location": {
+            "country": "China",
+            "geometry": {
+              "latitude": 37.59841,
+              "longitude": 104.1868
+            },
+            "name": "China",
+            "geoResolution": "Country"
+          }
+        }
+      ]
+    },
+    "importedCase": {
+      "ID": "000-1-1",
+      "city": "Shek Lei",
+      "province": "Hong Kong",
+      "country": "China",
+      "date_confirmation": "14.02.2020",
+      "travel_history_dates": "22.01.2020",
+      "travel_history_location": "China",
+      "chronic_disease_binary": "False",
+      "outcome": "critical condition, intubated as of 14.02.2020",
+      "admin_id": "8051.0"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 54.37002,
+        "longitude": -2.95214
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-14T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-14T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f1",
+      "sourceUrl": "https://twitter.com/DHSCgovuk/status/1238837700943323136",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "000-1-34326",
+      "country": "United Kingdom",
+      "date_confirmation": "14.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "236.0"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Wuhan City",
+      "administrativeAreaLevel1": "Hubei",
+      "country": "China",
+      "geometry": {
+        "latitude": 30.625059999999998,
+        "longitude": 114.3421
+      },
+      "name": "Hubei, Wuhan City",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-02-17T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-02-17T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f2",
+      "sourceUrl": "http://wjw.hubei.gov.cn/fbjd/dtyw/202002/t20200218_2091007.shtml",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "000-2-18700",
+      "city": "Wuhan City",
+      "province": "Hubei",
+      "country": "China",
+      "date_confirmation": "17.02.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "9390.0"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "South Africa",
+      "geometry": {
+        "latitude": -29.122,
+        "longitude": 25.031470000000002
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-07T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-07T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f3",
+      "sourceUrl": "github.com/dsfsi/covid19za",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "001-23950",
+      "country": "South Africa",
+      "date_confirmation": "07.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "207.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Egypt",
+      "geometry": {
+        "latitude": 26.667959999999997,
+        "longitude": 29.77867
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-06-03T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-06-03T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f4",
+      "sourceUrl": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_daily_reports/",
+      "verificationStatus": "UNVERIFIED",
+      "additionalSources": [
+        {
+          "sourceUrl": "daily totals confirmed on https://www.worldometers.info/coronavirus/"
+        }
+      ]
+    },
+    "importedCase": {
+      "ID": "001-48275",
+      "country": "Egypt",
+      "date_confirmation": "03.06.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "66.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "demographics": {
+      "ageRange": {
+        "start": 64,
+        "end": 64
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Philippines",
+      "geometry": {
+        "latitude": 9.333330000000046,
+        "longitude": 123.66667000000007
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-06-08T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-06-08T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "notes": "C960191",
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f5",
+      "sourceUrl": "PH Data Drop",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-113677",
+      "province": "Cebu Province",
+      "country": "Philippines",
+      "date_confirmation": "08.06.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "14108.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 18.940170000000023,
+        "longitude": 72.83483000000007
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-05T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-05T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f6",
+      "sourceUrl": "https://covid19-phdmah.hub.arcgis.com/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-138000",
+      "city": "Mumbai",
+      "province": "Maharashtra",
+      "country": "India",
+      "date_confirmation": "05.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Hospitalized",
+      "admin_id": "10992.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 18.940170000000023,
+        "longitude": 72.83483000000007
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-11T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-11T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e1f7",
+      "sourceUrl": "https://t.me/indiacovid/4560",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-162325",
+      "city": "Mumbai",
+      "province": "Maharashtra",
+      "country": "India",
+      "date_confirmation": "11.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Hospitalized",
+      "admin_id": "10992.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 21.185780000000022,
+        "longitude": 72.83679000000006
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-16T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-16T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e100",
+      "sourceUrl": "https://twitter.com/PIBAhmedabad/status/1261669285484793857",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-186650",
+      "city": "Surat",
+      "province": "Gujarat",
+      "country": "India",
+      "date_confirmation": "16.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Hospitalized",
+      "admin_id": "11037.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 19.03681000000006,
+        "longitude": 73.01582000000008
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-19T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-19T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e101",
+      "sourceUrl": "https://www.deshgujarat.com/2020/05/22/gujarat-covid19-cases-update/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-210974",
+      "province": "Maharashtra",
+      "country": "India",
+      "date_confirmation": "19.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Recovered",
+      "admin_id": "10997.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 23.027760000000058,
+        "longitude": 72.60027000000008
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-22T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-22T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e101",
+      "sourceUrl": "https://www.deshgujarat.com/2020/05/22/gujarat-covid19-cases-update/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-235299",
+      "city": "Ahmedabad",
+      "province": "Gujarat",
+      "country": "India",
+      "date_confirmation": "22.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Recovered",
+      "admin_id": "11047.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 13.083620000000053,
+        "longitude": 80.28252000000003
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-25T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e102",
+      "sourceUrl": "https://stopcorona.tn.gov.in/wp-content/uploads/2020/03/Media-Bulletin-25-05-20-COVID-19-6-PM.pdf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-259623",
+      "city": "Chennai",
+      "province": "Tamil Nadu",
+      "country": "India",
+      "date_confirmation": "25.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Recovered",
+      "admin_id": "11023.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 20.826760000000036,
+        "longitude": 71.04510000000005
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-28T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-28T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e103",
+      "sourceUrl": "mohfw.gov.in",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-283948",
+      "city": "Unassigned",
+      "province": "State Unassigned",
+      "country": "India",
+      "date_confirmation": "28.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Hospitalized",
+      "admin_id": "12668.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 18.940170000000023,
+        "longitude": 72.83483000000007
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-29T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-29T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e104",
+      "sourceUrl": "https://arogya.maharashtra.gov.in/pdf/ncovidepressnotemay29.pdf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-308271",
+      "city": "Mumbai",
+      "province": "Maharashtra",
+      "country": "India",
+      "date_confirmation": "29.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Recovered",
+      "admin_id": "10992.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 19.200000000000045,
+        "longitude": 72.96667000000008
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-31T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-31T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e104",
+      "sourceUrl": "https://arogya.maharashtra.gov.in/pdf/ncovidepressnotemay31.pdf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-332596",
+      "city": "Thane",
+      "province": "Maharashtra",
+      "country": "India",
+      "date_confirmation": "31.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Recovered",
+      "admin_id": "11099.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 19.03681000000006,
+        "longitude": 73.01582000000008
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-26T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-26T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e105",
+      "sourceUrl": "https://twitter.com/ANI/status/1254410536969809922",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-47997",
+      "province": "Maharashtra",
+      "country": "India",
+      "date_confirmation": "26.04.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Hospitalized",
+      "admin_id": "10997.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "demographics": {
+      "ageRange": {
+        "start": 30,
+        "end": 30
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "India",
+      "geometry": {
+        "latitude": 12.682240000000036,
+        "longitude": 79.98008000000004
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-21T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-21T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e106",
+      "sourceUrl": "https://stopcorona.tn.gov.in/wp-content/uploads/2020/03/Media-Bulletin-21-05-20-COVID-19-6-PM.pdf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-72321",
+      "city": "Chengalpattu",
+      "province": "Tamil Nadu",
+      "country": "India",
+      "date_confirmation": "21.05.2020",
+      "chronic_disease_binary": "False",
+      "outcome": "Hospitalized",
+      "admin_id": "12555.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Nanyang City",
+      "administrativeAreaLevel1": "Henan",
+      "country": "China",
+      "geometry": {
+        "latitude": 33.04534,
+        "longitude": 112.2833
+      },
+      "name": "Henan, Nanyang City",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-02-03T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-02-03T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e107",
+      "sourceUrl": "https://m.weibo.cn/status/4468161329843481",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "002-9665",
+      "city": "Nanyang City",
+      "province": "Henan",
+      "country": "China",
+      "date_confirmation": "03.02.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6480.0",
+      "travel_history_binary": "True"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "Catalonia",
+      "country": "Spain",
+      "geometry": {
+        "latitude": 41.803774100000005,
+        "longitude": 1.530937
+      },
+      "name": "Catalonia",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-22T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-22T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e108",
+      "sourceUrl": "https://en.wikipedia.org/wiki/2020_coronavirus_pandemic_in_Spain",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "003-23162",
+      "province": "Catalonia",
+      "country": "Spain",
+      "date_confirmation": "22.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "354.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Staffordshire",
+      "administrativeAreaLevel1": "England",
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 52.833332999999996,
+        "longitude": -2
+      },
+      "name": "England, Staffordshire",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-25T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e109",
+      "sourceUrl": "https://www.arcgis.com/apps/opsdashboard/index.html#/f94c3c90da5b4e9f9a0b19484dd4bb14",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "003-47489",
+      "city": "Staffordshire",
+      "province": "England",
+      "country": "United Kingdom",
+      "date_confirmation": "25.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "8305.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "demographics": {
+      "ageRange": {
+        "start": 50,
+        "end": 59
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Belgium",
+      "geometry": {
+        "latitude": 51.222120000000075,
+        "longitude": 4.397690000000068
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-26T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-26T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "003-71812",
+      "city": "Antwerpen",
+      "province": "Flanders",
+      "country": "Belgium",
+      "date_confirmation": "26.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "11417.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "demographics": {
+      "ageRange": {
+        "start": 60,
+        "end": 69
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Belgium",
+      "geometry": {
+        "latitude": 50.99142331000007,
+        "longitude": 5.429156289000048
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-15T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-15T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "003-96137",
+      "city": "Limburg",
+      "province": "Flanders",
+      "country": "Belgium",
+      "date_confirmation": "15.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "11422.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 39,
+        "end": 39
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Mexico",
+      "geometry": {
+        "latitude": 20.566667000000002,
+        "longitude": -103.68333299999999
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-29T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-29T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-09T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-09T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "004-30461",
+      "province": "Jalisco",
+      "country": "Mexico",
+      "date_onset_symptoms": "29.03.2020",
+      "date_confirmation": "09.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "501.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "Illinois",
+      "country": "United States",
+      "geometry": {
+        "latitude": 41.8781,
+        "longitude": -87.6298
+      },
+      "name": "Illinois",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-22T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-22T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e111",
+      "sourceUrl": "http://www.dph.illinois.gov/topics-services/diseases-and-conditions/diseases-a-z-list/coronavirus",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "005-14468",
+      "city": "Chicago",
+      "province": "Illinois",
+      "country": "United States",
+      "date_confirmation": "22.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "2232.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Cook County",
+      "administrativeAreaLevel1": "Illinois",
+      "country": "United States",
+      "geometry": {
+        "latitude": 41.843684,
+        "longitude": -87.816737
+      },
+      "name": "Illinois, Cook County",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-26T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-26T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e111",
+      "sourceUrl": "http://www.dph.illinois.gov/topics-services/diseases-and-conditions/diseases-a-z-list/coronavirus",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "005-38804",
+      "city": "Cook County",
+      "province": "Illinois",
+      "country": "United States",
+      "date_confirmation": "26.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "2446.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Orange County",
+      "administrativeAreaLevel1": "New York",
+      "country": "United States",
+      "geometry": {
+        "latitude": 41.4022111,
+        "longitude": -74.305756
+      },
+      "name": "New York, Orange County",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-21T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-21T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e112",
+      "sourceUrl": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "006-10920",
+      "city": "Orange County",
+      "province": "New York",
+      "country": "United States",
+      "date_confirmation": "21.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6788.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "New York",
+      "country": "United States",
+      "geometry": {
+        "latitude": 43.0140874,
+        "longitude": -75.646457
+      },
+      "name": "New York",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-26T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-26T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e112",
+      "sourceUrl": "https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "006-35245",
+      "province": "New York",
+      "country": "United States",
+      "date_confirmation": "26.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "658.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Spain",
+      "geometry": {
+        "latitude": 40.41955000000007,
+        "longitude": -3.6919599999999377
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-24T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-24T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e113",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-1002481",
+      "province": "Madrid",
+      "country": "Spain",
+      "date_confirmation": "24.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "583.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Spain",
+      "geometry": {
+        "latitude": 40.41955000000007,
+        "longitude": -3.6919599999999377
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-05T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-05T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e113",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-1026806",
+      "province": "Madrid",
+      "country": "Spain",
+      "date_confirmation": "05.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "583.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 15,
+        "end": 34
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Germany",
+      "geometry": {
+        "latitude": 49.30069000000003,
+        "longitude": 10.572080000000028
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-25T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-25T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-105113",
+      "city": "Ansbach",
+      "province": "Bayern",
+      "country": "Germany",
+      "date_onset_symptoms": "25.03.2020",
+      "date_confirmation": "25.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "11566.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "Pais Vasco",
+      "country": "Spain",
+      "geometry": {
+        "latitude": 43.04468920000001,
+        "longitude": -2.6168503
+      },
+      "name": "Pais Vasco",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-25T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e113",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-1075455",
+      "province": "Pais Vasco",
+      "country": "Spain",
+      "date_confirmation": "25.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "717.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Austria",
+      "geometry": {
+        "latitude": 47.30796174000005,
+        "longitude": 13.267656657000032
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-08T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-08T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e114",
+      "sourceUrl": "https://github.com/statistikat/coronaDAT/raw/master/archive/20200408/data/20200408_230000.rds",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-1099780",
+      "city": "Sankt Johann im Pongau",
+      "province": "Salzburg",
+      "country": "Austria",
+      "date_confirmation": "08.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "12151.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "Stockholm",
+      "country": "Sweden",
+      "geometry": {
+        "latitude": 59.6025,
+        "longitude": 18.1384
+      },
+      "name": "Stockholm",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-13T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-13T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e115",
+      "sourceUrl": "https://www.folkhalsomyndigheten.se/smittskydd-beredskap/utbrott/aktuella-utbrott/covid-19/bekraftade-fall-i-sverige",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-1124102",
+      "province": "Stockholm",
+      "country": "Sweden",
+      "date_confirmation": "13.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "845.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 35,
+        "end": 59
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "administrativeAreaLevel2": "Mansfeld-Sudharz",
+      "administrativeAreaLevel1": "Sachsen-Anhalt",
+      "country": "Germany",
+      "geometry": {
+        "latitude": 51.53589,
+        "longitude": 11.35641
+      },
+      "name": "Sachsen-Anhalt, Mansfeld-Sudharz",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-18T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-18T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-21T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-21T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-127500",
+      "city": "Mansfeld-Sudharz",
+      "province": "Sachsen-Anhalt",
+      "country": "Germany",
+      "date_onset_symptoms": "18.03.2020",
+      "date_confirmation": "21.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "5939.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Spain",
+      "geometry": {
+        "latitude": 35.88999000000007,
+        "longitude": -5.317839999999933
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-16T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-16T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e116",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-151825",
+      "province": "Ceuta",
+      "country": "Spain",
+      "date_confirmation": "16.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "12078.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Cremona",
+      "administrativeAreaLevel1": "Lombardia",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.220890000000004,
+        "longitude": 9.994373
+      },
+      "name": "Lombardia, Cremona",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-31T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-31T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200531.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-176150",
+      "city": "Cremona",
+      "province": "Lombardia",
+      "country": "Italy",
+      "date_confirmation": "31.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "2506.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Brescia",
+      "administrativeAreaLevel1": "Lombardia",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.70507,
+        "longitude": 10.31322
+      },
+      "name": "Lombardia, Brescia",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-16T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-16T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200316.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-200474",
+      "city": "Brescia",
+      "province": "Lombardia",
+      "country": "Italy",
+      "date_confirmation": "16.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "1743.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Varese",
+      "administrativeAreaLevel1": "Lombardia",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.80526,
+        "longitude": 8.776143
+      },
+      "name": "Lombardia, Varese",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-28T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-28T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200328.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-2248",
+      "city": "Varese",
+      "province": "Lombardia",
+      "country": "Italy",
+      "date_confirmation": "28.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "8915.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.165410000000065,
+        "longitude": 10.79242000000005
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-26T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-26T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200326.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-249123",
+      "city": "Mantova",
+      "province": "Lombardia",
+      "country": "Italy",
+      "date_confirmation": "26.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "10799.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Frosinone",
+      "administrativeAreaLevel1": "Lazio",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 41.616609999999994,
+        "longitude": 13.53626
+      },
+      "name": "Lazio, Frosinone",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-31T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-31T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200331.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-273448",
+      "city": "Frosinone",
+      "province": "Lazio",
+      "country": "Italy",
+      "date_confirmation": "31.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "3401.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Pavia",
+      "administrativeAreaLevel1": "Lombardia",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.110490000000006,
+        "longitude": 9.037306
+      },
+      "name": "Lombardia, Pavia",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-05T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-05T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200405.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-297773",
+      "city": "Pavia",
+      "province": "Lombardia",
+      "country": "Italy",
+      "date_confirmation": "05.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6932.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Pisa",
+      "administrativeAreaLevel1": "Toscana",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 43.50391,
+        "longitude": 10.6677
+      },
+      "name": "Toscana, Pisa",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-11T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-11T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200411.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-322096",
+      "city": "Pisa",
+      "province": "Toscana",
+      "country": "Italy",
+      "date_confirmation": "11.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "7093.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Bryansk Oblast",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 53.0409,
+        "longitude": 33.2691
+      },
+      "name": "Central, Bryansk Oblast",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-15T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-15T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e118",
+      "sourceUrl": "stopcoronavirus.rf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-346420",
+      "city": "Bryansk Oblast",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "15.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "1788.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Moscow",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 55.7558,
+        "longitude": 37.6173
+      },
+      "name": "Central, Moscow",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-20T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-20T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e118",
+      "sourceUrl": "stopcoronavirus.rf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-370745",
+      "city": "Moscow",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "20.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6363.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 60,
+        "end": 79
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Germany",
+      "geometry": {
+        "latitude": 51.98134561000006,
+        "longitude": 8.950931642000057
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-21T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-21T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-29T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-29T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-39507",
+      "city": "Lippe",
+      "province": "Nordrhein-Westfalen",
+      "country": "Germany",
+      "date_onset_symptoms": "21.03.2020",
+      "date_confirmation": "29.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "11771.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Moscow",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 55.7558,
+        "longitude": 37.6173
+      },
+      "name": "Central, Moscow",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-29T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-29T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e118",
+      "sourceUrl": "stopcoronavirus.rf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-419394",
+      "city": "Moscow",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "29.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6363.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 60,
+        "end": 79
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "administrativeAreaLevel2": "Tubingen",
+      "administrativeAreaLevel1": "Baden-Wurttemberg",
+      "country": "Germany",
+      "geometry": {
+        "latitude": 48.481840000000005,
+        "longitude": 8.98765
+      },
+      "name": "Baden-Wurttemberg, Tubingen",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-24T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-24T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-24T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-24T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-443718",
+      "city": "Tubingen",
+      "province": "Baden-Wurttemberg",
+      "country": "Germany",
+      "date_onset_symptoms": "24.03.2020",
+      "date_confirmation": "24.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "8778.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Moscow",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 55.7558,
+        "longitude": 37.6173
+      },
+      "name": "Central, Moscow",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-01T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-01T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e118",
+      "sourceUrl": "stopcoronavirus.rf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-468042",
+      "city": "Moscow",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "01.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6363.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Russia",
+      "geometry": {
+        "latitude": 43.04282494800003,
+        "longitude": 46.87255601000004
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-03T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-03T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e118",
+      "sourceUrl": "stopcoronavirus.rf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-492367",
+      "city": "Dagestan",
+      "province": "North Caucasian",
+      "country": "Russia",
+      "date_confirmation": "03.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "10860.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Moscow",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 55.7558,
+        "longitude": 37.6173
+      },
+      "name": "Central, Moscow",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-06T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-06T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e118",
+      "sourceUrl": "stopcoronavirus.rf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-516691",
+      "city": "Moscow",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "06.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6363.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Moscow",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 55.7558,
+        "longitude": 37.6173
+      },
+      "name": "Central, Moscow",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-08T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-08T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e118",
+      "sourceUrl": "stopcoronavirus.rf",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-541014",
+      "city": "Moscow",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "08.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6363.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 80
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Germany",
+      "geometry": {
+        "latitude": 49.45299347400004,
+        "longitude": 8.110168411000075
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-08T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-08T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-09T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-09T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-56534",
+      "city": "Bad Durkheim",
+      "province": "Rheinland-Pfalz",
+      "country": "Germany",
+      "date_onset_symptoms": "08.04.2020",
+      "date_confirmation": "09.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "11837.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Pavia",
+      "administrativeAreaLevel1": "Lombardia",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.110490000000006,
+        "longitude": 9.037306
+      },
+      "name": "Lombardia, Pavia",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-15T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-15T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200415.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-589665",
+      "city": "Pavia",
+      "province": "Lombardia",
+      "country": "Italy",
+      "date_confirmation": "15.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6932.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Torino",
+      "administrativeAreaLevel1": "Piemonte",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.14739,
+        "longitude": 7.443546
+      },
+      "name": "Piemonte, Torino",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-23T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-23T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200423.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-613989",
+      "city": "Torino",
+      "province": "Piemonte",
+      "country": "Italy",
+      "date_confirmation": "23.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "8737.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Lecco",
+      "administrativeAreaLevel1": "Lombardia",
+      "country": "Italy",
+      "geometry": {
+        "latitude": 45.904379999999996,
+        "longitude": 9.387806
+      },
+      "name": "Lombardia, Lecco",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-07T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-07T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e117",
+      "sourceUrl": "https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-province/dpc-covid19-ita-province-20200507.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-638312",
+      "city": "Lecco",
+      "province": "Lombardia",
+      "country": "Italy",
+      "date_confirmation": "07.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "5344.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "location": {
+      "administrativeAreaLevel2": "Moscow",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 55.7558,
+        "longitude": 37.6173
+      },
+      "name": "Central, Moscow",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-11T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-11T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-662637",
+      "city": "Moscow",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "11.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6363.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "location": {
+      "administrativeAreaLevel2": "Moscow",
+      "administrativeAreaLevel1": "Central",
+      "country": "Russia",
+      "geometry": {
+        "latitude": 55.7558,
+        "longitude": 37.6173
+      },
+      "name": "Central, Moscow",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-13T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-13T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-686962",
+      "city": "Moscow",
+      "province": "Central",
+      "country": "Russia",
+      "date_confirmation": "13.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6363.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "location": {
+      "country": "Russia",
+      "geometry": {
+        "latitude": 60.00000000000006,
+        "longitude": 100.00000000000006
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-15T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-15T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-711285",
+      "city": "Khakassia",
+      "province": "Siberia",
+      "country": "Russia",
+      "date_confirmation": "15.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "10852.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 35,
+        "end": 59
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Germany",
+      "geometry": {
+        "latitude": 48.420540542000026,
+        "longitude": 8.017447066000045
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-25T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-04T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-04T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "007-73561",
+      "city": "Ortenaukreis",
+      "province": "Baden-Wurttemberg",
+      "country": "Germany",
+      "date_onset_symptoms": "25.03.2020",
+      "date_confirmation": "04.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "11861.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Bouches-du-Rhone",
+      "administrativeAreaLevel1": "Provence-Alpes-Cote d'Azur",
+      "country": "France",
+      "geometry": {
+        "latitude": 43.543479999999995,
+        "longitude": 5.085989
+      },
+      "name": "Provence-Alpes-Cote d'Azur, Bouches-du-Rhone",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-12T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-12T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "hospitalAdmission",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-12T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-12T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e119",
+      "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-759935",
+      "city": "Bouches-du-Rhone",
+      "province": "Provence-Alpes-Cote d'Azur",
+      "country": "France",
+      "date_admission_hospital": "12.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "1694.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Nord",
+      "administrativeAreaLevel1": "Hauts-de-France",
+      "country": "France",
+      "geometry": {
+        "latitude": 50.45028,
+        "longitude": 3.212466
+      },
+      "name": "Hauts-de-France, Nord",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-12T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-12T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "hospitalAdmission",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-05T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-05T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e119",
+      "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-784259",
+      "city": "Nord",
+      "province": "Hauts-de-France",
+      "country": "France",
+      "date_admission_hospital": "05.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6645.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Paris",
+      "administrativeAreaLevel1": "Ile-de-France",
+      "country": "France",
+      "geometry": {
+        "latitude": 48.85666,
+        "longitude": 2.342325
+      },
+      "name": "Ile-de-France, Paris",
+      "geoResolution": "Admin2"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-12T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-12T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "hospitalAdmission",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-07T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-07T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e119",
+      "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-808583",
+      "city": "Paris",
+      "province": "Ile-de-France",
+      "country": "France",
+      "date_admission_hospital": "07.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "6904.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel2": "Seine-Saint-Denis",
+      "administrativeAreaLevel1": "Ile-de-France",
+      "country": "France",
+      "geometry": {
+        "latitude": 48.917559999999995,
+        "longitude": 2.47795
+      },
+      "name": "Ile-de-France, Seine-Saint-Denis",
+      "geoResolution": "Admin2"
+    },
+    "list": true,
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-12T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-12T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "hospitalAdmission",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-27T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-27T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e119",
+      "sourceUrl": "https://www.data.gouv.fr/fr/datasets/donnees-hospitalieres-relatives-a-lepidemie-de-covid-19/#_",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-832907",
+      "city": "Seine-Saint-Denis",
+      "province": "Ile-de-France",
+      "country": "France",
+      "date_admission_hospital": "27.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "7935.0",
+      "travel_history_binary": "False"
+    }
+  },
+  {
+    "location": {
+      "country": "Spain",
+      "geometry": {
+        "latitude": 37.463095115000044,
+        "longitude": -4.576205755999979
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-24T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-24T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e120",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-857231",
+      "province": "Andalucia",
+      "country": "Spain",
+      "date_confirmation": "24.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "12075.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "Castilla-La Mancha",
+      "country": "Spain",
+      "geometry": {
+        "latitude": 39.5934269,
+        "longitude": -3.0036282
+      },
+      "name": "Castilla-La Mancha",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-02T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-02T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e120",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-881556",
+      "province": "Castilla La Mancha",
+      "country": "Spain",
+      "date_confirmation": "02.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "350.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "Castilla y Leon",
+      "country": "Spain",
+      "geometry": {
+        "latitude": 41.767612299999996,
+        "longitude": -4.7805168
+      },
+      "name": "Castilla y Leon",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-04T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-04T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e120",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-905880",
+      "province": "Castilla y Leon",
+      "country": "Spain",
+      "date_confirmation": "04.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "351.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Spain",
+      "geometry": {
+        "latitude": 41.79850998500007,
+        "longitude": 1.5289057830000274
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-28T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-28T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e120",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-930203",
+      "province": "Cataluna",
+      "country": "Spain",
+      "date_confirmation": "28.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "12077.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Spain",
+      "geometry": {
+        "latitude": 41.79850998500007,
+        "longitude": 1.5289057830000274
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-17T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-17T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e120",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-954529",
+      "province": "Cataluna",
+      "country": "Spain",
+      "date_confirmation": "17.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "12077.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Spain",
+      "geometry": {
+        "latitude": 41.43312000000003,
+        "longitude": 1.8611000000000217
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-02T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-02T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e120",
+      "sourceUrl": "https://raw.githubusercontent.com/datadista/datasets/master/COVID%2019/ccaa_covid19_casos_long.csv",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "007-978854",
+      "province": "C. Valenciana",
+      "country": "Spain",
+      "date_confirmation": "02.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "12079.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Turkey",
+      "geometry": {
+        "latitude": 39.10205,
+        "longitude": 35.17355
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-20T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-20T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e121",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-103177",
+      "country": "Turkey",
+      "date_confirmation": "20.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "229.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Turkey",
+      "geometry": {
+        "latitude": 39.10205,
+        "longitude": 35.17355
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-28T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-28T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e121",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-127501",
+      "country": "Turkey",
+      "date_confirmation": "28.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "229.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Turkey",
+      "geometry": {
+        "latitude": 39.10205,
+        "longitude": 35.17355
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-10T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-10T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e121",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-151826",
+      "country": "Turkey",
+      "date_confirmation": "10.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "229.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Belarus",
+      "geometry": {
+        "latitude": 53.59231,
+        "longitude": 28.065179999999998
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-12T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-12T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e121",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/belarus/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-176150",
+      "country": "Belarus",
+      "date_confirmation": "12.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "21.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Belarus",
+      "geometry": {
+        "latitude": 53.59231,
+        "longitude": 28.065179999999998
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-15T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-15T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e121",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/belarus/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-200474",
+      "country": "Belarus",
+      "date_confirmation": "15.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "21.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel3": "Birmingham",
+      "administrativeAreaLevel2": "West Midlands",
+      "administrativeAreaLevel1": "England",
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 52.48,
+        "longitude": -1.9025
+      },
+      "name": "England, West Midlands, Birmingham",
+      "geoResolution": "Admin3"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-10T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-10T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-2248",
+      "city": "Birmingham,West Midlands",
+      "province": "England",
+      "country": "United Kingdom",
+      "date_confirmation": "10.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "1593.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel3": "Enfield",
+      "administrativeAreaLevel2": "Greater London",
+      "administrativeAreaLevel1": "England",
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 51.645,
+        "longitude": -0.06
+      },
+      "name": "England, Greater London, Enfield",
+      "geoResolution": "Admin3"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-02T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-02T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-249123",
+      "city": "Enfield,Greater London",
+      "province": "England",
+      "country": "United Kingdom",
+      "date_confirmation": "02.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "3149.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel3": "Brighton and Hove",
+      "administrativeAreaLevel2": "East Sussex",
+      "administrativeAreaLevel1": "England",
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 50.827778,
+        "longitude": -0.152778
+      },
+      "name": "England, East Sussex, Brighton and Hove",
+      "geoResolution": "Admin3"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-08T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-08T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-273448",
+      "city": "Brighton and Hove,East Sussex",
+      "province": "England",
+      "country": "United Kingdom",
+      "date_confirmation": "08.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "1749.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Serbia",
+      "geometry": {
+        "latitude": 44.24848,
+        "longitude": 20.7733
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-09T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-09T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e123",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/serbia/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-297773",
+      "country": "Serbia",
+      "date_confirmation": "09.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "198.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 54.37002,
+        "longitude": -2.95214
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-12T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-12T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-322096",
+      "country": "United Kingdom",
+      "date_confirmation": "12.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "236.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel3": "Brent",
+      "administrativeAreaLevel2": "Greater London",
+      "administrativeAreaLevel1": "England",
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 51.566111,
+        "longitude": -0.273889
+      },
+      "name": "England, Greater London, Brent",
+      "geoResolution": "Admin3"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-18T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-18T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-346420",
+      "city": "Brent,Greater London",
+      "province": "England",
+      "country": "United Kingdom",
+      "date_confirmation": "18.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "1742.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel3": "Enfield",
+      "administrativeAreaLevel2": "Greater London",
+      "administrativeAreaLevel1": "England",
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 51.645,
+        "longitude": -0.06
+      },
+      "name": "England, Greater London, Enfield",
+      "geoResolution": "Admin3"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-23T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-23T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-370745",
+      "city": "Enfield,Greater London",
+      "province": "England",
+      "country": "United Kingdom",
+      "date_confirmation": "23.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "3149.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Turkey",
+      "geometry": {
+        "latitude": 39.10205,
+        "longitude": 35.17355
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-05T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-05T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e125",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-39507",
+      "country": "Turkey",
+      "date_confirmation": "05.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "229.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 54.37002,
+        "longitude": -2.95214
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-03T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-03T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-419394",
+      "country": "United Kingdom",
+      "date_confirmation": "03.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "236.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 54.37002,
+        "longitude": -2.95214
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-08T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-08T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-443718",
+      "country": "United Kingdom",
+      "date_confirmation": "08.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "236.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 54.37002,
+        "longitude": -2.95214
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-15T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-15T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-468042",
+      "country": "United Kingdom",
+      "date_confirmation": "15.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "236.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "administrativeAreaLevel1": "England",
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 52.65185,
+        "longitude": -1.46183
+      },
+      "name": "England",
+      "geoResolution": "Admin1"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-25T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-492367",
+      "province": "England",
+      "country": "United Kingdom",
+      "date_confirmation": "25.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "411.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "United Kingdom",
+      "geometry": {
+        "latitude": 54.37002,
+        "longitude": -2.95214
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-06-08T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-06-08T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e122",
+      "sourceUrl": "https://coronavirus.data.gov.uk/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-516691",
+      "country": "United Kingdom",
+      "date_confirmation": "08.06.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "236.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Ukraine",
+      "geometry": {
+        "latitude": 49.09008,
+        "longitude": 31.36637
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-07T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-07T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e127",
+      "sourceUrl": "https://www.kyivpost.com/ukraine-politics/covid-19-in-ukraine-340-dead-13691-cases-507-new-infections.html",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-541014",
+      "country": "Ukraine",
+      "date_confirmation": "07.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "234.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Turkey",
+      "geometry": {
+        "latitude": 39.10205,
+        "longitude": 35.17355
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-10T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-10T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e125",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-56534",
+      "country": "Turkey",
+      "date_confirmation": "10.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "229.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "location": {
+      "country": "Turkey",
+      "geometry": {
+        "latitude": 39.10205,
+        "longitude": 35.17355
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Country"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-14T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-14T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "ZW",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e125",
+      "sourceUrl": "https://www.worldometers.info/coronavirus/country/turkey/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "importedCase": {
+      "ID": "008-75891",
+      "country": "Turkey",
+      "date_confirmation": "14.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "229.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 55,
+        "end": 55
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Colombia",
+      "geometry": {
+        "latitude": 6.3464100000000485,
+        "longitude": -75.50799999999998
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-16T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-16T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-17T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-17T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "009-10214",
+      "city": "Copacabana",
+      "province": "Antioquia",
+      "country": "Colombia",
+      "date_onset_symptoms": "16.04.2020",
+      "date_confirmation": "17.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "14484.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 20,
+        "end": 20
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -12.066669999999931,
+        "longitude": -77.13332999999994
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-06-06T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-06-06T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "009-3454",
+      "city": "Bellavista",
+      "province": "Callao",
+      "country": "Peru",
+      "date_confirmation": "06.06.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "14486.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 22,
+        "end": 22
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Argentina",
+      "geometry": {
+        "latitude": -34.610859,
+        "longitude": -58.486392
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "onsetSymptoms",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-27T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-27T00:00:00Z"
+          }
+        }
+      },
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-27T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-27T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "009-58865",
+      "city": "COMUNA 1",
+      "province": "CABA",
+      "country": "Argentina",
+      "date_onset_symptoms": "27.05.2020",
+      "date_confirmation": "27.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "15865.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 28,
+        "end": 28
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -11.93297999999993,
+        "longitude": -77.04084999999998
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-20T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-20T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "010-111367",
+      "city": "Comas",
+      "province": "Lima",
+      "country": "Peru",
+      "date_confirmation": "20.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "14426.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 37,
+        "end": 37
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -13.40199999999993,
+        "longitude": -76.15811999999994
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-25T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-25T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "010-135692",
+      "city": "GROCIO PRADO",
+      "province": "Chincha",
+      "country": "Peru",
+      "date_confirmation": "25.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "15126.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 45,
+        "end": 45
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -12.038179999999954,
+        "longitude": -76.89317999999997
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-29T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-29T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "010-160015",
+      "city": "Ate",
+      "province": "Lima",
+      "country": "Peru",
+      "date_confirmation": "29.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "14418.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 68,
+        "end": 68
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -6.548049999999932,
+        "longitude": -79.86393999999996
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-04-23T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-04-23T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "010-26450",
+      "city": "MOCHUMI",
+      "province": "Lambayeque",
+      "country": "Peru",
+      "date_confirmation": "23.04.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "14671.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 52,
+        "end": 52
+      },
+      "gender": "Male"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -8.081809999999962,
+        "longitude": -79.02201999999994
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-05-02T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-05-02T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "010-50775",
+      "city": "Florencia de Mora",
+      "province": "Trujillo",
+      "country": "Peru",
+      "date_confirmation": "02.05.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "15043.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  },
+  {
+    "caseReference": {
+      "sourceId": "5ea86423bae6982635d2e110",
+      "sourceUrl": "https://epistat.wiv-isp.be/Covid/",
+      "verificationStatus": "UNVERIFIED"
+    },
+    "demographics": {
+      "ageRange": {
+        "start": 56,
+        "end": 56
+      },
+      "gender": "Female"
+    },
+    "location": {
+      "country": "Peru",
+      "geometry": {
+        "latitude": -12.071769999999958,
+        "longitude": -77.11783999999994
+      },
+      "name": "Non-empty name",
+      "geoResolution": "Point"
+    },
+    "events": [
+      {
+        "name": "confirmed",
+        "dateRange": {
+          "start": {
+            "$date": "2020-03-28T00:00:00Z"
+          },
+          "end": {
+            "$date": "2020-03-28T00:00:00Z"
+          }
+        }
+      }
+    ],
+    "revisionMetadata": {
+      "revisionNumber": 0,
+      "creationMetadata": {
+        "curator": "TR",
+        "date": {
+          "$date": {
+            "$numberLong": "1587614400000"
+          }
+        }
+      }
+    },
+    "importedCase": {
+      "ID": "010-751",
+      "city": "La Perla",
+      "province": "Callao",
+      "country": "Peru",
+      "date_confirmation": "28.03.2020",
+      "chronic_disease_binary": "False",
+      "admin_id": "15077.0",
+      "travel_history_binary": "False"
+    },
+    "list": true
+  }
 ]


### PR DESCRIPTION
When you run `dev/setup.db`, you only saw 2 cases listed. That's because the other sample cases didn't have `list:true`, which we now need, so add that field.

[I did this with `jq` and it's re-ordered the fields, so the diff is massive. I promise I tested this and it worked!]