### PR TITLE
data-service/model: Fix mismatch in vaccine sideEffects schema

### DIFF
--- a/data-serving/data-service/src/model/vaccine.ts
+++ b/data-serving/data-service/src/model/vaccine.ts
@@ -17,7 +17,7 @@ export type VaccineDocument = mongoose.Document & {
     name: string;
     batch: string;
     date: Date;
-    sideEffects: SymptomsDocument;
+    sideEffects: SymptomsDocument & { status: "Symptomatic" };
     previousInfection: 'yes' | 'no' | 'NA';
     previousInfectionDetectionMethod: string;
 };

--- a/data-serving/data-service/src/model/vaccine.ts
+++ b/data-serving/data-service/src/model/vaccine.ts
@@ -6,7 +6,7 @@ export const vaccineSchema = new mongoose.Schema(
         name: String,
         batch: String,
         date: Date,
-        sideEffects: [symptomsSchema],
+        sideEffects: symptomsSchema,
         previousInfection: String,
         previousInfectionDetectionMethod: String,
     },


### PR DESCRIPTION
Vaccine side effects are an array in the Mongoose schema, but
of the form {values: [string], status: string} in the MongoDB
schema, which led to validation passing but raised an error
on insert to MongoDB.

Fixes: #2410
