### PR TITLE
Removing string template

### DIFF
--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -208,7 +208,7 @@ export default class CasesController {
             Key: filepath,
             Expires: 5 * 60,
             ResponseContentDisposition:
-                `attachment; filename ="${filename}"`,
+                'attachment; filename ="' + filename + '"',
         };
 
         const user = req.user as UserDocument;


### PR DESCRIPTION
Filtered downloads (country only) throw `There was an error while downloading data, please try again later. TypeError: o.headers['content-disposition'] is undefined`. Full data set downloads and non-country-only filtered downloads (e.g. country + gender) work as expected.