### PR TITLE
Remove unused arg from the cleanup script image build

### DIFF
--- a/.github/workflows/ingestion-cleanup-deploy.yml
+++ b/.github/workflows/ingestion-cleanup-deploy.yml
@@ -41,12 +41,11 @@ jobs:
       if: ${{ github.ref == 'refs/heads/main' }}
       working-directory: ingestion/functions
       env:
-        NOTIFY_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_METRICS_URL }}
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: gdh-ingestor-cleanup
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build --build-arg NOTIFY_WEBHOOK_URL -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY -f Dockerfile-clean .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY -f Dockerfile-clean .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
@@ -54,11 +53,10 @@ jobs:
       if: ${{ endsWith(github.ref, '-stable') }}
       working-directory: ingestion/functions
       env:
-        NOTIFY_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_METRICS_URL }}
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: gdh-ingestor-cleanup
         IMAGE_TAG: ${{ github.sha }}
       run: |
-        docker build --build-arg NOTIFY_WEBHOOK_URL -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:stable -f Dockerfile-clean .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:stable -f Dockerfile-clean .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:stable


### PR DESCRIPTION
This fixes one problem. The build action failed on merge, looks like the connection to ECR timed out but will reevaluate if this merge fails too.