### PR TITLE
#2637 UI: Disallow future dates in filters

### DIFF
--- a/verification/curator-service/ui/src/components/App/index.tsx
+++ b/verification/curator-service/ui/src/components/App/index.tsx
@@ -354,7 +354,7 @@ function ProfileMenu(props: { user: User; version: string }): JSX.Element {
                 </a>
 
                 {props.version && (
-                    <>
+                    <div>
                         <Divider className={classes.divider} />
 
                         <a
@@ -365,7 +365,7 @@ function ProfileMenu(props: { user: User; version: string }): JSX.Element {
                         >
                             <MenuItem>Version: {props.version}</MenuItem>
                         </a>
-                    </>
+                    </div>
                 )}
             </Menu>
         </div>

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -482,6 +482,8 @@ export default function FiltersDialog({
                             name="dateconfirmedbefore"
                             type="date"
                             variant="outlined"
+                            // This makes sure that only 4 digits can be entered as a year
+                            InputProps={{ inputProps: { max: '9999-12-31' } }}
                             size={inputSize}
                             InputLabelProps={{ shrink: true }}
                             value={formik.values.dateconfirmedbefore || ''}
@@ -504,6 +506,8 @@ export default function FiltersDialog({
                             name="dateconfirmedafter"
                             type="date"
                             variant="outlined"
+                            // This makes sure that only 4 digits can be entered as a year
+                            InputProps={{ inputProps: { max: '9999-12-31' } }}
                             size={inputSize}
                             InputLabelProps={{ shrink: true }}
                             value={formik.values.dateconfirmedafter || ''}

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -232,8 +232,6 @@ export default function FiltersDialog({
         return `${year}-${month}-${day}`;
     };
 
-    console.log(getMaxDate());
-
     return (
         <Dialog open={isOpen} maxWidth={'xl'} onClose={closeAndResetAlert}>
             <DialogTitle>

--- a/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
+++ b/verification/curator-service/ui/src/components/FiltersDialog/index.tsx
@@ -215,6 +215,25 @@ export default function FiltersDialog({
     //     </>
     // );
 
+    const getMaxDate = () => {
+        const currentDate = new Date();
+        const year = currentDate.getFullYear();
+        let month: number | string = currentDate.getMonth() + 1;
+        let day: number | string = currentDate.getDate();
+
+        if (month < 10) {
+            month = `0${month}`;
+        }
+
+        if (day < 10) {
+            day = `0${day}`;
+        }
+
+        return `${year}-${month}-${day}`;
+    };
+
+    console.log(getMaxDate());
+
     return (
         <Dialog open={isOpen} maxWidth={'xl'} onClose={closeAndResetAlert}>
             <DialogTitle>
@@ -483,7 +502,9 @@ export default function FiltersDialog({
                             type="date"
                             variant="outlined"
                             // This makes sure that only 4 digits can be entered as a year
-                            InputProps={{ inputProps: { max: '9999-12-31' } }}
+                            InputProps={{
+                                inputProps: { max: getMaxDate() },
+                            }}
                             size={inputSize}
                             InputLabelProps={{ shrink: true }}
                             value={formik.values.dateconfirmedbefore || ''}
@@ -507,7 +528,9 @@ export default function FiltersDialog({
                             type="date"
                             variant="outlined"
                             // This makes sure that only 4 digits can be entered as a year
-                            InputProps={{ inputProps: { max: '9999-12-31' } }}
+                            InputProps={{
+                                inputProps: { max: getMaxDate() },
+                            }}
                             size={inputSize}
                             InputLabelProps={{ shrink: true }}
                             value={formik.values.dateconfirmedafter || ''}


### PR DESCRIPTION
**Changes**
- Fixed bug where user could input more than 4 digits as a year in `FiltersDialog`