### PR TITLE
2670 bucket ages

### DIFF
--- a/data-serving/data-service/README.md
+++ b/data-serving/data-service/README.md
@@ -15,3 +15,12 @@ From the data-service root, run:
 2. Generate the CSV fields list
    `pushd ../scripts/prepare_fields_list; npm run populate-fields; popd`
 3. re-build the data service (`npm run dev` watches the source so will do this automatically)
+
+# Age bucketing
+
+To prevent reidentification of individual cases, we use bucketed age ranges for infants (<1 year old) and then five year ranges.
+This bucketing is done in the data service: age ranges are converted to age buckets when you write through the API (PUT/POST/upsert/batchUpsert),
+then the bucketed age range is returned in API requests (GET or download).
+
+This could have been done using mongoose hooks but we don't want to rely on mongoose for much longer (already removed from the curator service),
+so instead all transformations are done by the cases controller.

--- a/data-serving/data-service/package-lock.json
+++ b/data-serving/data-service/package-lock.json
@@ -10889,14 +10889,14 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
+      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
       "dependencies": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2"
       },
       "engines": {
@@ -11028,17 +11028,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mongodb/node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mongoose": {
       "version": "5.13.9",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.9.tgz",
@@ -11073,44 +11062,6 @@
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
       "peerDependencies": {
         "mongoose": "*"
-      }
-    },
-    "node_modules/mongoose/node_modules/mongodb": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
-      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
-      "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.0.3",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws4": {
-          "optional": true
-        },
-        "bson-ext": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
       }
     },
     "node_modules/mongoose/node_modules/ms": {
@@ -12263,14 +12214,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
@@ -22482,26 +22425,16 @@
       }
     },
     "mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
+      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
-      },
-      "dependencies": {
-        "optional-require": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-          "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-          "requires": {
-            "require-at": "^1.0.6"
-          }
-        }
       }
     },
     "mongodb-memory-server": {
@@ -22604,19 +22537,6 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "mongodb": {
-          "version": "3.6.11",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
-          "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
-          "requires": {
-            "bl": "^2.2.1",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
-            "optional-require": "^1.0.3",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -23497,11 +23417,6 @@
       "requires": {
         "rc": "^1.2.8"
       }
-    },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/data-serving/data-service/package-lock.json
+++ b/data-serving/data-service/package-lock.json
@@ -10889,14 +10889,14 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
-      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "dependencies": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.3",
+        "optional-require": "^1.1.8",
         "safe-buffer": "^5.1.2"
       },
       "engines": {
@@ -11028,6 +11028,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/mongodb/node_modules/optional-require": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "dependencies": {
+        "require-at": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mongoose": {
       "version": "5.13.9",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.9.tgz",
@@ -11062,6 +11073,44 @@
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
       "peerDependencies": {
         "mongoose": "*"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
+      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+      "dependencies": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.0.3",
+        "safe-buffer": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws4": {
+          "optional": true
+        },
+        "bson-ext": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "mongodb-extjson": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongoose/node_modules/ms": {
@@ -12214,6 +12263,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-directory": {
@@ -22425,16 +22482,26 @@
       }
     },
     "mongodb": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
