### PR TITLE
2185 source info in source data

### DIFF
--- a/data-serving/scripts/setup-db/migrations/20220223130636-add_origin_fields_to_sources.js
+++ b/data-serving/scripts/setup-db/migrations/20220223130636-add_origin_fields_to_sources.js
@@ -1,0 +1,47 @@
+const originalOriginSchema = {
+  "bsonType": "object",
+  "required": ["url"],
+  "properties": {
+    "url": {
+      "bsonType": "string"
+    },
+    "license": {
+      "bsonType": "string"
+    }
+  }
+}
+
+const newOriginSchema = {
+  "bsonType": "object",
+  "required": ["license", "url"],
+  "properties": {
+    "url": {
+      "bsonType": "string"
+    },
+    "license": {
+      "bsonType": "string"
+    },
+    "providerName": {
+      "bsonType": "string"
+    },
+    "providerWebsiteUrl": {
+      "bsonType": "string"
+    }
+  }
+}
+
+module.exports = {
+  async up(db, client) {
+    let res = await db.command({listCollections: undefined, filter: {name: 'sources'}});
+    let schema = res.cursor.firstBatch[0].options.validator.$jsonSchema;
+    schema.properties.origin = newOriginSchema;
+    await db.command({ collMod: 'sources', validator:{ $jsonSchema: schema } } );
+},
+
+  async down(db, client) {
+    let res = await db.command({listCollections: undefined, filter: {name: 'sources'}});
+    let schema = res.cursor.firstBatch[0].options.validator.$jsonSchema;
+    schema.properties.origin = originalOriginSchema;
+    await db.command({ collMod: 'sources', validator:{ $jsonSchema: schema } } );
+  }
+};

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1137,17 +1137,26 @@ components:
                 name:
                     type: string
                     description: Human readable name of a source
-                    example: Paraguay Ministry of Health and Labor
+                    example: Paraguay
                 origin:
                     type: object
                     properties:
                         url:
                             type: string
                             example: https://opendata.digilugu.ee/opendata_covid19_test_results.csv
-                            description: Source location, can be http, https, or s3 schemes.
+                            description: Source location, can be http, https, or s3 schemes. This must be the link to the source data download.
                         license:
                             type: string
                             example: MIT
