### PR TITLE
Removing responseType headers from request to curator API

### DIFF
--- a/dev/docker-compose.dev.full.yml
+++ b/dev/docker-compose.dev.full.yml
@@ -16,6 +16,10 @@ services:
       LOCALSTACK_URL: "http://localstack:4566"
       SERVICE_ENV: "locale2e"
       AFTER_LOGIN_REDIRECT_URL: "http://localhost:3002"
+      EVENT_ROLE_ARN: "fake"
+      JOB_QUEUE_ARN: "fake"
+      SESSION_COOKIE_KEY: "fake"
+      STATIC_DIR: ""
   data:
     command: "npm run dev"
     volumes:
@@ -23,6 +27,8 @@ services:
       - "../data-serving/data-service/api:/usr/src/app/data-serving/data-service/api"
     depends_on:
       - mongo
+    environment:
+      SERVICE_ENV: "local"
   curatorui:
     command: "npm run start-noenv"
     volumes:
@@ -70,7 +76,7 @@ services:
       AWS_DEFAULT_REGION: "us-east-1"
       AWS_ENDPOINT: "http://localstack:4566"
       DATA_BUCKET_NAME: "covid-19-data-export"
-      CACHE_BUCKET_NAME: "covid-19-cache"
+      CACHE_BUCKET_NAME: "covid-19-country-export"
       RETRIEVAL_BUCKET_NAME: "epid-sources-raw"
       BATCH_QUEUE_NAME: "ingestion-queue"
       SES_EMAIL_ADDRESS: "info@global.health"

--- a/dev/setup_localstack.py
+++ b/dev/setup_localstack.py
@@ -45,7 +45,7 @@ BATCH_COMPUTE_ENVIRONMENT_ORDER = [{
 }]
 
 DATA_BUCKET_NAME = environ.get("DATA_BUCKET_NAME", "covid-19-data-export")
-CACHE_BUCKET_NAME = environ.get("CACHE_BUCKET_NAME", "covid-19-cache")
+CACHE_BUCKET_NAME = environ.get("CACHE_BUCKET_NAME", "covid-19-country-export")
 RETRIEVAL_BUCKET_NAME = environ.get("RETRIEVAL_BUCKET_NAME", "epid-sources-raw")
 SES_EMAIL_ADDRESS = environ.get("SES_EMAIL_ADDRESS", "info@global.health")
 ECR_REPOSITORY_NAME = environ.get("ECR_REPOSITORY_NAME", "gdh-ingestor")

--- a/verification/curator-service/api/src/controllers/cases.ts
+++ b/verification/curator-service/api/src/controllers/cases.ts
@@ -93,7 +93,7 @@ export default class CasesController {
             this.getDownloadLink(req, res);
             return;
         } else if (this.hasCountryOnly(req.body.query)) {
-            const country = req.body.query.split(":")[1].toLowerCase();
+            const country = req.body.query.split(':')[1].toLowerCase().replace(/ /g,'_');
             const inBucket = await this.S3BucketContains(country, req.body.format);
             if (inBucket) {
                 this.getCountryDownloadLink(req, res, country, req.body.format);
@@ -208,7 +208,7 @@ export default class CasesController {
             Key: filepath,
             Expires: 5 * 60,
             ResponseContentDisposition:
-                `attachment; filename ="${filename}"`,
+                'attachment; filename ="' + filename + '"',
         };
 
         const user = req.user as UserDocument;

--- a/verification/curator-service/ui/src/components/LinelistTable.tsx
+++ b/verification/curator-service/ui/src/components/LinelistTable.tsx
@@ -536,9 +536,7 @@ export function DownloadButton(): JSX.Element {
     const downloadDataSet = async (dataSet: string, formatType?: string) => {
         setIsLoading(true);
 
-        console.log('downloading data set');
         const searchQuery: string = URLToSearchQuery(location.search);
-        console.log(`query ${searchQuery}`);
         switch (dataSet) {
             case 'fullDataset':
                 try {
@@ -560,7 +558,6 @@ export function DownloadButton(): JSX.Element {
                 break;
 
             case 'partialDataset':
-                console.log('downloading partial data set');
                 try {
                     const response = await axios({
                         method: 'post',
@@ -569,23 +566,27 @@ export function DownloadButton(): JSX.Element {
                             format: formatType,
                             query: searchQuery,
                         },
-                        responseType: 'blob',
                         headers: {
                             'Content-Type': 'application/json',
                         },
                     });
 
-                    const filename = response.headers['content-disposition']
-                        .split('filename=')[1]
-                        .replace(/["]/g, '');
-                    const downloadUrl = window.URL.createObjectURL(
-                        new Blob([response.data]),
-                    );
-                    const link = document.createElement('a');
-                    link.href = downloadUrl;
-                    link.setAttribute('download', filename);
-                    document.body.appendChild(link);
-                    link.click();
+                    // Check for S3 signed URL
+                    if (response.data.signedUrl !== undefined) {
+                        window.location.href = response.data.signedUrl;
+                    } else {
+                        const filename = response.headers['content-disposition']
+                            .split('filename=')[1]
+                            .replace(/["]/g, '');
+                        const downloadUrl = window.URL.createObjectURL(
+                            new Blob([response.data]),
+                        );
+                        const link = document.createElement('a');
+                        link.href = downloadUrl;
+                        link.setAttribute('download', filename);
+                        document.body.appendChild(link);
+                        link.click();
+                    }
                 } catch (err) {
                     alert(
                         `There was an error while downloading data, please try again later. ${err}`,


### PR DESCRIPTION
The 'blob' responseType ate the signedUrl, making it look like it was undefined. We don't need it anymore, as the filtered data downloads can work from S3 and the data service without it.
I also replaced spaces in country names with underscores, removed some `console.log` statements, and updated the local environment.