-      "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.3",
+        "optional-require": "^1.1.8",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "optional-require": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+          "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+          "requires": {
+            "require-at": "^1.0.6"
+          }
+        }
       }
     },
     "mongodb-memory-server": {
@@ -22537,6 +22604,19 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
+        "mongodb": {
+          "version": "3.6.11",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.11.tgz",
+          "integrity": "sha512-4Y4lTFHDHZZdgMaHmojtNAlqkvddX2QQBEN0K//GzxhGwlI9tZ9R0vhbjr1Decw+TF7qK0ZLjQT292XgHRRQgw==",
+          "requires": {
+            "bl": "^2.2.1",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "optional-require": "^1.0.3",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -23417,6 +23497,11 @@
       "requires": {
         "rc": "^1.2.8"
       }
+    },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -221,7 +221,8 @@ export class CasesController {
                 doc = await cursor.next();
                 while (doc != null) {
                     delete doc.restrictedNotes;
-                    const parsedCase = parseDownloadedCase(doc);
+                    const caseDTO = await dtoFromCase(doc);
+                    const parsedCase = parseDownloadedCase(caseDTO);
                     const stringifiedCase = stringify([parsedCase], {
                         header: false,
                         columns: this.csvHeaders,

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -5,6 +5,7 @@ import {
     RestrictedCase,
 } from '../model/case';
 import { EventDocument } from '../model/event';
+import { GenomeSequenceDocument } from '../model/genome-sequence';
 import caseFields from '../model/fields.json';
 import { Source } from '../model/source';
 import {

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -721,19 +721,22 @@ export class CasesController {
                 req.body.caseReference?.sourceEntryId &&
                 c
             ) {
-                c.set(req.body);
+                const update = await caseFromDTO(req.body as CaseDTO);
+                c.set(update);
                 const result = await c.save();
                 res.status(200).json(result);
                 return;
             } else {
                 // Geocode new cases.
                 await this.geocode(req);
-                const c = new Case(req.body);
+                const update = await caseFromDTO(req.body as CaseDTO);
+                const c = new Case(update);
                 const result = await c.save();
                 res.status(201).json(result);
                 return;
             }
-        } catch (err) {
+        } catch (e) {
+            const err = e as Error;
             if (err instanceof GeocodeNotFoundError) {
                 res.status(404).json({ message: err.message });
             }

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -5,7 +5,6 @@ import {
     RestrictedCase,
 } from '../model/case';
 import { EventDocument } from '../model/event';
-import { GenomeSequenceDocument } from '../model/genome-sequence';
 import caseFields from '../model/fields.json';
 import { Source } from '../model/source';
 import {

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -74,6 +74,8 @@ const dtoFromCase = async (storedCase: LeanDocument<CaseDocument>) => {
                 }
             }
         }
+        // although the type system can't see it, there's an ageBuckets property on the demographics DTO now
+        delete (dto as unknown as { demographics: { ageBuckets?: [ObjectId] }}).demographics.ageBuckets;
     }
     delete dto.restrictedNotes;
 

--- a/data-serving/data-service/src/controllers/case.ts
+++ b/data-serving/data-service/src/controllers/case.ts
@@ -644,11 +644,11 @@ export class CasesController {
             return;
         }
         try {
-            const unrestrictedCases: CaseDocument[] = [];
-            const restrictedCases: CaseDocument[] = [];
+            const unrestrictedCases: LeanDocument<CaseDocument>[] = [];
+            const restrictedCases: LeanDocument<CaseDocument>[] = [];
 
             for (const c in req.body.cases) {
-                const caseDoc = req.body.cases[c] as CaseDocument;
+                const caseDoc = await caseFromDTO(req.body.cases[c] as CaseDTO);
                 let aCase = await Case.findOne({ _id: caseDoc._id });
                 if (aCase) {
                     unrestrictedCases.push(caseDoc);

--- a/data-serving/data-service/src/model/age-bucket.ts
+++ b/data-serving/data-service/src/model/age-bucket.ts
@@ -16,7 +16,7 @@ export const ageBucketSchema = new mongoose.Schema({
 
 export type AgeBucketDocument = mongoose.Document & Range<number>;
 
-export const AgeBucket = mongoose.model<AgeBucketDocument>(
+export const AgeBuckets = mongoose.model<AgeBucketDocument>(
     'AgeBuckets',
     ageBucketSchema,
 );

--- a/data-serving/data-service/src/model/age-bucket.ts
+++ b/data-serving/data-service/src/model/age-bucket.ts
@@ -16,7 +16,7 @@ export const ageBucketSchema = new mongoose.Schema({
 
 export type AgeBucketDocument = mongoose.Document & Range<number>;
 
-export const AgeBuckets = mongoose.model<AgeBucketDocument>(
+export const AgeBucket = mongoose.model<AgeBucketDocument>(
     'AgeBuckets',
     ageBucketSchema,
 );

--- a/data-serving/data-service/src/model/age-bucket.ts
+++ b/data-serving/data-service/src/model/age-bucket.ts
@@ -1,0 +1,22 @@
+import { Range } from './range';
+import mongoose from 'mongoose';
+
+export const ageBucketSchema = new mongoose.Schema({
+    start: {
+        type: Number,
+        min: 0,
+        max: 116,
+    },
+    end: {
+        type: Number,
+        min: 0,
+        max: 120,
+    },
+});
+
+export type AgeBucketDocument = mongoose.Document & Range<number>;
+
+export const AgeBuckets = mongoose.model<AgeBucketDocument>(
+    'AgeBuckets',
+    ageBucketSchema,
+);

--- a/data-serving/data-service/src/model/case.ts
+++ b/data-serving/data-service/src/model/case.ts
@@ -23,7 +23,7 @@ import { VariantDocument, variantSchema } from './variant';
 
 import { ObjectId } from 'mongodb';
 import _ from 'lodash';
-import mongoose from 'mongoose';
+import mongoose, { LeanDocument } from 'mongoose';
 import { ExclusionDataDocument, exclusionDataSchema } from './exclusion-data';
 import { dateFieldInfo } from './date';
 
@@ -172,14 +172,14 @@ export type CaseDocument = mongoose.Document & ICase & {
 
 /* Denormalise the confirmation date before saving or updating any case object */
 
-function denormaliseConfirmationDate(aCase: CaseDocument) {
+function denormaliseConfirmationDate(aCase: CaseDocument | LeanDocument<CaseDocument>) {
     const confirmationEvents = _.filter(aCase.events, (e) => e.name === 'confirmed');
     if (confirmationEvents.length) {
         aCase.confirmationDate = confirmationEvents[0].dateRange.start;
     }
 }
 
-export function caseWithDenormalisedConfirmationDate(aCase: CaseDocument) {
+export function caseWithDenormalisedConfirmationDate(aCase: CaseDocument | LeanDocument<CaseDocument>) {
     denormaliseConfirmationDate(aCase);
     return aCase;
 }

--- a/data-serving/data-service/src/model/case.ts
+++ b/data-serving/data-service/src/model/case.ts
@@ -26,6 +26,7 @@ import _ from 'lodash';
 import mongoose from 'mongoose';
 import { ExclusionDataDocument, exclusionDataSchema } from './exclusion-data';
 import { dateFieldInfo } from './date';
+import { AgeBucket } from './age-bucket';
 
 const requiredDateField = {
     ...dateFieldInfo,
@@ -169,8 +170,42 @@ export function caseWithDenormalisedConfirmationDate(aCase: CaseDocument) {
     return aCase;
 }
 
+/* Turn an age range in demographic info into age buckets */
+
+async function bucketAgeRange(aCase: CaseDocument) {
+    // there should be a small number of these age ranges, so fetch all
+    const ageBuckets = await AgeBucket.find({});
+    if (aCase.demographics?.ageRange?.start && aCase.demographics?.ageRange?.end) {
+        const caseStart = aCase.demographics?.ageRange?.start;
+        const caseEnd = aCase.demographics?.ageRange?.end;
+        const matchingBuckets = ageBuckets.filter((b) => {
+            const bRangeWithinCaseRange = (b.start <= caseStart && b.end >= caseEnd);
+            const bContainsCaseStart = (b.start <= caseStart && b.end >= caseStart);
+            const bContainsCaseEnd = (b.start <= caseEnd && b.end >= caseEnd);
+            const bWithinCaseRange = (b.start >= caseStart && b.end <= caseEnd);
+            const matches = (
+                bRangeWithinCaseRange ||
+                bContainsCaseStart    ||
+                bContainsCaseEnd      ||
+                bWithinCaseRange
+            );
+            return matches;
+        });
+        aCase.demographics.ageBuckets = matchingBuckets.map((b) => (b._id));
+    }
+}
+
+async function caseWithBucketedAge(aCase: CaseDocument) {
+    await bucketAgeRange(aCase);
+    return aCase;
+}
+
 caseSchema.pre('save', async function(this: CaseDocument) {
     denormaliseConfirmationDate(this);
+});
+
+caseSchema.pre('save', async function(this: CaseDocument) {
+    await bucketAgeRange(this);
 });
 
 caseSchema.pre('validate', async function(this: CaseDocument) {

--- a/data-serving/data-service/src/model/demographics.ts
+++ b/data-serving/data-service/src/model/demographics.ts
@@ -37,7 +37,7 @@ export const demographicsSchema = new mongoose.Schema(
 
 export type DemographicsDocument = mongoose.Document & {
     ageBuckets: ObjectId[];
-    ageRange?: Range<number>;
+    ageRange: Range<number>;
     gender: string;
     occupation: string;
     nationalities: [string];

--- a/data-serving/data-service/src/model/demographics.ts
+++ b/data-serving/data-service/src/model/demographics.ts
@@ -1,8 +1,19 @@
 import { Range } from './range';
 import mongoose from 'mongoose';
+import { ObjectId } from 'mongodb';
 
 export const demographicsSchema = new mongoose.Schema(
     {
+        /*
+         * The idea is that the age buckets are an enumeration supplied in the database,
+         * so you can refer to them here in the ageBuckets collection but you shouldn't
+         * make up your own age ranges.
+         * 
+         * A case can belong to zero age buckets if it didn't specify an age, and more
+         * than one age bucket if the age range specified in the case overlapped more
+         * than one of the buckets we use.
+         */
+        ageBuckets: [{ type: mongoose.Schema.Types.ObjectId, ref: 'ageBuckets' }],
         ageRange: {
             start: {
                 type: Number,
@@ -25,6 +36,7 @@ export const demographicsSchema = new mongoose.Schema(
 );
 
 export type DemographicsDocument = mongoose.Document & {
+    ageBuckets: ObjectId[];
     ageRange: Range<number>;
     gender: string;
     occupation: string;

--- a/data-serving/data-service/src/model/demographics.ts
+++ b/data-serving/data-service/src/model/demographics.ts
@@ -2,6 +2,15 @@ import { Range } from './range';
 import mongoose from 'mongoose';
 import { ObjectId } from 'mongodb';
 
+/*
+ * There are separate types for demographics for data storage (the mongoose document) and
+ * for data transfer (DemographicsDTO). The DTO only has an age range, and is what the cases
+ * controller receives and transmits over the network. The mongoose document has both an age
+ * range and age buckets, and is what gets written to the database. The end goal is that the
+ * mongoose document only has age buckets, and that the cases controller converts between the
+ * two so that outside you only see a single age range.
+ */
+
 export const demographicsSchema = new mongoose.Schema(
     {
         /*
@@ -35,13 +44,16 @@ export const demographicsSchema = new mongoose.Schema(
     { _id: false },
 );
 
-export type DemographicsDocument = mongoose.Document & {
-    ageBuckets: ObjectId[];
-    ageRange: Range<number>;
+export type DemographicsDTO = {
+    ageRange?: Range<number>;
     gender: string;
     occupation: string;
     nationalities: [string];
     ethnicity: string;
+}
+
+export type DemographicsDocument = mongoose.Document & DemographicsDTO & {
+    ageBuckets: ObjectId[];
 };
 
 export const Demographics = mongoose.model<DemographicsDocument>(

--- a/data-serving/data-service/src/model/demographics.ts
+++ b/data-serving/data-service/src/model/demographics.ts
@@ -37,7 +37,7 @@ export const demographicsSchema = new mongoose.Schema(
 
 export type DemographicsDocument = mongoose.Document & {
     ageBuckets: ObjectId[];
-    ageRange: Range<number>;
+    ageRange?: Range<number>;
     gender: string;
     occupation: string;
     nationalities: [string];

--- a/data-serving/data-service/src/util/case.ts
+++ b/data-serving/data-service/src/util/case.ts
@@ -1,4 +1,4 @@
-import { CaseDocument } from '../model/case';
+import { CaseDocument, CaseDTO } from '../model/case';
 import { CaseReferenceDocument } from '../model/case-reference';
 import { DemographicsDocument } from '../model/demographics';
 import { EventDocument } from '../model/event';
@@ -59,7 +59,7 @@ export const parseCaseEvents = (
 /**
  * Converts case to fulfill CSV file structure requirements.
  */
-export const parseDownloadedCase = (caseDocument: CaseDocument) => {
+export const parseDownloadedCase = (caseDocument: CaseDTO) => {
     const { demographics, symptoms } = caseDocument;
 
     const parsedDemographics = demographics?.nationalities

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -1557,6 +1557,35 @@ describe('PUT', () => {
         expect(cases[0].notes).toEqual(newNotes);
         expect(cases[1].notes).toEqual(newNotes2);
     });
+    it('update many items should update the age buckets', async () => {
+        const c = new Case(minimalCase);
+        await c.save();
+
+        const ageRange = {
+            start: 1,
+            end: 9,
+        };
+
+        const res = await request(app)
+            .post('/api/cases/batchUpdate')
+            .send({
+                ...curatorMetadata,
+                cases: [
+                    { 
+                        _id: c._id,
+                        demographics: {
+                            ageRange,
+                        }
+                    },
+                ],
+            })
+            .expect('Content-Type', /json/)
+            .expect(200);
+
+        expect(res.body.numModified).toEqual(1);
+        const cases = await Case.find();
+        expect(cases[0].demographics.ageBuckets).toHaveLength(2);
+    });
     it('update many items without locations in travel history should return 200 OK', async () => {
         const c = new Case(minimalCase);
         await c.save();

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -223,6 +223,18 @@ describe('GET', () => {
                 .expect(200, /got it at work/)
                 .expect('Content-Type', /json/);
         });
+        it('should use age buckets in results', async () => {
+            const c = new Case(minimalCase);
+            const aBucket = await AgeBucket.findOne({});
+            c.demographics.ageBuckets = [aBucket!._id];
+            await c.save();
+            const res = await request(app)
+                .get(`/api/cases?page=1&limit=10`)
+                .expect(200)
+                .expect('Content-Type', /json/);
+            expect(res.body.cases[0].demographics.ageRange.start).toEqual(aBucket!.start);
+            expect(res.body.cases[0].demographics.ageRange.end).toEqual(aBucket!.end);
+        });
         it('should ignore the restricted collection', async () => {
             const r = new RestrictedCase(minimalCase);
             await r.save();

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -113,6 +113,15 @@ describe('GET', () => {
         const res = await request(app).get(`/api/cases/${c._id}`).expect(200);
         expect(res.body[0].restrictedNotes).toBeUndefined();
     });
+    it('should convert age bucket to age range', async () => {
+        const c = new Case(minimalCase);
+        const bucket = await AgeBucket.findOne({});
+        c.demographics.ageBuckets = [bucket!._id];
+        await c.save();
+        const res = await request(app).get(`/api/cases/${c._id}`).expect(200);
+        expect(res.body[0].demographics.ageRange.start).toEqual(bucket!.start);
+        expect(res.body[0].demographics.ageRange.end).toEqual(bucket!.end);
+    });
     describe('list', () => {
         it('should return 200 OK', () => {
             return request(app)

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -1,3 +1,4 @@
+import { AgeBucket } from '../../src/model/age-bucket';
 import { Case, RestrictedCase } from '../../src/model/case';
 import { CaseRevision } from '../../src/model/case-revision';
 import { Demographics } from '../../src/model/demographics';
@@ -26,6 +27,11 @@ const minimalRequest = {
     ...curatorMetadata,
 };
 
+const fullRequest = {
+    ...fullCase,
+    ...curatorMetadata,
+};
+
 const invalidRequest = {
     ...minimalRequest,
     demographics: { ageRange: { start: 400 } },
@@ -43,10 +49,25 @@ function stringParser(res: request.Response) {
     });
 }
 
+async function createAgeBuckets() {
+    await new AgeBucket({
+        start: 0,
+        end: 0,
+    }).save();
+    for (let start = 1; start <= 116; start += 5) {
+        const end = start + 4;
+        await new AgeBucket({
+            start,
+            end,
+        }).save();
+    }
+}
+
 beforeAll(async () => {
     mockLocationServer.listen();
     mongoServer = new MongoMemoryServer();
     global.Date.now = jest.fn(() => new Date('2020-12-12T12:12:37Z').getTime());
+    await createAgeBuckets();
 });
 
 beforeEach(async () => {
@@ -63,6 +84,7 @@ afterEach(() => {
 afterAll(async () => {
     mockLocationServer.close();
     global.Date.now = realDate;
+    await AgeBucket.deleteMany({});
     return mongoServer.stop();
 });
 
@@ -515,6 +537,22 @@ describe('POST', () => {
 
         expect(await Case.collection.countDocuments()).toEqual(0);
         expect(res.body._id).not.toHaveLength(0);
+    });
+    it('create with valid input should write age buckets', async () => {
+        /*
+         * The idea is that the age bucketing done in #2670 should improve the privacy of the application
+         * without changing the API. You still tell us what the age range of the case is, and we map that
+         * onto the buckets supported in the application and store those.
+         */
+        const res = await request(app)
+            .post('/api/cases')
+            .send(fullRequest)
+            .expect('Content-Type', /json/)
+            .expect(201);
+        expect(await Case.collection.countDocuments()).toEqual(1);
+        // case has age range 50-59, which matches our buckets 46-50, 51-55, 56-60
+        const theCase = await Case.findOne({});
+        expect(theCase?.demographics.ageBuckets.length).toEqual(3);
     });
     it('batch upsert with no body should return 415', () => {
         return request(app).post('/api/cases/batchUpsert').expect(415);

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -483,7 +483,7 @@ describe('POST', () => {
         // case has range 40-50, should be bucketed into 36-40, 41-45, 46-50
         expect(theCase!.demographics.ageBuckets).toHaveLength(3);
     })
-    it('GETting the PUT case should return an age range', async () => {
+    it('GETting the POSTed case should return an age range', async () => {
         const theCase = await request(app)
             .post('/api/cases')
             .send(minimalRequest)
@@ -1390,6 +1390,27 @@ describe('PUT', () => {
             .expect(200);
 
         expect(res.body.notes).toEqual(newNotes);
+    });
+    it('update present item with new age range should change the age buckets', async () => {
+        const c = new Case(minimalCase);
+        await c.save();
+
+        const newAgeRange = {
+            start: 6,
+            end: 7,
+        };
+        const res = await request(app)
+            .put(`/api/cases/${c._id}`)
+            .send({
+                ...curatorMetadata,
+                demographics: {
+                    ageRange: newAgeRange,
+                },
+            })
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(res.body.demographics.ageRange.start).toEqual(6);
+        expect(res.body.demographics.ageRange.end).toEqual(10);
     });
     it('update present item with unknown travel locations should be 200 OK', async () => {
         const c = new Case(minimalCase);

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -483,6 +483,22 @@ describe('POST', () => {
         // case has range 40-50, should be bucketed into 36-40, 41-45, 46-50
         expect(theCase!.demographics.ageBuckets).toHaveLength(3);
     })
+    it('GETting the PUT case should return an age range', async () => {
+        const theCase = await request(app)
+            .post('/api/cases')
+            .send(minimalRequest)
+            .expect('Content-Type', /json/)
+            .expect(201);
+
+        const res = await request(app)
+            .get(`/api/cases/${theCase.body._id}`)
+            .expect('Content-Type', /json/)
+            .expect(200);
+        expect(res.body[0].demographics.ageRange).toEqual({
+            start: 36,
+            end: 50,
+        });
+    });
     it('create many cases with valid input should return 201 OK', async () => {
         const res = await request(app)
             .post('/api/cases?num_cases=3')

--- a/data-serving/data-service/test/controllers/case.test.ts
+++ b/data-serving/data-service/test/controllers/case.test.ts
@@ -881,6 +881,31 @@ describe('POST', () => {
                 fs.unlinkSync(destination);
             });
         });
+        it('should use the age buckets in the download', async () => {
+            const destination = './test_buckets.csv';
+            const fileStream = fs.createWriteStream(destination);
+
+            const c = new Case(minimalCase);
+            await c.save();
+
+            const responseStream = request(app)
+                .post('/api/cases/download')
+                .send({ format: 'csv' })
+                .expect('Content-Type', 'text/csv')
+                .expect(200)
+                .parse(stringParser);
+
+            responseStream.pipe(fileStream);
+            responseStream.on('finish', () => {
+                const text: string = fs
+                    .readFileSync(destination)
+                    .toString('utf-8');
+                expect(text).toContain('35');
+                expect(text).toContain('50');
+
+                fs.unlinkSync(destination);
+            });
+        });
         it('should exclude restricted cases', async () => {
             const destination = './test_exclude_restricted_cases.csv';
             const fileStream = fs.createWriteStream(destination);

--- a/data-serving/data-service/test/util/case.test.ts
+++ b/data-serving/data-service/test/util/case.test.ts
@@ -35,7 +35,7 @@ describe('Case', () => {
             demographics: {
                 nationalities: [],
             },
-        } as CaseDocument);
+        } as CaseDTO);
 
         expect(res.events).toEqual({
             onsetSymptoms: {

--- a/data-serving/scripts/setup-db/migrations/20220420100113-add-age-buckets.js
+++ b/data-serving/scripts/setup-db/migrations/20220420100113-add-age-buckets.js
@@ -1,0 +1,77 @@
+/*
+ * We need to ensure that ages are bucketed within five-year brackets, except for infants (below 1 year)
+ * to improve the protection against deanonymisation in the case database. In this migration I create an
+ * ageBuckets collection which represents an enumeration of the age ranges 0, 1-5, 6-10, 11-15, ..., 116-120.
+ * 
+ * I also allow the cases collection documents to have an array of unique objectIDs in the 'demographics.ageBuckets'
+ * property. That means that each case can link to zero or more elements in the enumeration. Here are some examples of
+ * how that will work:
+ * 
+ * case has no age specified: ageBuckets = []
+ * case has exact age 18: ageBuckets = [(16-20)._id]
+ * case has range 18-24: ageBuckets = [(16-20)._id, (21-25)._id]
+ */
+
+const ageBucketSchema = {
+  bsonType: 'array',
+  uniqueItems: true,
+  items: {
+    bsonType: "objectId",
+  }
+};
+
+module.exports = {
+  async up(db, client) {
+    await db.createCollection("ageBuckets", {
+      validator: {
+        $jsonSchema: {
+          "bsonType": "object",
+          "additionalProperties": false,
+          "required": ["start", "end"],
+          "properties": {
+            "_id": {
+              "bsonType": "objectId",
+            },
+            "start": {
+              "bsonType": "number",
+              "minimum": 0,
+              "maximum": 116
+            },
+            "end": {
+              "bsonType": "number",
+              "minimum": 0,
+              "maximum": 120
+            }
+          }
+        }
+      }
+    });
+
+    const ageBuckets = db.collection('ageBuckets');
+    await ageBuckets.insertOne({
+      start: 0,
+      end: 0,
+    });
+    for(let start = 1; start <= 116; start += 5) {
+      const end = start + 4;
+      await ageBuckets.insertOne({
+        start,
+        end,
+      });
+    }
+
+    let res = await db.command({listCollections: undefined, filter: {name: 'cases'}});
+    let schema = res.cursor.firstBatch[0].options.validator.$jsonSchema;
+    schema.properties.demographics.properties.ageBuckets = ageBucketSchema;
+    await db.command({ collMod: 'cases', validator:{ $jsonSchema: schema } } );
+  },
+
+  async down(db, client) {
+    let res = await db.command({listCollections: undefined, filter: {name: 'cases'}});
+    let schema = res.cursor.firstBatch[0].options.validator.$jsonSchema;
+    delete schema.properties.demographics.properties.ageBuckets;
+    await db.command( { collMod: 'cases', validator:{ $jsonSchema: schema } } );
+
+    await db.collection('ageBuckets').drop();
+  }
+};

--- a/data-serving/scripts/setup-db/schemas/README.md
+++ b/data-serving/scripts/setup-db/schemas/README.md
@@ -1,4 +1,5 @@
 # Mongodb schema validators
 
 This directory contains schema validators and index files for the various collections stored in mongodb.
-These are the _initial_ state of the database: modifications are made via migrations. See the `mongo-migrations` folder for more information.
+These are the _initial_ state of the database: do not make changes here, as they won't make any difference in production!
+Modifications are made via migrations: every new change requires a new migration. See the `migrations` folder for more information.


### PR DESCRIPTION
These are the changes to schema and data-service to support bucketed age ranges and to use them whenever a case is added or returned via the API, but not to remove the existing age range data or change data exports/UI to work with the ranges.

See documentation on the migration and data-service README for rationale behind this design.

I fully expect some e2e breakages so will wait not merge until the cypress tests are passing.