+                            description: The license under which we have the right to ingest the data. Ideally a SPDX identifier (https://spdx.org/licenses/).
+                        providerName:
+                            type: string
+                            example: Paraguay Ministry of Public Health and Social Welfare
+                            description: The organisation or individual who collects the data in this source.
+                        providerWebsiteUrl:
+                            type: string
+                            example: https://www.mspbs.gov.py/index.php
+                            description: The provider's website, or where possible their specific site for information about this outbreak (including the source data used here).
                 format:
                     type: string
                     description: Format of the source to be ingested, useful when automated ingestion

--- a/verification/curator-service/api/src/model/origin.ts
+++ b/verification/curator-service/api/src/model/origin.ts
@@ -4,9 +4,14 @@ export const originSchema = new mongoose.Schema(
     {
         url: {
             type: String,
-            required: 'Enter an origin URL',
+            required: 'Enter a data source URL',
         },
-        license: String,
+        license: {
+            type: String,
+            required: 'Enter a source license',
+        },
+        providerName: String,
+        providerWebsiteUrl: String,
     },
     { _id: false },
 );
@@ -14,4 +19,6 @@ export const originSchema = new mongoose.Schema(
 export type OriginDocument = mongoose.Document & {
     url: string;
     license: string;
+    providerName: string;
+    providerWebsiteUrl: string;
 };

--- a/verification/curator-service/api/test/model/data/origin.full.json
+++ b/verification/curator-service/api/test/model/data/origin.full.json
@@ -1,4 +1,6 @@
 {
     "url": "http://foo.bar",
-    "license": "MIT"
+    "license": "MIT",
+    "providerName": "The Ministry of Sound",
+    "providerWebsiteUrl": "https://www.ministryofsound.example"
 }

--- a/verification/curator-service/api/test/model/data/origin.minimal.json
+++ b/verification/curator-service/api/test/model/data/origin.minimal.json
@@ -1,3 +1,4 @@
 {
-    "url": "http://foo.bar"
+    "url": "http://foo.bar",
+    "license": "GPL3"
 }

--- a/verification/curator-service/api/test/model/origin.test.ts
+++ b/verification/curator-service/api/test/model/origin.test.ts
@@ -21,7 +21,14 @@ describe('validate', () => {
     });
 
     it('a minimal origin is valid', async () => {
-        return new Origin(minimalModel).validate();
+        const missingLicense = _.cloneDeep(minimalModel);
+        delete missingLicense.license;
+
+        return new Origin(missingLicense).validate((e) => {
+            expect(e).not.toBeNull();
+            if (e)
+                expect(e.name).toBe(Error.ValidationError.name);
+        });
     });
 
     it('a fully specified origin is valid', async () => {

--- a/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/BulkCaseForm.spec.ts
@@ -139,6 +139,7 @@ describe('Bulk upload form', function () {
         cy.get('div[data-testid="caseReference"]').type('www.new-source.com');
         cy.contains('li', 'www.new-source.com').click();
         cy.get('input[name="caseReference.sourceName"]').type('New source');
+        cy.get('input[name="caseReference.sourceLicense"]').type('GPL3');
         const csvFixture = '../fixtures/bulk_data.csv';
         cy.get('input[type="file"]').attachFile(csvFixture);
         cy.server();

--- a/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/Curator.spec.ts
@@ -45,6 +45,7 @@ describe('Curator', function () {
         cy.get('div[data-testid="caseReference"]').type('www.example.com');
         cy.contains('li', 'www.example.com').click();
         cy.get('input[name="caseReference.sourceName"]').type('Example source');
+        cy.get('input[name="caseReference.sourceLicense"]').type('MPL');
         cy.get('div[data-testid="sourceEntryId"]')
             .click()
             .type('testSourceEntryID123');

--- a/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/NewCaseForm.spec.ts
@@ -57,6 +57,7 @@ describe('New case form', function () {
         cy.get('div[data-testid="caseReference"]').type('www.new-source.com');
         cy.get('input[name="caseReference.sourceName"]').click();
         cy.get('input[name="caseReference.sourceName"]').type('New source');
+        cy.get('input[name="caseReference.sourceLicense"]').type('WTFPL');
         cy.get('div[data-testid="location"]').type('France');
         cy.contains('li', 'France').click();
         cy.get('input[name="confirmedDate"]').type('2020-01-01');

--- a/verification/curator-service/ui/src/components/AutomatedSourceForm.test.tsx
+++ b/verification/curator-service/ui/src/components/AutomatedSourceForm.test.tsx
@@ -59,7 +59,8 @@ describe('<AutomatedSourceForm />', () => {
         expect(screen.getByTestId('recipients')).toBeInTheDocument();
         expect(screen.getByTestId('excludeFromLineList')).toBeInTheDocument();
         expect(screen.getByTestId('hasStableIdentifiers')).toBeInTheDocument();
-
+        expect(screen.getByTestId('providerName')).toBeInTheDocument();
+        expect(screen.getByTestId('providerWebsiteUrl')).toBeInTheDocument();
         // Buttons
         expect(screen.getByText(/create source/i)).toBeEnabled();
         expect(screen.getByText(/cancel/i)).toBeEnabled();

--- a/verification/curator-service/ui/src/components/AutomatedSourceForm.tsx
+++ b/verification/curator-service/ui/src/components/AutomatedSourceForm.tsx
@@ -83,6 +83,8 @@ export interface AutomatedSourceFormValues {
     url: string;
     license: string;
     name: string;
+    providerName: string;
+    providerWebsiteUrl: string;
     countryCodes: string[];
     format: string;
     notificationRecipients: string[];
@@ -96,6 +98,8 @@ const AutomatedSourceFormSchema = Yup.object().shape({
     countryCodes: Yup.array().of(Yup.string()).required('Required'),
     format: Yup.string().required('Required'),
     license: Yup.string().required('Required'),
+    providerName: Yup.string(),
+    providerWebsiteUrl: Yup.string(),
     notificationRecipients: Yup.array().of(Yup.string().email()),
     excludeFromLineList: Yup.boolean().required('Required'),
     hasStableIdentifiers: Yup.boolean().required('Required'),
@@ -114,7 +118,12 @@ export default function AutomatedSourceForm(props: Props): JSX.Element {
         const newSource = {
             name: values.name,
             countryCodes: values.countryCodes,
-            origin: { url: values.url, license: values.license },
+            origin: {
+                url: values.url,
+                license: values.license,
+                providerName: values.providerName,
+                providerWebsiteUrl: values.providerWebsiteUrl,
+            },
             format: values.format,
             notificationRecipients: values.notificationRecipients,
             excludeFromLineList: values.excludeFromLineList,
@@ -149,6 +158,8 @@ export default function AutomatedSourceForm(props: Props): JSX.Element {
                             countryCodes: [],
                             format: '',
                             license: '',
+                            providerName: '',
+                            providerWebsiteUrl: '',
                             notificationRecipients: [user.email],
                             excludeFromLineList: false,
                             hasStableIdentifiers: false,
@@ -243,6 +254,26 @@ export default function AutomatedSourceForm(props: Props): JSX.Element {
                                                 name="license"
                                                 type="text"
                                                 data-testid="license"
+                                                component={TextField}
+                                                fullWidth
+                                            />
+                                        </div>
+                                        <div className={classes.formSection}>
+                                            <FastField
+                                                name="providerName"
+                                                label="Data Provider Name"
+                                                type="text"
+                                                data-testid="providerName"
+                                                component={TextField}
+                                                fullWidth
+                                            />
+                                        </div>
+                                        <div className={classes.formSection}>
+                                            <FastField
+                                                name="providerWebsiteUrl"
+                                                label="Data Provider Website"
+                                                type="text"
+                                                data-testid="providerWebsiteUrl"
                                                 component={TextField}
                                                 fullWidth
                                             />

--- a/verification/curator-service/ui/src/components/BulkCaseForm.tsx
+++ b/verification/curator-service/ui/src/components/BulkCaseForm.tsx
@@ -556,6 +556,9 @@ class BulkCaseForm extends React.Component<
                 const newCaseReference = await submitSource({
                     name: values.caseReference.sourceName as string,
                     url: values.caseReference.sourceUrl,
+                    license: values.caseReference.sourceLicense as string,
+                    providerName: values.caseReference.sourceProviderName,
+                    providerWebsiteUrl: values.caseReference.sourceProviderUrl,
                     format: 'CSV',
                 });
                 values.caseReference.sourceId = newCaseReference.sourceId;

--- a/verification/curator-service/ui/src/components/CaseForm.tsx
+++ b/verification/curator-service/ui/src/components/CaseForm.tsx
@@ -349,6 +349,9 @@ export default function CaseForm(props: Props): JSX.Element {
                 const newCaseReference = await submitSource({
                     name: values.caseReference.sourceName as string,
                     url: values.caseReference.sourceUrl,
+                    license: values.caseReference.sourceLicense as string,
+                    providerName: values.caseReference.sourceProviderName,
+                    providerWebsiteUrl: values.caseReference.sourceProviderUrl,
                 });
                 values.caseReference.sourceId = newCaseReference.sourceId;
             } catch (e) {

--- a/verification/curator-service/ui/src/components/SourceTable.test.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.test.tsx
@@ -22,6 +22,8 @@ describe('<SourceTable />', () => {
         const sourceName = 'source_name';
         const originUrl = 'origin url';
         const format = 'JSON';
+        const providerName = 'provider_name';
+        const providerWebsiteUrl = 'website url';
         const countryCodes = ['US', 'MX', 'CA'];
         const license = 'MIT';
         const recipients = ['foo@bar.com', 'bar@baz.com'];
@@ -36,7 +38,9 @@ describe('<SourceTable />', () => {
                 countryCodes: countryCodes,
                 origin: {
                     url: originUrl,
-                    license: license,
+                    license,
+                    providerName,
+                    providerWebsiteUrl,
                 },
                 automation: {
                     parser: {
@@ -89,6 +93,12 @@ describe('<SourceTable />', () => {
         expect(await screen.findByText(new RegExp(format))).toBeInTheDocument();
         expect(
             await screen.findByText(new RegExp(license)),
+        ).toBeInTheDocument();
+        expect(
+            await screen.findByText(new RegExp(providerName)),
+        ).toBeInTheDocument();
+        expect(
+            await screen.findByText(new RegExp(providerWebsiteUrl)),
         ).toBeInTheDocument();
         expect(
             await screen.findByText(new RegExp(recipients.join('.*'))),

--- a/verification/curator-service/ui/src/components/SourceTable.tsx
+++ b/verification/curator-service/ui/src/components/SourceTable.tsx
@@ -24,7 +24,9 @@ import ChipInput from 'material-ui-chip-input';
 
 interface Origin {
     url: string;
-    license?: string;
+    license: string;
+    providerName?: string;
+    providerWebsiteUrl?: string;
 }
 
 interface Field {
@@ -88,10 +90,11 @@ interface TableRow {
     countryCodes: string; // flattened
     // origin
     url: string;
+    license: string;
+    providerName?: string;
+    providerWebsiteUrl?: string;
 
-    license?: string;
     // automation.parser
-
     format?: string;
     awsLambdaArn?: string;
     // automation.schedule
@@ -232,6 +235,8 @@ class SourceTable extends React.Component<Props, SourceTableState> {
             origin: {
                 url: rowData.url,
                 license: rowData.license,
+                providerName: rowData.providerName,
+                providerWebsiteUrl: rowData.providerWebsiteUrl,
             },
             format: rowData.format,
             automation:
@@ -423,6 +428,57 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                         size="small"
                                         fullWidth
                                         placeholder="License"
+                                        error={
+                                            !this.validateRequired(props.value)
+                                        }
+                                        helperText={
+                                            this.validateRequired(props.value)
+                                                ? ''
+                                                : 'Required field'
+                                        }
+                                        onChange={(event): void =>
+                                            props.onChange(event.target.value)
+                                        }
+                                        defaultValue={props.value}
+                                    />
+                                ),
+                            },
+                            {
+                                title: 'Provider Name',
+                                field: 'providerName',
+                                tooltip:
+                                    'Miskatonic University Department of Medecine',
+                                editComponent: (props): JSX.Element => (
+                                    <TextField
+                                        type="text"
+                                        size="small"
+                                        fullWidth
+                                        placeholder="Provider Name"
+                                        error={
+                                            !this.validateRequired(props.value)
+                                        }
+                                        helperText={
+                                            this.validateRequired(props.value)
+                                                ? ''
+                                                : 'Required field'
+                                        }
+                                        onChange={(event): void =>
+                                            props.onChange(event.target.value)
+                                        }
+                                        defaultValue={props.value}
+                                    />
+                                ),
+                            },
+                            {
+                                title: 'Provider Website',
+                                field: 'providerWebsiteUrl',
+                                tooltip: 'https://medsci.miskatonic.edu/',
+                                editComponent: (props): JSX.Element => (
+                                    <TextField
+                                        type="text"
+                                        size="small"
+                                        fullWidth
+                                        placeholder="Provider Website"
                                         error={
                                             !this.validateRequired(props.value)
                                         }
@@ -658,6 +714,10 @@ class SourceTable extends React.Component<Props, SourceTableState> {
                                                 format: s.format,
                                                 url: s.origin.url,
                                                 license: s.origin.license,
+                                                providerName:
+                                                    s.origin.providerName,
+                                                providerWebsiteUrl:
+                                                    s.origin.providerWebsiteUrl,
                                                 awsLambdaArn:
                                                     s.automation?.parser
                                                         ?.awsLambdaArn,

--- a/verification/curator-service/ui/src/components/common-form-fields/Source.tsx
+++ b/verification/curator-service/ui/src/components/common-form-fields/Source.tsx
@@ -26,12 +26,16 @@ const TooltipText = () => (
         <ul>
             <li>
                 <strong>New data source:</strong> If this is a new data source
-                you will need to add it to the system along with the root data
-                source name. For example if the raw source was the ""7th July
-                Press Release from Honduras” the source name would be the issuer
-                of the press release e.g. “Honduras ministry of health'. The
-                source name needs to reflect the actually provider of the data,
-                not the method of reporting.
+                you will need to add it to the system along with the data source
+                name, license, and information about the provider. For example
+                if the raw source was the “7th July Press Release from Honduras”
+                the provider name would be the issuer of the press release e.g.
+                “Honduras ministry of health”. The provider name needs to
+                reflect the actual provider of the data, not the method of
+                reporting. The source name can be anything informative to
+                curators. The source URL should be a link to the data you’re
+                uploading, while the provider website URL should link to an
+                informative website.
             </li>
             <li>
                 <strong>Existing data source:</strong> If the URL is an existing
@@ -79,6 +83,9 @@ export default class Source extends React.Component<
 
 interface OriginData {
     url: string;
+    license: string;
+    providerName?: string;
+    providerWebsiteUrl?: string;
 }
 
 interface SourceData {
@@ -95,6 +102,9 @@ interface ListSourcesResponse {
 export interface CaseReferenceForm extends CaseReference {
     inputValue?: string;
     sourceName?: string;
+    sourceLicense?: string;
+    sourceProviderName?: string;
+    sourceProviderUrl?: string;
 }
 
 interface SourceAutocompleteProps {
@@ -106,12 +116,18 @@ interface SourceAutocompleteProps {
 export async function submitSource(opts: {
     name: string;
     url: string;
+    license: string;
     format?: string;
+    providerName?: string;
+    providerWebsiteUrl?: string;
 }): Promise<CaseReference> {
     const newSource = {
         name: opts.name,
         origin: {
             url: opts.url,
+            license: opts.license,
+            providerName: opts.providerName,
+            providerWebsiteUrl: opts.providerWebsiteUrl,
         },
         format: opts.format,
     };
@@ -126,7 +142,7 @@ export async function submitSource(opts: {
 const filter = createFilterOptions<CaseReferenceForm>();
 
 const useStyles = makeStyles(() => ({
-    sourceNameField: {
+    sourceTextField: {
         marginTop: '1em',
     },
 }));
@@ -209,6 +225,9 @@ export function SourcesAutocomplete(
                             sourceId: source._id,
                             sourceUrl: source.origin.url,
                             sourceName: source.name,
+                            sourceLicense: source.origin.license,
+                            sourceProviderName: source.origin.providerName,
+                            sourceProviderUrl: source.origin.providerWebsiteUrl,
                             additionalSources: [] as unknown as [
                                 { sourceUrl: string },
                             ],
@@ -258,6 +277,12 @@ export function SourcesAutocomplete(
                             sourceUrl: newValue,
                             sourceId: '',
                             sourceName: values.caseReference?.sourceName ?? '',
+                            sourceLicense:
+                                values.caseReference?.sourceLicense ?? '',
+                            sourceProviderName:
+                                values.caseReference?.sourceProviderName ?? '',
+                            sourceProviderUrl:
+                                values.caseReference?.sourceProviderUrl ?? '',
                             additionalSources: [] as unknown as [
                                 { sourceUrl: string },
                             ],
@@ -288,6 +313,12 @@ export function SourcesAutocomplete(
                             sourceUrl: params.inputValue,
                             sourceId: '',
                             sourceName: values.caseReference?.sourceName ?? '',
+                            sourceLicense:
+                                values.caseReference?.sourceLicense ?? '',
+                            sourceProviderName:
+                                values.caseReference?.sourceProviderName ?? '',
+                            sourceProviderUrl:
+                                values.caseReference?.sourceProviderUrl ?? '',
                             additionalSources: [] as unknown as [
                                 { sourceUrl: string },
                             ],
@@ -343,12 +374,40 @@ export function SourcesAutocomplete(
                 !options.find((option) => option.sourceUrl === inputValue) && (
                     <>
                         <FastField
-                            className={classes.sourceNameField}
+                            className={classes.sourceTextField}
                             label="Source name"
                             name={`${name}.sourceName`}
                             helperText="Required"
                             type="text"
                             data-testid="sourceName"
+                            component={TextField}
+                            fullWidth
+                        />
+                        <FastField
+                            className={classes.sourceTextField}
+                            label="Source license"
+                            name={`${name}.sourceLicense`}
+                            helperText="Required"
+                            type="text"
+                            data-testid="sourceLicense"
+                            component={TextField}
+                            fullWidth
+                        />
+                        <FastField
+                            className={classes.sourceTextField}
+                            label="Source provider name"
+                            name={`${name}.sourceProviderName`}
+                            type="text"
+                            data-testid="sourceProviderName"
+                            component={TextField}
+                            fullWidth
+                        />
+                        <FastField
+                            className={classes.sourceTextField}
+                            label="Source provider website"
+                            name={`${name}.sourceProviderUrl`}
+                            type="text"
+                            data-testid="sourceProviderUrl"
                             component={TextField}
                             fullWidth
                         />


### PR DESCRIPTION
Add the extra fields that can be used to generate the acknowledgements page for #2499. I noticed that the "source name" wasn't being used in a very informative way so I've added _another_ name field that should be used to identify the data provider.