### PR TITLE
retrieval: Assign auth a value if cookies unset

### DIFF
--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -213,10 +213,7 @@ def upload_to_s3(
 def invoke_parser(
     env, parser_module, source_id, upload_id, api_headers, cookies, s3_object_key,
         source_url, date_filter, parsing_date_range):
-    if cookies:
-        auth = {
-            "email": os.getenv("EPID_INGESTION_EMAIL", "")
-        }
+    auth = {"email": os.getenv("EPID_INGESTION_EMAIL", "")} if cookies else None
     payload = {
         "env": env,
         "s3Bucket": OUTPUT_BUCKET,


### PR DESCRIPTION
This prevents UnboundLocalError when creating the payload.
