### PR TITLE
curator(api): allow deleting users

### DIFF
--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -1056,6 +1056,21 @@ paths:
                     $ref: '#/components/responses/422'
                 '500':
                     $ref: '#/components/responses/500'
+        delete:
+            tags: [User]
+            summary: Deletes a user
+            operationId: deleteUser
+            responses:
+                '204':
+                    $ref: '#/components/responses/204'
+                '401':
+                    $ref: '#/components/responses/401'
+                '403':
+                    $ref: '#/components/responses/403'
+                '404':
+                    $ref: '#/components/responses/404'
+                '500':
+                    $ref: '#/components/responses/500'
     /users/roles:
         get:
             tags: [User]

--- a/verification/curator-service/api/openapi/openapi.yaml
+++ b/verification/curator-service/api/openapi/openapi.yaml
@@ -2164,6 +2164,8 @@ components:
             description: Empty
         '400':
             description: Malformed request
+        '401':
+            description: Unauthorized
         '403':
             description: Forbidden
             content:

--- a/verification/curator-service/api/src/controllers/users.ts
+++ b/verification/curator-service/api/src/controllers/users.ts
@@ -89,6 +89,34 @@ export const updateRoles = async (
 };
 
 /**
+ * Delete a user
+ */
+export const deleteUser = async (
+    req: Request,
+    res: Response,
+): Promise<void> => {
+    try {
+        const result = await users().deleteOne(
+            { _id: new ObjectId(req.params.id) },
+        );
+        console.log(result);
+        if (result.deletedCount !== 1) {
+            res.status(404).json({
+                message: `user with id ${req.params.id} could not be found`,
+            });
+            return;
+        }
+        res.status(204).end();
+        return;
+    } catch (err) {
+        const error = err as Error;
+        logger.error('error in deleting user', error);
+        res.status(500).json(error);
+        return;
+    }
+};
+
+/**
  * List the roles defined in the system.
  */
 export const listRoles = (req: Request, res: Response): void => {

--- a/verification/curator-service/api/src/index.ts
+++ b/verification/curator-service/api/src/index.ts
@@ -359,6 +359,12 @@ async function makeApp() {
         mustHaveAnyRole(['admin']),
         usersController.updateRoles,
     );
+    apiRouter.delete(
+        '/users/:id',
+        authenticateByAPIKey,
+        mustHaveAnyRole(['admin']),
+        usersController.deleteUser,
+    );
     apiRouter.get(
         '/users/roles',
         authenticateByAPIKey,

--- a/verification/curator-service/api/test/users.test.ts
+++ b/verification/curator-service/api/test/users.test.ts
@@ -153,19 +153,18 @@ describe('PUT', () => {
     });
 });
 
-
 describe('DELETE', () => {
     it('should delete a user', async () => {
         const request = supertest.agent(app);
         const userRes = await request
             .post('/auth/register')
-            .send({ ...baseUser, ...{ roles: ['admin'] } })
-            .expect(200, /admin/)
+            .send({ ...baseUser, ...{ roles: [] } })
+            .expect(200)
             .expect('Content-Type', /json/);
         const userRes2 = await request
             .post('/auth/register')
-            .send({ ...baseUser, ...{ roles: [] } })
-            .expect(200)
+            .send({ ...baseUser, ...{ roles: ['admin'] } })
+            .expect(200, /admin/)
             .expect('Content-Type', /json/);
 
         const res = await request

--- a/verification/curator-service/api/test/users.test.ts
+++ b/verification/curator-service/api/test/users.test.ts
@@ -152,3 +152,48 @@ describe('PUT', () => {
             .expect(400);
     });
 });
+
+
+describe('DELETE', () => {
+    it('should delete a user', async () => {
+        const request = supertest.agent(app);
+        const userRes = await request
+            .post('/auth/register')
+            .send({ ...baseUser, ...{ roles: ['admin'] } })
+            .expect(200, /admin/)
+            .expect('Content-Type', /json/);
+        const userRes2 = await request
+            .post('/auth/register')
+            .send({ ...baseUser, ...{ roles: [] } })
+            .expect(200)
+            .expect('Content-Type', /json/);
+
+        const res = await request
+            .delete(`/api/users/${userRes.body._id}`)
+            .expect(204);
+        const res2 = await request
+            .delete(`/api/users/${userRes2.body._id}`)
+            .expect(204);
+    });
+    it('cannot delete an nonexistent user', async () => {
+        const request = supertest.agent(app);
+        await request
+            .post('/auth/register')
+            .send({ ...baseUser, ...{ roles: ['admin'] } })
+            .expect(200)
+            .expect('Content-Type', /json/);
+        return request
+            .delete('/api/users/5ea86423bae6982635d2e1f8')
+            .expect(404);
+    });
+    it('should not delete without admin permissions', async () => {
+        const request = supertest.agent(app);
+        const userRes = await request
+            .post('/auth/register')
+            .send({ ...baseUser, ...{ roles: [] } })
+            .expect('Content-Type', /json/);
+        const res = await request
+            .delete(`/api/users/${userRes.body._id}`)
+            .expect(403);
+    });
+});


### PR DESCRIPTION
This PR adds API endpoints to delete users. It does not have the UI changes or the cleanup process which will assign cases created by them to a nobody or community user