### PR TITLE
prune-uploads: Add aggregate hook to prune-uploads

### DIFF
--- a/data-serving/scripts/prune-uploads/hooks/aggregate.py
+++ b/data-serving/scripts/prune-uploads/hooks/aggregate.py
@@ -1,0 +1,42 @@
+# Runs aggregate job after prune-uploads
+import os
+from typing import Any
+
+import boto3
+
+AWS_REGION = os.getenv("GDH_AGGREGATE_AWS_REGION", "eu-central-1")
+# Job definition names are of the form PREFIX-<env>
+PREFIX = "gdh-map-aggregation"
+JOB_QUEUE = "gdh-map-aggregation"
+
+
+def run(sources: list[dict[str, Any]], env: str, dry_run: bool = False):
+    print("*** Running hook: aggregate ***")
+    batch = boto3.client("batch", region_name=AWS_REGION)
+    if not sources:
+        print("No sources to run hook for, quitting.")
+        return
+    try:
+        jobdefs = set(
+            j["jobDefinitionName"]
+            for j in batch.describe_job_definitions()["jobDefinitions"]
+            if j["jobDefinitionName"].startswith(PREFIX)
+        )
+    except Exception as e:
+        print("Error occurred when fetching job definitions")
+        print(e)
+        return
+
+    if (jobdef := f"{PREFIX}-{env}") in jobdefs:
+        print(f"Submitting aggregation job: {jobdef} ...")
+        try:
+            if not dry_run:
+                batch.submit_job(
+                    jobName=jobdef, jobDefinition=jobdef, jobQueue=JOB_QUEUE
+                )
+                print(f"Successfully submitted job for {jobdef}")
+        except Exception as e:
+            print(f"Error occurred while trying to submit {jobdef}")
+            print(e)
+    else:
+        print(f"Could not find job definition: {jobdef}")

--- a/data-serving/scripts/prune-uploads/prune_uploads.py
+++ b/data-serving/scripts/prune-uploads/prune_uploads.py
@@ -17,8 +17,9 @@ import requests
 from bson.objectid import ObjectId
 
 import hooks.country_export
+import hooks.aggregate
 
-HOOKS = ["country_export"]
+HOOKS = ["country_export", "aggregate"]
 
 def _ids(xs):
     return [str(x["_id"]) for x in xs]
@@ -316,5 +317,11 @@ if __name__ == "__main__":
         notify("\n".join(m), webhook_url)
 
     selected_hooks = get_selected_hooks(args.run_hooks)
-    if ingested_sources and "country_export" in selected_hooks:
+    if not ingested_sources:
+        print("No sources were ingested, skipping hooks.")
+        sys.exit(0)
+
+    if "country_export" in selected_hooks:
         hooks.country_export.run(ingested_sources, args.env, args.dry_run)
+    if "aggregate" in selected_hooks:
+        hooks.aggregate.run(ingested_sources, args.env, args.dry_run)


### PR DESCRIPTION
Now that aggregate is fixed, we can hook it up to prune-uploads, which will avoid us having to manage another EventBridge rule, as well as making sure it runs *after* prune.