### PR TITLE
ingestion: Revert removal of imports workaround, fixes #2532

### DIFF
--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -9,18 +9,23 @@ object.
 
 import os
 import re
+import sys
 import json
 import tempfile
 import requests
 import functools
-import common.ingestion_logging as logging
+from enum import Enum
+from pathlib import Path
 
 import google
 import google.auth.transport.requests
-
-from enum import Enum
-from pathlib import Path
 from google.oauth2 import service_account
+
+try:
+    import ingestion_logging as logging
+except Exception:
+    sys.path.append(Path(__file__).parent)
+    import common.ingestion_logging as logging
 
 E2E_MOCK_SOURCE_URL = os.environ.get("MOCK_SOURCE_DATA_ADDRESS", "")
 REGISTRATION_ENDPOINT = os.environ.get("REGISTRATION_ENDPOINT", "http://localhost:3001/auth/register")

--- a/ingestion/functions/common/common_lib.py
+++ b/ingestion/functions/common/common_lib.py
@@ -41,6 +41,7 @@ _METADATA_BUCKET = "epid-ingestion"
 MIN_SOURCE_ID_LENGTH, MAX_SOURCE_ID_LENGTH = 24, 24
 
 logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
 
 class UploadError(Enum):
     """Upload error categories corresponding to the G.h Source API."""

--- a/ingestion/functions/common/ingestion_logging.py
+++ b/ingestion/functions/common/ingestion_logging.py
@@ -8,7 +8,7 @@ def getLogger(module_name):
     if not logger.hasHandlers():
         handler = logging.StreamHandler(stream=sys.stdout)
         handler.setLevel(logging.DEBUG)
-        logger.addHandler()
+        logger.addHandler(handler)
         handlers.add(handler)
     return logger
 

--- a/ingestion/functions/common/parsing_lib.py
+++ b/ingestion/functions/common/parsing_lib.py
@@ -42,6 +42,7 @@ DATE_FORMATS = ["%m/%d/%YZ", "%m/%d/%Y"]
 CASES_BATCH_SIZE = 250
 
 logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
 
 try:
     with (Path(__file__).parent / "geocoding_countries.json").open() as g:

--- a/ingestion/functions/parsing/USA/USA.py
+++ b/ingestion/functions/parsing/USA/USA.py
@@ -5,9 +5,19 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 import csv
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
     
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/argentina/argentina.py
+++ b/ingestion/functions/parsing/argentina/argentina.py
@@ -4,7 +4,18 @@ from datetime import datetime
 import csv
 import json
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir, os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/brazil_acre/acre.py
+++ b/ingestion/functions/parsing/brazil_acre/acre.py
@@ -4,7 +4,18 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
+
 
 _AGE = "idade"
 _GENDER = "sexo"

--- a/ingestion/functions/parsing/brazil_amapa/amapa.py
+++ b/ingestion/functions/parsing/brazil_amapa/amapa.py
@@ -3,9 +3,19 @@ import os
 import sys
 from datetime import datetime
 import csv
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/brazil_ceara/ceara.py
+++ b/ingestion/functions/parsing/brazil_ceara/ceara.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 _UUID = "ÿid"
 _AGE = "idade"

--- a/ingestion/functions/parsing/brazil_distrito_federal/distrito_federal.py
+++ b/ingestion/functions/parsing/brazil_distrito_federal/distrito_federal.py
@@ -3,9 +3,19 @@ import sys
 from datetime import datetime
 import csv
 import json
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/brazil_espirito_santo/espirito_santo.py
+++ b/ingestion/functions/parsing/brazil_espirito_santo/espirito_santo.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 _AGE = "FaixaEtaria"
 _GENDER = "Sexo"

--- a/ingestion/functions/parsing/brazil_goias/goias.py
+++ b/ingestion/functions/parsing/brazil_goias/goias.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 _AGE = "faixa_etaria"
 _GENDER = "sexo"

--- a/ingestion/functions/parsing/brazil_para/para.py
+++ b/ingestion/functions/parsing/brazil_para/para.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 _UUID = "ÿid"
 _AGE = "idade"

--- a/ingestion/functions/parsing/brazil_paraiba/paraiba.py
+++ b/ingestion/functions/parsing/brazil_paraiba/paraiba.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 _UUID = "ÿid"
 _AGE = "idade"

