### PR TITLE
Add hooks in prune, support multiple environments in export

### DIFF
--- a/.github/workflows/export-deploy.yml
+++ b/.github/workflows/export-deploy.yml
@@ -27,13 +27,12 @@ jobs:
     - name: Build, tag, and push image to Amazon ECR (latest)
       working-directory: data-serving/scripts/export-data
       env:
-        CONN: ${{ secrets.EXPORT_CONN_PROD }}
         REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REPO_COUNTRY: gdh-country-exporter
         REPO_FULL: gdh-full-exporter
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build --build-arg CONN -t $REGISTRY/$REPO_COUNTRY:$IMAGE_TAG -t $REGISTRY/$REPO_COUNTRY .
+        docker build -t $REGISTRY/$REPO_COUNTRY:$IMAGE_TAG -t $REGISTRY/$REPO_COUNTRY .
         docker push $REGISTRY/$REPO_COUNTRY:$IMAGE_TAG
         docker push $REGISTRY/$REPO_COUNTRY:latest
         docker build -f ./Dockerfile_full_export -t $REGISTRY/$REPO_FULL:$IMAGE_TAG -t $REGISTRY/$REPO_FULL .

--- a/.github/workflows/export-tests.yml
+++ b/.github/workflows/export-tests.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches: [main]
     paths:
-    - '.github/workflows/ingestion-functions-python.yml'
+    - '.github/workflows/export-tests.yml'
     - 'data-serving/scripts/export-data/*.py'
+    - 'data-serving/scripts/export-data/*.sh'
   pull_request:
     paths:
-    - '.github/workflows/ingestion-functions-python.yml'
+    - '.github/workflows/export-tests.yml'
     - 'data-serving/scripts/export-data/*.py'
+    - 'data-serving/scripts/export-data/*.sh'
 
 jobs:
   ci:
@@ -23,6 +25,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+    - name: Lint with shellcheck
+      run: |
+        shellcheck *.sh
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/prune-uploads-dev.yml
+++ b/.github/workflows/prune-uploads-dev.yml
@@ -28,4 +28,4 @@ jobs:
       env:
         PRUNE_EPOCH: 2021-07-30
         CONN: ${{ secrets.DB_CONNECTION_URL_DEV }}
-      run: python prune_uploads.py --run-hooks=all
+      run: python prune_uploads.py --run-hooks=all --env=dev

--- a/.github/workflows/prune-uploads-dev.yml
+++ b/.github/workflows/prune-uploads-dev.yml
@@ -12,6 +12,12 @@ jobs:
         working-directory: data-serving/scripts/prune-uploads
     steps:
     - uses: actions/checkout@v2
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
@@ -22,4 +28,4 @@ jobs:
       env:
         PRUNE_EPOCH: 2021-07-30
         CONN: ${{ secrets.DB_CONNECTION_URL_DEV }}
-      run: python prune_uploads.py
+      run: python prune_uploads.py --run-hooks=all

--- a/.github/workflows/prune-uploads-prod.yml
+++ b/.github/workflows/prune-uploads-prod.yml
@@ -12,6 +12,12 @@ jobs:
         working-directory: data-serving/scripts/prune-uploads
     steps:
     - uses: actions/checkout@v2
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
@@ -23,4 +29,4 @@ jobs:
         PRUNE_EPOCH: 2021-07-30
         CONN: ${{ secrets.DB_CONNECTION_URL_PROD }}
         PRUNE_UPLOADS_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_METRICS_URL }}
-      run: python prune_uploads.py
+      run: python prune_uploads.py --run-hooks=all

--- a/.github/workflows/prune-uploads-prod.yml
+++ b/.github/workflows/prune-uploads-prod.yml
@@ -29,4 +29,4 @@ jobs:
         PRUNE_EPOCH: 2021-07-30
         CONN: ${{ secrets.DB_CONNECTION_URL_PROD }}
         PRUNE_UPLOADS_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_METRICS_URL }}
-      run: python prune_uploads.py --run-hooks=all
+      run: python prune_uploads.py --run-hooks=all --env=prod

--- a/data-serving/scripts/export-data/Dockerfile
+++ b/data-serving/scripts/export-data/Dockerfile
@@ -3,8 +3,7 @@ FROM alpine:3.14
 RUN apk update
 RUN apk add bash mongodb-tools python3 aws-cli
 
