### PR TITLE
Changing localstack version due to SSL cert issue

### DIFF
--- a/ingestion/functions/docker-compose-test.yml
+++ b/ingestion/functions/docker-compose-test.yml
@@ -7,5 +7,5 @@ services:
       dockerfile: Dockerfile-test
     env_file: ./.env
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.12.17.5
     env_file: ./.env


### PR DESCRIPTION
Fixes failing ingestor tests in CI caused by https://github.com/localstack/localstack/issues/4903