--- a/ingestion/functions/parsing/brazil_rio_de_janeiro/rio_de_janeiro.py
+++ b/ingestion/functions/parsing/brazil_rio_de_janeiro/rio_de_janeiro.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 def convert_date(date_str: str,dataserver=True):
     """ 

--- a/ingestion/functions/parsing/brazil_santa_catarina/santa_catarina.py
+++ b/ingestion/functions/parsing/brazil_santa_catarina/santa_catarina.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 
 _AGE = "idade"

--- a/ingestion/functions/parsing/brazil_srag/srag.py
+++ b/ingestion/functions/parsing/brazil_srag/srag.py
@@ -4,7 +4,18 @@ from datetime import datetime
 import csv
 import json
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir, os.pardir, 'common'))
+    import parsing_lib
+
 
 _AGE = "NU_IDADE_N"
 _AGE_TYPE = "TP_IDADE"

--- a/ingestion/functions/parsing/canada/canada.py
+++ b/ingestion/functions/parsing/canada/canada.py
@@ -5,8 +5,17 @@ import sys
 import re
 from datetime import date, datetime
 
-import common.parsing_lib as parsing_lib
-
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 # Input format: 
 # 1. '60-69' -> {"start": 60, "end": 69}
 # 2. '<10' -> {"start": 0, "end": 10}

--- a/ingestion/functions/parsing/ch_zurich/zurich.py
+++ b/ingestion/functions/parsing/ch_zurich/zurich.py
@@ -3,9 +3,19 @@ import os
 import sys
 from datetime import datetime
 import csv
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/colombia/colombia.py
+++ b/ingestion/functions/parsing/colombia/colombia.py
@@ -3,9 +3,19 @@ import sys
 from datetime import datetime
 import csv
 import json
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir, os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/cuba/cuba.py
+++ b/ingestion/functions/parsing/cuba/cuba.py
@@ -5,11 +5,21 @@ import copy
 from datetime import datetime
 import json
 from pathlib import Path
+import common.ingestion_logging as logging
 
 import pycountry
 
-import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/czechia/czechia.py
+++ b/ingestion/functions/parsing/czechia/czechia.py
@@ -5,7 +5,17 @@ import csv
 from pathlib import Path
 from datetime import datetime
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 _CZ = parsing_lib.geocode_country('CZ')
 

--- a/ingestion/functions/parsing/england/england.py
+++ b/ingestion/functions/parsing/england/england.py
@@ -3,9 +3,19 @@ import sys
 from datetime import datetime
 import csv
 import json
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'common/python'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/estonia/estonia.py
+++ b/ingestion/functions/parsing/estonia/estonia.py
@@ -4,7 +4,17 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 # Fixed location, all cases are for Estonia and no finer location is available in the source.
 _LOCATION = {

--- a/ingestion/functions/parsing/example/example.py
+++ b/ingestion/functions/parsing/example/example.py
@@ -3,7 +3,17 @@ import sys
 import csv
 import json
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'common/python'))
+    import parsing_lib
 
 
 def parse_cases(raw_data_file: str, source_id: str, source_url: str):

--- a/ingestion/functions/parsing/germany/germany.py
+++ b/ingestion/functions/parsing/germany/germany.py
@@ -3,9 +3,19 @@ import sys
 from datetime import datetime
 import csv
 import json
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/hongkong/hongkong.py
+++ b/ingestion/functions/parsing/hongkong/hongkong.py
@@ -3,9 +3,19 @@ import os
 import sys
 from datetime import datetime
 import csv
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/india/india.py
+++ b/ingestion/functions/parsing/india/india.py
@@ -5,7 +5,19 @@ import os
 import sys
 from datetime import datetime
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
+
+
 
 def convert_date(raw_date):
     """

--- a/ingestion/functions/parsing/japan/japan.py
+++ b/ingestion/functions/parsing/japan/japan.py
@@ -4,7 +4,19 @@ import sys
 from datetime import datetime
 from typing import Dict
 
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
+
 
 def convert_gender(raw_gender):
     if "gender" in raw_gender:

