### PR TITLE
Checking for presigned URL before checking for content-disposition header

### DIFF
--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -208,7 +208,7 @@ export default class CasesController {
             Key: filepath,
             Expires: 5 * 60,
             ResponseContentDisposition:
-                `attachment; filename ="${filename}"`,
+                'attachment; filename ="' + filename + '"',
         };
 
         const user = req.user as UserDocument;

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -575,17 +575,22 @@ export function DownloadButton(): JSX.Element {
                         },
                     });
 
-                    const filename = response.headers['content-disposition']
-                        .split('filename=')[1]
-                        .replace(/["]/g, '');
-                    const downloadUrl = window.URL.createObjectURL(
-                        new Blob([response.data]),
-                    );
-                    const link = document.createElement('a');
-                    link.href = downloadUrl;
-                    link.setAttribute('download', filename);
-                    document.body.appendChild(link);
-                    link.click();
+                    // Check for S3 signed URL
+                    if (response.data.signedUrl !== undefined) {
+                        window.location.href = response.data.signedUrl;
+                    } else {
+                        const filename = response.headers['content-disposition']
+                            .split('filename=')[1]
+                            .replace(/["]/g, '');
+                        const downloadUrl = window.URL.createObjectURL(
+                            new Blob([response.data]),
+                        );
+                        const link = document.createElement('a');
+                        link.href = downloadUrl;
+                        link.setAttribute('download', filename);
+                        document.body.appendChild(link);
+                        link.click();
+                    }
                 } catch (err) {
                     alert(
                         `There was an error while downloading data, please try again later. ${err}`,


### PR DESCRIPTION
A country-only download query should download from S3, which will return a presigned URL the curator should redirect to.
Other filtered download queries should stream through the data service, which will set the file name through the content-disposition header.