### PR TITLE
prune-uploads: No-op when no pending uploads for UUID sources

### DIFF
--- a/data-serving/scripts/prune-uploads/hooks/country_export.py
+++ b/data-serving/scripts/prune-uploads/hooks/country_export.py
@@ -74,6 +74,9 @@ def get_exporters(source: dict[str, Any], env: str) -> set[str]:
 def run(sources: list[dict[str, Any]], env: str, dry_run: bool = False):
     print("*** Running hook: country_export ***")
     batch = boto3.client("batch")
+    if not sources:
+        print("No sources to run hook for, quitting.")
+        return
     jobdefs = set.union(*(get_exporters(s, env) for s in sources))
     all_exporters = list_exporters(env)
     if unknown_exporters := jobdefs - all_exporters:

--- a/data-serving/scripts/prune-uploads/prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/prune_uploads.py
@@ -90,11 +90,12 @@ def find_acceptable_upload(
         return None
 
     if source.get("hasStableIdentifiers", False):
-        return _ids(
+        pending_upload_ids = _ids(
             u for u in uploads
             if u['status'] != "IN_PROGRESS"
             and "accepted" not in u
-        ), []
+        )
+        return (pending_upload_ids, []) if pending_upload_ids else None
 
     # skip rejected uploads
     uploads = [u for u in uploads if "accepted" not in u or u['accepted']]
@@ -315,5 +316,5 @@ if __name__ == "__main__":
         notify("\n".join(m), webhook_url)
 
     selected_hooks = get_selected_hooks(args.run_hooks)
-    if "country_export" in selected_hooks:
+    if ingested_sources and "country_export" in selected_hooks:
         hooks.country_export.run(ingested_sources, args.env, args.dry_run)

--- a/data-serving/scripts/prune-uploads/test_prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/test_prune_uploads.py
@@ -24,7 +24,30 @@ def _u(i, status, date, created=0, errors=0, updated=0, accepted=None):
     return u
 
 
-S0 = {"_id": ObjectId("123456789012345678901231"), "hasStableIdentifiers": True}
+S0 = {
+    "_id": ObjectId("123456789012345678901231"),
+    "hasStableIdentifiers": True,
+    "uploads": [
+        _u("60f733dcfae8bf76717d598e", Status.SUCCESS, "2021-01-01", 100),
+        _u("60f734296e50eb2592992fb0", Status.ERROR, "2020-12-31", 5),
+        _u("60f7343a6e50eb2592992fb1", Status.ERROR, "2020-12-25", 0, accepted=True),
+    ],
+}
+
+S0_all_accepted = {
+    "_id": ObjectId("123456789012345678901231"),
+    "hasStableIdentifiers": True,
+    "uploads": [
+        _u("60f733dcfae8bf76717d598e", Status.SUCCESS, "2021-01-01", 100, accepted=True),
+        _u("60f734296e50eb2592992fb0", Status.ERROR, "2020-12-31", 5, accepted=True),
+        _u("60f7343a6e50eb2592992fb1", Status.ERROR, "2020-12-25", 0, accepted=True),
+    ],
+}
+
+T0 = [
+    (S0, (["60f733dcfae8bf76717d598e", "60f734296e50eb2592992fb0"], [])),
+    (S0_all_accepted, None)
+]
 S1 = {"_id": ObjectId("123456789012345678901232"), "uploads": []}
 
 S2 = {
@@ -141,6 +164,11 @@ def test_find_acceptable_upload_with_epoch(source, expected):
         find_acceptable_upload(source, ERROR_THRESHOLD, datetime(2021, 3, 1))
         == expected
     )
+
+
+@pytest.mark.parametrize("source,expected", T0)
+def test_find_acceptable_upload_uuid(source, expected):
+    assert find_acceptable_upload(source, ERROR_THRESHOLD) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently, find_acceptable_upload() returns a tuple ([], [])
when no pending uploads are present for UUID sources.
Change this to None to bring in sync with non-UUID sources.

This should no-op prune-uploads when no pending uploads are
found. Also add a check that sources were actually ingested
in this prune before calling hooks for country export, both
in prune-uploads and in the country export hook.
