### PR TITLE
Added S3 cache layer to locale2e and Curator API

### DIFF
--- a/dev/docker-compose.dev.full.yml
+++ b/dev/docker-compose.dev.full.yml
@@ -13,7 +13,7 @@ services:
       - "../verification/curator-service/api/src:/usr/src/app/verification/curator-service/api/src"
       - "../verification/curator-service/api/openapi:/usr/src/app/verification/curator-service/api/openapi"
     environment:
-      LOCALHOST_URL: "http://localstack:4566"
+      LOCALSTACK_URL: "http://localstack:4566"
       SERVICE_ENV: "locale2e"
       AFTER_LOGIN_REDIRECT_URL: "http://localhost:3002"
   data:
@@ -70,7 +70,7 @@ services:
       AWS_DEFAULT_REGION: "us-east-1"
       AWS_ENDPOINT: "http://localstack:4566"
       DATA_BUCKET_NAME: "covid-19-data-export"
-      DOWNLOAD_BUCKET_NAME: "covid19-filtered-downloads"
+      CACHE_BUCKET_NAME: "covid-19-cache"
       RETRIEVAL_BUCKET_NAME: "epid-sources-raw"
       BATCH_QUEUE_NAME: "ingestion-queue"
       SES_EMAIL_ADDRESS: "info@global.health"

--- a/dev/setup_localstack.py
+++ b/dev/setup_localstack.py
@@ -45,7 +45,7 @@ BATCH_COMPUTE_ENVIRONMENT_ORDER = [{
 }]
 
 DATA_BUCKET_NAME = environ.get("DATA_BUCKET_NAME", "covid-19-data-export")
-DOWNLOAD_BUCKET_NAME = environ.get("DOWNLOAD_BUCKET_NAME", "covid19-filtered-downloads")
+CACHE_BUCKET_NAME = environ.get("CACHE_BUCKET_NAME", "covid-19-cache")
 RETRIEVAL_BUCKET_NAME = environ.get("RETRIEVAL_BUCKET_NAME", "epid-sources-raw")
 SES_EMAIL_ADDRESS = environ.get("SES_EMAIL_ADDRESS", "info@global.health")
 ECR_REPOSITORY_NAME = environ.get("ECR_REPOSITORY_NAME", "gdh-ingestor")
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     lw.create_batch_job_queue(BATCH_JOB_QUEUE_NAME)
     lw.setup_ses(SES_EMAIL_ADDRESS)
     lw.create_s3_bucket(DATA_BUCKET_NAME)
-    lw.create_s3_bucket(DOWNLOAD_BUCKET_NAME)
+    lw.create_s3_bucket(CACHE_BUCKET_NAME)
     lw.create_s3_bucket(RETRIEVAL_BUCKET_NAME)
     lw.create_container_repository(ECR_REPOSITORY_NAME)
     print("Done setting up localstack resources")

--- a/ingestion/functions/common/parsing_lib.py
+++ b/ingestion/functions/common/parsing_lib.py
@@ -1,3 +1,4 @@
+import csv
 import datetime
 import json
 import os
@@ -14,6 +15,7 @@ import requests
 import requests.exceptions
 
 import common_lib
+
 
 ENV_FIELD = "env"
 SOURCE_URL_FIELD = "sourceUrl"
@@ -36,6 +38,7 @@ DATE_FORMATS = ["%m/%d/%YZ", "%m/%d/%Y"]
 # Increasing that number will speed-up the ingestion but will increase memory
 # usage on the server-side and is known to cause OOMs so increase with caution.
 CASES_BATCH_SIZE = 250
+
 
 try:
     with (Path(__file__).parent / "geocoding_countries.json").open() as g:
