### PR TITLE
migrations: Add collation to byDateIfListed index collated

### DIFF
--- a/data-serving/scripts/setup-db/migrations/20211204203100-fix-byDateIfListed.js
+++ b/data-serving/scripts/setup-db/migrations/20211204203100-fix-byDateIfListed.js
@@ -1,0 +1,48 @@
+const createIndexes = [
+  {
+    name: 'byDateIfListedCollated',
+    key: {
+      'list': 1,
+      'revisionMetadata.creationMetadata.date': -1,
+    },
+    collation: {
+      locale: 'en_US',
+      strength: 2,
+    },
+  },
+];
+
+const dropIndexes = [
+  {
+    name: 'byDateIfListed',
+    key: {
+      'list': 1,
+      'revisionMetadata.creationMetadata.date': -1,
+    },
+  },
+];
+
+
+
+module.exports = {
+  async up(db, client) {
+    await db.command({
+      createIndexes: 'cases',
+      indexes: createIndexes,
+    });
+    await db.command({
+      dropIndexes: 'cases',
+      index: ['byDateIfListed']
+    });
+  },
+  async down(db, client) {
+    await db.command({
+      createIndexes: 'cases',
+      indexes: dropIndexes,
+    });
+    await db.command({
+      dropIndexes: 'cases',
+      index: ['byDateIfListedCollated']
+    });
+  }
+};


### PR DESCRIPTION
Sorting in the data UI uses collation with en_US and strength 2.
The landing page shows cases with list: true and sorts by
revisionMetadata.creationMetadata.date, which should have been
handled by the byDateIfListed index. This index was not
collated, leading MongoDB to do a collection scan on the landing
page. This issue type (504s due to missing collation) has
happened before, see 0b01e0a059c68cea09975394022c168a3a23b039.

Other pages such as filtering by country were not affected as the
corresponding indices were collated already.

Fixes: #2298