-ARG CONN
-ENV CONN=${CONN}
+COPY common.sh .
 COPY country_export.sh .
 COPY transform.py .
 COPY fields.txt .

--- a/data-serving/scripts/export-data/Dockerfile_full_export
+++ b/data-serving/scripts/export-data/Dockerfile_full_export
@@ -2,6 +2,7 @@ FROM alpine:3.14
 RUN apk update
 RUN apk add bash aws-cli
 
+COPY common.sh .
 COPY full_export.sh .
 COPY data_dictionary.txt .
 COPY citation.txt .

--- a/data-serving/scripts/export-data/README.md
+++ b/data-serving/scripts/export-data/README.md
@@ -7,8 +7,8 @@ you'll need access to AWS and aws-cli setup on your local machine.
   a .csv.gz file.
 * **full_export.sh**: Script that does the full export in various formats
   by making a tarball from country_export output.
-* **setup_batch.sh**: This is used to setup AWS Batch job definitions for country
-  export. It only needs to be run once and takes no parameters.
+* **setup_country_export.sh**: This is used to setup AWS Batch job definitions
+  for country export. It only needs to be run once and takes no parameters.
 * **setup_full_export.sh**: Sets up AWS Batch job definitions for full export.
   It only needs to be run once and takes no parameters.
 * **submit_job.sh**: Used to submit an export job to AWS Batch. This takes one
