### PR TITLE
#2278 Updated countries list source file

### DIFF
--- a/verification/curator-service/ui/src/redux/filters/thunk.ts
+++ b/verification/curator-service/ui/src/redux/filters/thunk.ts
@@ -2,11 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
 const countryListJsonFile =
-    'https://covid-19-aggregates.s3.amazonaws.com/country/latest.json';
-
-type countryObject = {
-    _id: string;
-};
+    'https://covid-19-aggregates.s3.amazonaws.com/countries-list.json';
 
 export const fetchCountries = createAsyncThunk<
     string[],
@@ -14,17 +10,12 @@ export const fetchCountries = createAsyncThunk<
     { rejectValue: string }
 >('filters/fetchCountries', async (_, { rejectWithValue }) => {
     try {
-        const response = await axios.get(countryListJsonFile);
-        const responseArray = Object.entries(response.data)[0][1] as [];
-        const countries = responseArray
-            .map((el: countryObject) => {
-                return el._id;
-            })
-            .sort();
-
+        const response = await axios.get<string[]>(countryListJsonFile);
         if (response.status !== 200) {
             throw new Error('Something went wrong, please try again');
         }
+
+        const countries = response.data.sort();
         return countries;
     } catch (error) {
         if (!error.response) throw error;


### PR DESCRIPTION
**Changes**
- Created and uploaded file to AWS S3: https://covid-19-aggregates.s3.amazonaws.com/countries-list.json containing a list of all countries that we have data from. This file is now used to populate country dropdown in filters modal in Curator UI. This fixes Cypress tests sometimes failing due to missing countries in latest data exports