--- a/ingestion/functions/parsing/mexico/mexico.py
+++ b/ingestion/functions/parsing/mexico/mexico.py
@@ -3,9 +3,19 @@ import sys
 from datetime import datetime
 import csv
 import json
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/new_zealand/new_zealand.py
+++ b/ingestion/functions/parsing/new_zealand/new_zealand.py
@@ -5,7 +5,17 @@ from datetime import datetime
 import csv
 from pathlib import Path
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 _NZ = parsing_lib.geocode_country('NZ')
 _NZ["country"] = "New Zealand"

--- a/ingestion/functions/parsing/paraguay/paraguay.py
+++ b/ingestion/functions/parsing/paraguay/paraguay.py
@@ -4,7 +4,18 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
+
 
 _UUID = "ID"
 _AGE = "Edad"

--- a/ingestion/functions/parsing/peru/peru.py
+++ b/ingestion/functions/parsing/peru/peru.py
@@ -3,9 +3,19 @@ import sys
 from datetime import datetime
 import csv
 import json
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/republic_of_korea/republic_of_korea.py
+++ b/ingestion/functions/parsing/republic_of_korea/republic_of_korea.py
@@ -4,7 +4,17 @@ import sys
 import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 def convert_date(raw_date: str, dataserver=True):
     """

--- a/ingestion/functions/parsing/riograndedosul/riograndedosul.py
+++ b/ingestion/functions/parsing/riograndedosul/riograndedosul.py
@@ -4,7 +4,17 @@ import sys
 from datetime import date, datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 
 _AGE_INDEX = 5

--- a/ingestion/functions/parsing/saopaolo/saopaolo.py
+++ b/ingestion/functions/parsing/saopaolo/saopaolo.py
@@ -4,7 +4,18 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
+
 
 
 def convert_date(raw_date):

--- a/ingestion/functions/parsing/scotland/scotland.py
+++ b/ingestion/functions/parsing/scotland/scotland.py
@@ -4,7 +4,18 @@ import sys
 from datetime import datetime
 import csv
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
+
 
 
 def convert_date(raw_date: str, dataserver=True):

--- a/ingestion/functions/parsing/south_africa/south_africa.py
+++ b/ingestion/functions/parsing/south_africa/south_africa.py
@@ -5,7 +5,17 @@ from datetime import datetime
 import csv
 import pycountry
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 
 _UUID = "case_id"

--- a/ingestion/functions/parsing/taiwan/taiwan.py
+++ b/ingestion/functions/parsing/taiwan/taiwan.py
@@ -4,9 +4,20 @@ import csv
 import json
 from datetime import datetime
 from pathlib import Path
-
 import common.ingestion_logging as logging
-import common.parsing_lib as parsing_lib
+
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 logger = logging.getLogger(__name__)
 

--- a/ingestion/functions/parsing/thailand/thailand.py
+++ b/ingestion/functions/parsing/thailand/thailand.py
@@ -3,7 +3,17 @@ import os
 import sys
 from datetime import datetime
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,os.pardir, 'common'))
+    import parsing_lib
 
 with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "nationalities.json")) as json_file:
     nationalities = json.load(json_file)

--- a/ingestion/functions/parsing/variants/variants.py
+++ b/ingestion/functions/parsing/variants/variants.py
@@ -5,7 +5,17 @@ import csv
 import json
 import copy
 
-import common.parsing_lib as parsing_lib
+# Layer code, like parsing_lib, is added to the path by AWS.
+# To test locally (e.g. via pytest), we have to modify sys.path.
+# pylint: disable=import-error
+try:
+    import parsing_lib
+except ImportError:
+    sys.path.append(
+        os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'common/python'))
+    import parsing_lib
 
 def convert_date(raw_date: str):
     """

--- a/ingestion/functions/retrieval/retrieval.py
+++ b/ingestion/functions/retrieval/retrieval.py
@@ -18,6 +18,7 @@ import requests
 from datetime import datetime, timezone, timedelta
 
 logger = logging.getLogger(__name__)
+logger.setLevel("INFO")
 
 TEMP_PATH = "/tmp"
 ENV_FIELD = "env"


### PR DESCRIPTION
- Revert "Test removal of import workaround. Tests still passed locally... #2319"
- Revert "Remove the imports hack in the rest of the parsers #2319"
- ingestion(logging): addHandler() requires argument
- ingestion: Change path to make pytest pass
- ingestion: Set logging level to INFO
