### PR TITLE
prune-uploads: Disallow non-UUID updates where cases are dropped

### DIFF
--- a/data-serving/scripts/prune-uploads/README.md
+++ b/data-serving/scripts/prune-uploads/README.md
@@ -64,6 +64,11 @@ Remove the -n to actually prune uploads.
 
 * **-n**, **--dry-run**: Dry run, do not change the database
 
+* **-d**, **--allow-decrease**: Allow cases to decrease in ingestion for non-UUID
+  uploads. By default, non-UUID uploads are only accepted if they increase the number
+  of cases. This option has no effect on UUID source uploads, which are always
+  ingested.
+
 
 ## How it works
 


### PR DESCRIPTION
By default, only allow updates which increase the number of cases.
Adds a --allow-decrease (-d) option to override this behaviour.

Fixes: #2175
