### PR TITLE
ci: Pin Ubuntu release to 20.04 LTS

### DIFF
--- a/.github/workflows/aggregate-ci.yml
+++ b/.github/workflows/aggregate-ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: data-serving/scripts/aggregate/aggregate

--- a/.github/workflows/aggregate-deploy.yml
+++ b/.github/workflows/aggregate-deploy.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Configure AWS credentials

--- a/.github/workflows/api-python-tests.yml
+++ b/.github/workflows/api-python-tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: api/python

--- a/.github/workflows/completeness.yml
+++ b/.github/workflows/completeness.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   freshness:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ingestion/monitoring

--- a/.github/workflows/curator-api-node.yml
+++ b/.github/workflows/curator-api-node.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/curator-service-package.yml
+++ b/.github/workflows/curator-service-package.yml
@@ -3,7 +3,7 @@ name: Curator Service Github Packages Push
 on:
   # Build whenever a PR is merged into the main branch.
   push:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
       - ".github/workflows/curator-service-package.yml"
       - "verification/curator-service/**"
@@ -12,7 +12,7 @@ on:
     tags:
       - "*"
   workflow_dispatch:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
       - ".github/workflows/curator-service-package.yml"
       - "verification/curator-service/**"

--- a/.github/workflows/curator-service-package.yml
+++ b/.github/workflows/curator-service-package.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/curator-ui-node.yml
+++ b/.github/workflows/curator-ui-node.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/data-service-node.yml
+++ b/.github/workflows/data-service-node.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/data-service-package.yml
+++ b/.github/workflows/data-service-package.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/data-service-package.yml
+++ b/.github/workflows/data-service-package.yml
@@ -3,7 +3,7 @@ name: Data Service Github Packages Push
 on:
   # Build whenever a PR is merged into the main branch.
   push:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
       - ".github/workflows/data-service-package.yml"
       - "data-serving/data-service/**"
@@ -11,7 +11,7 @@ on:
     tags:
       - "*"
   workflow_dispatch:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
       - ".github/workflows/data-service-package.yml"
       - "data-serving/data-service/**"

--- a/.github/workflows/export-deploy.yml
+++ b/.github/workflows/export-deploy.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Configure AWS credentials

--- a/.github/workflows/export-tests.yml
+++ b/.github/workflows/export-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: data-serving/scripts/export-data

--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   freshness:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ingestion/monitoring

--- a/.github/workflows/geocoding-service-package.yml
+++ b/.github/workflows/geocoding-service-package.yml
@@ -3,7 +3,7 @@ name: Geocoding Service Github Packages Push
 on:
   # Build whenever a PR is merged into the main branch.
   push:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
       - ".github/workflows/geocoding-service-package.yml"
       - "geocoding/location-service/**"
@@ -11,7 +11,7 @@ on:
     tags:
       - "*"
   workflow_dispatch:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
       - ".github/workflows/geocoding-service-package.yml"
       - "geocoding/location-service/**"

--- a/.github/workflows/geocoding-service-package.yml
+++ b/.github/workflows/geocoding-service-package.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/geocoding-service-python.yml
+++ b/.github/workflows/geocoding-service-python.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: geocoding/location-service

--- a/.github/workflows/ingestion-cleanup-deploy.yml
+++ b/.github/workflows/ingestion-cleanup-deploy.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Configure AWS credentials

--- a/.github/workflows/ingestion-functions-deploy.yml
+++ b/.github/workflows/ingestion-functions-deploy.yml
@@ -2,7 +2,7 @@ name: Ingestion functions deploy
 
 on:
   push:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
     - '.github/workflows/ingestion-functions-deploy.yml'
     - 'ingestion/functions/**'
@@ -11,7 +11,7 @@ on:
     tags:
       - "*"
   workflow_dispatch:
-    branches: [main, '*-stable', 'main-eu']
+    branches: [main, '*-stable']
     paths:
     - '.github/workflows/ingestion-functions-deploy.yml'
     - 'ingestion/functions/**'

--- a/.github/workflows/ingestion-functions-deploy.yml
+++ b/.github/workflows/ingestion-functions-deploy.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Configure AWS credentials

--- a/.github/workflows/ingestion-functions-python.yml
+++ b/.github/workflows/ingestion-functions-python.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ingestion/functions

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/kubemon.yml
+++ b/.github/workflows/kubemon.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: k8s/monitoring

--- a/.github/workflows/monitoring-notify.yml
+++ b/.github/workflows/monitoring-notify.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   monitoring-notify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ingestion/monitoring

--- a/.github/workflows/monitoring-tests.yml
+++ b/.github/workflows/monitoring-tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   monitoring-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ingestion/monitoring

--- a/.github/workflows/prune-deploy.yml
+++ b/.github/workflows/prune-deploy.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Configure AWS credentials

--- a/.github/workflows/prune-uploads-tests.yml
+++ b/.github/workflows/prune-uploads-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: data-serving/scripts/prune-uploads

--- a/.github/workflows/r-package.yml
+++ b/.github/workflows/r-package.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: api/R

--- a/.github/workflows/suggest-python.yml
+++ b/.github/workflows/suggest-python.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: suggest/acronyms

--- a/.github/workflows/update-dev-curator-db-schema.yml
+++ b/.github/workflows/update-dev-curator-db-schema.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   update-sources-data-dev:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/update-prod-curator-db-schema.yaml
+++ b/.github/workflows/update-prod-curator-db-schema.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   update-sources-data:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/data-serving/data-service/package.json
+++ b/data-serving/data-service/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "config": {
     "mongodbMemoryServer": {
-      "version": "latest"
+      "version": "5.0.8"
     }
   },
   "devDependencies": {

--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "config": {
     "mongodbMemoryServer": {
-      "version": "latest"
+      "version": "5.0.8"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Now that 22.04 LTS has been released, at some point ubuntu-latest
will point to ubuntu-22.04 which can cause unplanned breakage,
pinning CI to 20.04 until we have a migration plan.

Additionally, drop main-eu builds as EU migration is complete.