@@ -442,6 +445,7 @@ def run(
         excluded_case_ids = retrieve_excluded_case_ids(source_id, date_filter, date_range, env,
                                                        headers=api_creds, cookies=cookies)
         final_cases = prepare_cases(case_data, upload_id, excluded_case_ids)
+
         count_created, count_updated, count_error = write_to_server(
             filter_cases_by_date(
                 final_cases,
@@ -452,6 +456,7 @@ def run(
             env, source_id, upload_id,
             api_creds, cookies,
             CASES_BATCH_SIZE)
+
         for _ in range(5):  # Maximum number of attempts to finalize upload
             status, text = common_lib.finalize_upload(
                 env, source_id, upload_id, api_creds, cookies, count_created,
@@ -465,6 +470,7 @@ def run(
                 continue
             else:
                 raise RuntimeError(f"Error updating upload record, status={status}, response={text}")
+
         return {"count_created": count_created, "count_updated": count_updated}
     except Exception as e:
         common_lib.complete_with_error(

--- a/ingestion/functions/common/parsing_lib_test.py
+++ b/ingestion/functions/common/parsing_lib_test.py
@@ -26,6 +26,7 @@ except ImportError:
     sys.path.append(os.path.dirname(os.path.abspath(__file__)))
     import common_lib
 
+
 _SOURCE_API_URL = "http://bar.baz"
 _SOURCE_ID = "5f0b9a7ead3a2b003edc0e7f"
 _SOURCE_URL = "https://foo.bar"
@@ -78,6 +79,20 @@ CASE_JUNE_FIFTH = {
     ],
 }
 
+MOCK_SOURCE_DETAILS = {
+    "origin": {
+        "url": ""
+    },
+    "format": "",
+    "automation": {
+        "parser": {
+            "awsLambdaArn": "",
+        },
+    },
+    "dateFilter": "",
+    "hasStableIdentifiers": False
+}
+
 
 def fake_parsing_fn(raw_data_file, source_id, source_url):
     """For use in testing parsing_lib.run_lambda()."""
@@ -101,9 +116,9 @@ def mock_source_api_url_fixture():
             os.pardir,
             os.pardir,
             os.pardir,
-            'common'))
+            "common"))
     import common_lib  # pylint: disable=import-error
-    with patch('common_lib.get_source_api_url') as mock:
+    with patch("common_lib.get_source_api_url") as mock:
         mock.return_value = _SOURCE_API_URL
         yield common_lib
 
@@ -156,11 +171,11 @@ def test_e2e(
         json={"numCreated": num_created,
               "numUpdated": num_updated})
     source_info_url = f"{_SOURCE_API_URL}/sources/{input_event['sourceId']}"
+    source_details = MOCK_SOURCE_DETAILS.copy()
+    source_details["hasStableIdentifiers"] = True
     requests_mock.get(
         source_info_url,
-        json={
-            "hasStableIdentifiers": True
-        }
+        json=source_details
     )
 
     # Delete the provided upload ID to force parsing_lib to create a new upload.
@@ -224,11 +239,10 @@ def test_e2e_with_unstable_case_ids(
         json={"numCreated": num_created,
               "numUpdated": num_updated})
     source_info_url = f"{_SOURCE_API_URL}/sources/{input_event['sourceId']}"
+    source_details = MOCK_SOURCE_DETAILS.copy()
     requests_mock.get(
         source_info_url,
-        json={
-            "hasStableIdentifiers": False
-        }
+        json=source_details
     )
 
     # Delete the provided upload ID to force parsing_lib to create a new upload.

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -197,12 +197,12 @@ def retrieve_content(
 
 def upload_to_s3(
         file_name, s3_object_key, env, source_id, upload_id, api_headers,
-        cookies):
+        cookies, bucket=OUTPUT_BUCKET):
     try:
         s3_client.upload_file(
-            file_name, OUTPUT_BUCKET, s3_object_key)
+            file_name, bucket, s3_object_key)
         print(
-            f"Uploaded source content to s3://{OUTPUT_BUCKET}/{s3_object_key}")
+            f"Uploaded source content to s3://{bucket}/{s3_object_key}")
         os.unlink(file_name)
     except Exception as e:
         common_lib.complete_with_error(
@@ -331,6 +331,7 @@ def run_retrieval(tempdir=TEMP_PATH):
                 env, parser_module,
                 source_id, upload_id, auth_headers, cookies,
                 s3_object_key, url, date_filter, parsing_date_range)
+
     else:
         common_lib.complete_with_error(
             ValueError(f"No parser set for {source_id}"),

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -583,7 +583,7 @@ paths:
     /cases/downloadAsync:
         post:
             summary: >
-                Emails a CSV attachment of cases matching the search query.
+                Streams an attachment of cases matching the search query.
             tags: [Case]
             operationId: downloadAsync
             requestBody:
@@ -597,6 +597,8 @@ paths:
                                         Cases matching this query will be returned.
                                     type: string
             responses:
+                '200':
+                    $ref: '#/components/responses/200FilteredDataSetDownload'
                 '204':
                     $ref: '#/components/responses/204'
                 '500':
@@ -1900,6 +1902,12 @@ components:
                 text/csv:
                     schema:
                         description: A CSV with headers detailing case data.
+        '200FilteredDataSetDownload':
+            description: OK
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/SignedUrl'
         '200FullDataSetDownload':
             description: OK
             content:

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -124,7 +124,17 @@ const awsEventsClient = new AwsEventsClient(
     awsBatchClient,
     env.EVENT_ROLE_ARN,
 );
-const s3Client = new S3({ region: 'us-east-1', signatureVersion: 'v4' });
+
+let s3Client;
+if (env.SERVICE_ENV == 'locale2e') {
+    s3Client = new S3({
+        region: env.AWS_SERVICE_REGION,
+        endpoint: env.LOCALSTACK_URL,
+        s3ForcePathStyle: true,
+    });
+} else {
+    s3Client = new S3({ region: env.AWS_SERVICE_REGION, signatureVersion: 'v4' });
+}
 
 // Configure Email Client
 const emailClient = new EmailClient(


### PR DESCRIPTION
When a source ingestion without a date filter finishes ingestion will push .json, .tsv, and .csv files to a versioned S3 bucket.
When a user requests a country-only filtered download from the curator it will look in the S3 bucket for that file, return it if it exists, and fall back to the data service if it does not.