### PR TITLE
Update data dictionary and fields.txt references

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can tell if a case was imported from the manually created spreadsheets data 
 
 A daily export of case data can be downloaded from the data portal. The data
 is generated using this [script](data-serving/scripts/export-data/README.md), with
-this [data dictionary](data-serving/scripts/export-data/functions/01-split/fields.txt).
+this [data dictionary](data-serving/scripts/export-data/data_dictionary.txt).
 
 ## CI/CD status
 

--- a/data-serving/data-service/README.md
+++ b/data-serving/data-service/README.md
@@ -11,7 +11,7 @@ From the data-service root, run:
 (You may want to optionally `npm run drop-cases` first to remove any stale data: beware doing this in production!)
 
 # Update the fields used in CSV export
-1. edit `../scripts/export-data/functions/01-split/fields.txt`
+1. edit `../scripts/export-data/fields.txt`
 2. Generate the CSV fields list
    `pushd ../scripts/prepare_fields_list; npm run populate-fields; popd`
 3. re-build the data service (`npm run dev` watches the source so will do this automatically)

--- a/dev/run_session.py
+++ b/dev/run_session.py
@@ -38,7 +38,7 @@ DOWNLOADS = {
     "all.tsv": {"format": "tsv"}
 }
 
-FIELDS_FILE = "../data-serving/scripts/export-data/functions/01-split/fields.txt"
+FIELDS_FILE = "../data-serving/scripts/export-data/fields.txt"
 
 
 def sign_up(session: Session) -> None:

--- a/verification/curator-service/ui/src/components/App/App.test.tsx
+++ b/verification/curator-service/ui/src/components/App/App.test.tsx
@@ -104,7 +104,7 @@ describe('<App />', () => {
         );
         expect(await screen.findByTestId('dictionaryButton')).toHaveAttribute(
             'href',
-            'https://github.com/globaldothealth/list/blob/main/data-serving/scripts/export-data/functions/01-split/fields.txt',
+            'https://raw.githubusercontent.com/globaldothealth/list/main/data-serving/scripts/export-data/data_dictionary.txt',
         );
         expect(
             await screen.findByTestId('acknowledgmentsButton'),

--- a/verification/curator-service/ui/src/components/App/App.tsx
+++ b/verification/curator-service/ui/src/components/App/App.tsx
@@ -364,7 +364,7 @@ function ProfileMenu(props: { user: User }): JSX.Element {
                     className={classes.link}
                     rel="noopener noreferrer"
                     target="_blank"
-                    href="https://github.com/globaldothealth/list/blob/main/data-serving/scripts/export-data/functions/01-split/fields.txt"
+                    href="https://raw.githubusercontent.com/globaldothealth/list/main/data-serving/scripts/export-data/data_dictionary.txt"
                     onClick={handleClose}
                 >
                     <MenuItem>Data dictionary</MenuItem>
@@ -737,7 +737,7 @@ export default function App(): JSX.Element {
                             <div className={classes.spacer}></div>
                             <div className={classes.divider}></div>
                             <a
-                                href="https://github.com/globaldothealth/list/blob/main/data-serving/scripts/export-data/functions/01-split/fields.txt"
+                                href="https://raw.githubusercontent.com/globaldothealth/list/main/data-serving/scripts/export-data/data_dictionary.txt"
                                 rel="noopener noreferrer"
                                 target="_blank"
                                 data-testid="dictionaryButton"

--- a/verification/curator-service/ui/src/components/landing-page/LandingPage.test.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/LandingPage.test.tsx
@@ -42,7 +42,7 @@ describe('<LandingPage />', () => {
         );
         expect(screen.getByText('Data dictionary')).toHaveAttribute(
             'href',
-            'fields.txt',
+            'https://raw.githubusercontent.com/globaldothealth/list/main/data-serving/scripts/export-data/data_dictionary.txt',
         );
         expect(screen.getByText('Data acknowledgments')).toHaveAttribute(
             'href',

--- a/verification/curator-service/ui/src/components/landing-page/LandingPage.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/LandingPage.tsx
@@ -172,7 +172,7 @@ const LandingPage = (): JSX.Element => {
                             </div>
                             <div className={classes.link}>
                                 <a
-                                    href="fields.txt"
+                                    href="https://raw.githubusercontent.com/globaldothealth/list/main/data-serving/scripts/export-data/data_dictionary.txt"
                                     rel="noopener noreferrer"
                                     target="_blank"
                                 >


### PR DESCRIPTION
The full version of the data dictionary (data_dictionary.txt)
is now linked to from the UI, and references to the older
01-split/fields.txt has been changed to the correct location.

Fixes: #2309
