### PR TITLE
2526 fix geocoding

### DIFF
--- a/geocoding/location-service/src/app/geocoder_suggester.py
+++ b/geocoding/location-service/src/app/geocoder_suggester.py
@@ -1,4 +1,12 @@
+import logging
+import sys
+
 from src.app.geocoder import Geocoder
+
+h = logging.StreamHandler(sys.stdout)
+logger = logging.getLogger(__name__)
+logger.addHandler(h)
+logger.setLevel(logging.INFO)
 
 class GeocodeSuggester:
     """Suggest geocoding by asking a cohort of geocoders to locate the query."""
@@ -17,14 +25,19 @@ class GeocodeSuggester:
         """Interpret the request and pass it to the geocoders until one of them
         returns a geocode result."""
         if 'q' not in request:
+            logger.debug('empty query')
             return []
+        logger.debug(f"suggesting for query: {request['q']}")
         opts = { }
         if 'limitToResolution' in request:
             opts['limitToResolution'] = [self.limitToValidResolution(x) for x in request['limitToResolution'].split(',')]
         if 'limitToCountry' in request:
             opts['limitToCountry'] = request['limitToCountry'].split(',')
+        logger.debug(f"opts: {opts}")
         for g in self.geocoders:
             suggestions = g.geocode(request['q'], opts)
             if len(suggestions) > 0:
+                logger.debug("geocoder {g} suggests {suggestions}")
                 return suggestions
+        logger.debug(f"No suggestions for query {request['q']}")
         return []

--- a/geocoding/location-service/test/test_fake_geocoder.py
+++ b/geocoding/location-service/test/test_fake_geocoder.py
@@ -1,5 +1,7 @@
+import os
 import unittest
 
+os.environ['ENABLE_FAKE_GEOCODER'] = 'YES'
 from src.app import main
 
 

--- a/geocoding/location-service/test/test_geocoder.py
+++ b/geocoding/location-service/test/test_geocoder.py
@@ -83,3 +83,8 @@ class GeocodeTests(unittest.TestCase):
         })
         mapbox_patch.assert_called_once()
         assert feats == feats2
+
+    def test_canFindCodeForUnitedStates(self):
+        geocoder = Geocoder('api_token', FakeAdminsFetcher())
+        code = geocoder.getISO3166Code('United States')
+        assert code == 'US'


### PR DESCRIPTION
Problem was that the name-to-country mapping used in the location service correctly rejects ambiguous names, but that mapbox returns "United States" for the USA which is ambiguous. I've special-cased that, and added enough logging that we should be able to find other cases much more quickly.