### PR TITLE
1875 denormalise confirmed date

### DIFF
--- a/data-serving/data-service/test/model/case.test.ts
+++ b/data-serving/data-service/test/model/case.test.ts
@@ -37,6 +37,12 @@ describe('validate', () => {
         return new Case(minimalModel).validate();
     });
 
+    it('denormalises the date of the confirmed event', async () => {
+        const c = new Case(minimalModel);
+        await c.validate();
+        expect(c.confirmationDate.toISOString()).toEqual(minimalModel.events[0].dateRange.start);
+    });
+    
     it('fully-specified model is valid', async () => {
         return new Case(fullModel).validate();
     });

--- a/data-serving/scripts/setup-db/migrations/20211109102327-denormalise-confirmation-date-1875.js
+++ b/data-serving/scripts/setup-db/migrations/20211109102327-denormalise-confirmation-date-1875.js
@@ -1,0 +1,39 @@
+const confirmationDate = {
+  bsonType: "date",
+};
+
+module.exports = {
+  async up(db, client) {
+    let res = await db.command({listCollections: undefined, filter: {name: 'cases'}});
+    let schema = res.cursor.firstBatch[0].options.validator.$jsonSchema;
+    schema.properties.confirmationDate = confirmationDate;
+    await db.command({ collMod: 'cases', validator:{ $jsonSchema: schema } } );
+
+    // now amend the existing cases. This must be done one by one so will take a lot of time!
+    const collection = db.collection('cases');
+    collection.find({}).forEach(function(err, doc) {
+      if(!doc) {
+        console.error(`error ${err} migrating confirmation date on doc ${doc?._id ?? ''}`);
+        // continue as subsequent case modifications may still work
+        return;
+      }
+      doc.events.forEach((anEvent) => {
+        if (anEvent.name === 'confirmed') {
+          const confirmationDate = anEvent.dateRange.start;
+          collection.updateOne({ _id: doc._id }, { confirmationDate });
+          return;
+        }
+      });
+    });
+  },
+
+  async down(db, client) {
+    let res = await db.command({listCollections: undefined, filter: {name: 'cases'}});
+    let schema = res.cursor.firstBatch[0].options.validator.$jsonSchema;
+    delete schema.properties.confirmationDate;
+    await db.command( { collMod: 'cases', validator:{ $jsonSchema: schema } } );
+
+    const collection = db.collection('cases');
+    collection.updateMany({}, {$unset: {"confirmationDate":1}});
+  }
+};

--- a/data-serving/scripts/setup-db/migrations/20211109102327-denormalise-confirmation-date-1875.js
+++ b/data-serving/scripts/setup-db/migrations/20211109102327-denormalise-confirmation-date-1875.js
@@ -2,6 +2,16 @@ const confirmationDate = {
   bsonType: "date",
 };
 
+const indexes = [
+  {
+    name: 'byConfirmationDateIfListed',
+    key: {
+      'confirmationDate': 1,
+      'list': 1,
+    }
+  },
+];
+
 module.exports = {
   async up(db, client) {
     let res = await db.command({listCollections: undefined, filter: {name: 'cases'}});
@@ -11,23 +21,29 @@ module.exports = {
 
     // now amend the existing cases. This must be done one by one so will take a lot of time!
     const collection = db.collection('cases');
-    collection.find({}).forEach(function(err, doc) {
-      if(!doc) {
-        console.error(`error ${err} migrating confirmation date on doc ${doc?._id ?? ''}`);
-        // continue as subsequent case modifications may still work
-        return;
-      }
+    collection.find({}).forEach(function(doc) {
       doc.events.forEach((anEvent) => {
         if (anEvent.name === 'confirmed') {
           const confirmationDate = anEvent.dateRange.start;
-          collection.updateOne({ _id: doc._id }, { confirmationDate });
+          collection.updateOne({ _id: doc._id }, { $set: { confirmationDate } });
           return;
         }
       });
     });
+
+    // and index the above
+    await db.command({
+      createIndexes: 'cases',
+      indexes: indexes,
+    });
   },
 
   async down(db, client) {
+    await db.command({
+      dropIndexes: 'cases',
+      index: ['byConfirmationDateIfListed']
+    });
+    
     let res = await db.command({listCollections: undefined, filter: {name: 'cases'}});
     let schema = res.cursor.firstBatch[0].options.validator.$jsonSchema;
     delete schema.properties.confirmationDate;


### PR DESCRIPTION
I've added an index on confirmed date. To do that I've added a migration to extract the date on the confirmed event and store it in a top-level field, and I've added mongoose middleware to keep that in sync for new additions/changes. This means that there are no changes to ingestion scripts or the APIs, the app works as previously but the data-service does the heavy lifting of keeping this extra field in sync.

The reason I've gone for mongoose middleware here is simply that mongo itself doesn't have database triggers (mongodb atlas does, via realm, but then we couldn't actually synchronise those triggers with our existing migration tools). I could've written express middleware to rewrite the requests in the same way that our creation metadata works, but then there's more work remembering that any new method needs to borrow that middleware. To be clear I don't think the existing approach to revision metadata is wrong, because it needs access to the user property on the request which wouldn't be available in mongoose middleware.

@maciekz1996 let me know if this unblocks you on sorting by date, or if you need something more.