@@ -32,10 +32,58 @@ MongoDB, you must specify CONN as a
 [MongoDB connection string](https://docs.mongodb.com/manual/reference/connection-string/)
 during the build phase:
 
-    CONN='<url>' docker build --build-arg CONN -t country-export
+    docker build -t country-export
 
 You will need write access to S3. Alternatively, you can setup localstack to
 have a mock S3 environment. To run a hypothetical export for Antarctica:
 
-    docker run -e 'COUNTRY=Antarctica' country-export
+    docker run -e 'COUNTRY=Antarctica' -e 'CONN=xx' country-export
 
+## Setting up exports
+
+There are two steps: initial creation of S3 buckets, and setting up job definitions.
+
+### Initial S3 bucket creation
+
+Create two S3 buckets with the following structure. The exact bucket names will
+vary according to the environment (prod/dev/qa).
+
+**country-export** This is a versioned S3 bucket with the following structure:
+```bash
+country-export/
+├── csv
+├── json
+└── tsv
+```
+
+**data-export** This is a unversioned S3 bucket with the following structure:
+```
+data-export/
+├── archive
+└── latest
+```
+
+Currently the corresponding S3 buckets according to environment are:
+* **prod**: covid-19-country-export, covid-19-data-export
+* **dev**: covid-19-country-export-dev, covid-19-data-export-dev
+
+### Create job definitions
+
+* **setup_country_export.sh**: Sets up country-export job definitions
+      (set ENV to environment, such as prod | dev | qa)
+
+  ```bash
+  CONN=<MongoDB connection URI> ENV=<env> bash setup_country_export.sh
+  ```
+
+  Job definitions are named *env-exporter_slug* where *slug* is the lowercase
+  form of the country with punctuation removed and spaces replaced by underscores.
+
+* **setup_full_export.sh**: Sets up full export job definitions
+
+  ```bash
+  ENV=<env> COUNTRY_EXPORT_BUCKET=<bucket> \
+  FULL_EXPORT_BUCKET=<bucket> bash setup_full_export.sh
+  ```
+
+  Job definitions are named *env-full-exporter-format* where *format* is one of tsv,json,csv.

--- a/data-serving/scripts/export-data/common.sh
+++ b/data-serving/scripts/export-data/common.sh
@@ -1,3 +1,11 @@
-ECR=612888738066.dkr.ecr.us-east-1.amazonaws.com
+#!/bin/bash
+export ECR=612888738066.dkr.ecr.us-east-1.amazonaws.com
 # ingestion role contains necessary permissions to access S3 buckets
-JOB_ROLE_ARN="arn:aws:iam::612888738066:role/gdh-ingestion-job-role"
+export JOB_ROLE_ARN="arn:aws:iam::612888738066:role/gdh-ingestion-job-role"
+
+require_env() {
+    if [ -z "$1" ]; then
+        echo "$2"
+        exit 1
+    fi
+}

--- a/data-serving/scripts/export-data/country_export.sh
+++ b/data-serving/scripts/export-data/country_export.sh
@@ -2,13 +2,22 @@
 
 set -euo pipefail
 
+source ./common.sh
+require_env "${CONN:-}" "Specify MongoDB connection string in CONN"
+require_env "${BUCKET:-}" "Specify S3 bucket to output files in BUCKET"
+require_env "${COUNTRY:-}" "Specify which country to export in COUNTRY"
+
 FORMAT="${FORMAT:-csv,tsv,json}"
 SLUG=$(echo "$COUNTRY" | sed "s/ /_/g;s/[.,']//g" | tr '[:upper:]' '[:lower:]')
 QUERY="{\"list\": true, \"location.country\": \"$COUNTRY\"}"
 mongoexport --query="$QUERY" --uri="$CONN" --collection=cases \
     --fieldFile=fields.txt --type=csv | python3 transform.py -f "$FORMAT" "$SLUG"
 
+# ignore shellcheck warning on word splitting, as it's actually needed here
+# shellcheck disable=SC2086
 for fmt in ${FORMAT//,/ }
 do
-    aws s3 cp "$SLUG.$fmt.gz" s3://covid-19-country-export/$fmt/
+    if [ -f "${SLUG}.{fmt}.gz" ]; then
+        aws s3 cp "${SLUG}.${fmt}.gz" "s3://${BUCKET}/${fmt}/"
+    fi
 done

--- a/data-serving/scripts/export-data/full_export.sh
+++ b/data-serving/scripts/export-data/full_export.sh
@@ -3,32 +3,35 @@
 # Depends: aws-cli
 
 set -xeuo pipefail
+source ./common.sh
+require_env "${COUNTRY_EXPORT_BUCKET:-}" "Specify COUNTRY_EXPORT_BUCKET"
+require_env "${FULL_EXPORT_BUCKET:-}" "Specify FULL_EXPORT_BUCKET"
 
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-retries.html#cli-usage-retries-configure
 export AWS_MAX_ATTEMPTS=10
 
-COUNTRY_EXPORT_BUCKET="s3://covid-19-country-export"
-FULL_EXPORT_BUCKET="s3://covid-19-data-export"
+COUNTRY_EXPORT_BUCKET="s3://${COUNTRY_EXPORT_BUCKET}"
+FULL_EXPORT_BUCKET="s3://${FULL_EXPORT_BUCKET}"
 
 # Unlike country_export.sh, here FORMAT only takes one value
 # Multiple formats are exported using separate AWS Batch job definitions
 FORMAT="${FORMAT:-csv}"
-FILE="latestdata-$FORMAT.tar"
-FILE_DATE="$(date '+%Y-%m-%d')-$FORMAT.tar"
+FILE="latestdata-${FORMAT}.tar"
+FILE_DATE="$(date '+%Y-%m-%d')-${FORMAT}.tar"
 
 DIR="$(mktemp -d)"
 echo "Starting full export for format: $FORMAT"
 echo "Made temporary directory $DIR"
-trap "rm -rf $DIR" EXIT  # Cleanup before exit
+trap 'rm -rf "$DIR"' EXIT  # Cleanup before exit
 
 cp data_dictionary.txt citation.txt "$DIR"
 
-mkdir "$DIR/country"
-echo "Downloading files from $COUNTRY_EXPORT_BUCKET..."
-aws s3 sync $COUNTRY_EXPORT_BUCKET/$FORMAT/ "$DIR/country"
+mkdir "${DIR}/country"
+echo "Downloading files from ${COUNTRY_EXPORT_BUCKET}..."
+aws s3 sync "${COUNTRY_EXPORT_BUCKET}/${FORMAT}/" "${DIR}/country"
 echo "Preparing tarball..."
-tar cf $FILE -C "$DIR" .
-echo "Uploading to $FULL_EXPORT_BUCKET..."
-aws s3 cp $FILE $FULL_EXPORT_BUCKET/latest/$FILE
-aws s3 cp $FULL_EXPORT_BUCKET/latest/$FILE $FULL_EXPORT_BUCKET/archive/$FILE_DATE
+tar cf "$FILE" -C "$DIR" .
+echo "Uploading to ${FULL_EXPORT_BUCKET}..."
+aws s3 cp "$FILE" "${FULL_EXPORT_BUCKET}/latest/${FILE}"
+aws s3 cp "${FULL_EXPORT_BUCKET}/latest/${FILE}" "${FULL_EXPORT_BUCKET}/archive/${FILE_DATE}"
 echo "Done!"

--- a/data-serving/scripts/export-data/setup_full_export.sh
+++ b/data-serving/scripts/export-data/setup_full_export.sh
@@ -4,21 +4,33 @@
 
 set -eou pipefail
 source ./common.sh
-
+require_env "${ENV:-}" "Specify environment in ENV"
+require_env "${COUNTRY_EXPORT_BUCKET:-}" "Specify COUNTRY_EXPORT_BUCKET"
+require_env "${FULL_EXPORT_BUCKET:-}" "Specify FULL_EXPORT_BUCKET"
 IMAGE="${IMAGE:-$ECR/gdh-full-exporter:latest}"
+
+echo "Setting up full expotr job definitions for environment ${ENV}..."
+echo "Will tar files from ${COUNTRY_EXPORT_BUCKET} -> ${FULL_EXPORT_BUCKET}"
 
 function containerprops {
     # usage: containerprops "<country>"
-    P='{'
-    P+="\"image\": \"${IMAGE}\""
-    P+=", \"vcpus\": 1, \"memory\": 2048, \"jobRoleArn\": \"${JOB_ROLE_ARN}\""
-    P+=", \"environment\": [{\"name\": \"FORMAT\", \"value\": \"$1\" }]"
-    P+='}'
-    echo "$P"
+    cat <<EOF
+{
+  "image": "$IMAGE",
+  "vcpus": 1,
+  "memory": 2048,
+  "jobRoleArn": "$JOB_ROLE_ARN",
+  "environment": [
+     {"name": "FORMAT", "value": "$1"}
+   , {"name": "COUNTRY_EXPORT_BUCKET", "value": "$COUNTRY_EXPORT_BUCKET"}
+   , {"name": "FULL_EXPORT_BUCKET", "value": "$FULL_EXPORT_BUCKET"}
+  ]
+}
+EOF
 }
 
 for fmt in tsv csv json; do
-    aws batch register-job-definition --job-definition-name "full-exporter-$fmt" \
+    aws batch register-job-definition --job-definition-name "${ENV}-full-exporter-${fmt}" \
         --container-properties "$(containerprops "$fmt")" \
         --timeout "attemptDurationSeconds=3600" --type container
 done

--- a/data-serving/scripts/export-data/transform.py
+++ b/data-serving/scripts/export-data/transform.py
@@ -184,7 +184,11 @@ def get_fields(fileobject) -> list[str]:
     Add processed event fieldnames to fields.
     """
     reader = csv.DictReader(fileobject)
-    row = next(reader)
+    try:
+        row = next(reader)
+    except StopIteration:
+        print("No rows found for country, aborting")
+        sys.exit(1)
     headers = list(row.keys())
     cols_to_add = [
         "events.confirmed.value",

--- a/data-serving/scripts/prepare_fields_list/src/index.ts
+++ b/data-serving/scripts/prepare_fields_list/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 try {
-    const data = fs.readFileSync('../export-data/functions/01-split/fields.txt', 'utf-8');
+    const data = fs.readFileSync('../export-data/fields.txt', 'utf-8');
     const fieldNames = data.split(/\n/);
     const fieldsList = JSON.stringify(fieldNames);
     fs.writeFileSync('../../data-service/src/model/fields.json', fieldsList);

--- a/data-serving/scripts/prune-uploads/README.md
+++ b/data-serving/scripts/prune-uploads/README.md
@@ -69,6 +69,8 @@ Remove the -n to actually prune uploads.
   of cases. This option has no effect on UUID source uploads, which are always
   ingested.
 
+* **-r**, **--run-hooks**=*hook1*[,*hook2*]: Runs hooks after prune finishes. Specify
+  *all* to run all hooks configured to run.
 
 ## How it works
 

--- a/data-serving/scripts/prune-uploads/README.md
+++ b/data-serving/scripts/prune-uploads/README.md
@@ -72,6 +72,9 @@ Remove the -n to actually prune uploads.
 * **-r**, **--run-hooks**=*hook1*[,*hook2*]: Runs hooks after prune finishes. Specify
   *all* to run all hooks configured to run.
 
+* **--env** (default=prod): Specifies which environment to use. This is passed to hooks
+  which can vary behaviour based on this, as with the country export script.
+
 ## How it works
 
 Prune uploads uses the *uploads* array in the sources collection to get a list

--- a/data-serving/scripts/prune-uploads/hooks/country_export.py
+++ b/data-serving/scripts/prune-uploads/hooks/country_export.py
@@ -71,7 +71,7 @@ def get_exporters(source: dict[str, Any]) -> set[str]:
         return {f"exporter_{slug(name)}"}
 
 
-def run(sources: list[dict[str, Any]]):
+def run(sources: list[dict[str, Any]], dry_run: bool = False):
     print("*** Running hook: country_export ***")
     batch = boto3.client("batch")
     jobdefs = set.union(*(get_exporters(s) for s in sources))
@@ -81,9 +81,10 @@ def run(sources: list[dict[str, Any]]):
     for jobdef in jobdefs & all_exporters:
         try:
             print(f"Submitting job for {jobdef} ...")
-            batch.submit_job(
-                jobName=jobdef, jobDefinition=jobdef, jobQueue="export-queue"
-            )
+            if not dry_run:
+                batch.submit_job(
+                    jobName=jobdef, jobDefinition=jobdef, jobQueue="export-queue"
+                )
         except Exception as e:
             print(f"Error occurred while trying to submit {jobdef}")
             print(e)

--- a/data-serving/scripts/prune-uploads/hooks/tests/test_country_export.py
+++ b/data-serving/scripts/prune-uploads/hooks/tests/test_country_export.py
@@ -28,12 +28,12 @@ def test_slug(source, expected):
     [
         (
             _NORTH_AMERICA,
-            {"exporter_united_states", "exporter_canada", "exporter_mexico"},
+            {"prod-exporter_united_states", "prod-exporter_canada", "prod-exporter_mexico"},
         ),
-        (_REUNION, {"exporter_reunion"}),
-        (_NEW_ZEALAND, {"exporter_new_zealand"}),
+        (_REUNION, {"prod-exporter_reunion"}),
+        (_NEW_ZEALAND, {"prod-exporter_new_zealand"}),
         (_INVALID, set()),
     ],
 )
 def test_get_exporters(source, expected):
-    assert T.get_exporters(source) == expected
+    assert T.get_exporters(source, "prod") == expected

--- a/data-serving/scripts/prune-uploads/prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/prune_uploads.py
@@ -260,6 +260,8 @@ if __name__ == "__main__":
                         help="Allow decrease in cases (non-UUID)", action="store_true")
     parser.add_argument("-r", "--run-hooks",
                         help="Run hooks after prune finishes. Specify 'all' to run all hooks")
+    parser.add_argument("--env",
+                        help="Which environment to use for hooks (default: prod)", default="prod")
     args = parser.parse_args()
 
     # Prefer command line arguments to environment variables
@@ -314,4 +316,4 @@ if __name__ == "__main__":
 
     selected_hooks = get_selected_hooks(args.run_hooks)
     if "country_export" in selected_hooks:
-        hooks.country_export.run(ingested_sources, args.dry_run)
+        hooks.country_export.run(ingested_sources, args.env, args.dry_run)

--- a/data-serving/scripts/prune-uploads/test_prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/test_prune_uploads.py
@@ -3,7 +3,7 @@ from bson.objectid import ObjectId
 from datetime import datetime
 from enum import Enum
 
-from prune_uploads import find_acceptable_upload
+from prune_uploads import find_acceptable_upload, HOOKS, get_selected_hooks
 
 # If the ratio of numError / numCreated is greater than this,
 # do not accept upload
@@ -141,3 +141,11 @@ def test_find_acceptable_upload_with_epoch(source, expected):
         find_acceptable_upload(source, ERROR_THRESHOLD, datetime(2021, 3, 1))
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [(None, []), ("all", HOOKS), ("country_export", ["country_export"])],
+)
+def test_get_selected_hooks(source, expected):
+    assert get_selected_hooks(source) == expected


### PR DESCRIPTION
We don't need to run export on dev, so disable hooks by default.