### PR TITLE
Robustify country migration

### DIFF
--- a/data-serving/scripts/setup-db/manual-migration-helpers/batch_countries.js
+++ b/data-serving/scripts/setup-db/manual-migration-helpers/batch_countries.js
@@ -35,14 +35,16 @@ var prog = 0;
 print("Processing " + count + " documents");
 sourceCollection.find(filter, { _id: 1, location: 1, travelHistory: 1 }).batchSize(1000).forEach(function(doc) {
   prog++;
-  const country = countryNameToCode(doc.location.country);
-  if (country) {
-    batch.find({ _id: doc._id }).updateOne({ $set: { 'location.country' : country }});
-}
+  if (doc.location.country.length !== 2) {
+    const country = countryNameToCode(doc.location.country);
+    if (country) {
+        batch.find({ _id: doc._id }).updateOne({ $set: { 'location.country' : country }});
+    }
+  }
   const travel = doc.travelHistory?.travel ?? null;
   if (travel) {
     travel.forEach((aTravel, i) => {
-        if (aTravel.location?.country) {
+        if (aTravel.location?.country && aTravel.location?.country.length !== 2) {
             const key = `travelHistory.travel.${i}.location.country`;
             const code = countryNameToCode(aTravel.location.country);
             if (code) {


### PR DESCRIPTION
Before I re-run the country codes migration in dev I need to fix the problem that made it bomb out last time, and ensure it doesn't try to migrate data that's already been fixed.