### PR TITLE
2712 api parameterisation

### DIFF
--- a/api/R/R/cases_cachefile.R
+++ b/api/R/R/cases_cachefile.R
@@ -1,5 +1,5 @@
 cases_cachefile <-
-function(server = GDH_URL, folder="cache", ...) {
+function(server, folder="cache", ...) {
     return(paste0(folder, "/",
                   sha256(paste0(stringify_filters(...), "|", server)), ".csv"))
 }

--- a/api/R/R/constants.R
+++ b/api/R/R/constants.R
@@ -1,3 +1,3 @@
-GDH_URL <- "https://data.covid-19.global.health"
 FILTERS <- c("country")
+DISEASE <- "covid-19"
 downloadAsync <- "/api/cases/downloadAsync"

--- a/api/R/R/constants.R
+++ b/api/R/R/constants.R
@@ -1,3 +1,4 @@
 FILTERS <- c("country")
 DISEASE <- "covid-19"
+ENVIRONMENT <- 'production'
 downloadAsync <- "/api/cases/downloadAsync"

--- a/api/R/R/constants.R
+++ b/api/R/R/constants.R
@@ -1,4 +1,2 @@
 FILTERS <- c("country")
-DISEASE <- "covid-19"
-ENVIRONMENT <- 'production'
 downloadAsync <- "/api/cases/downloadAsync"

--- a/api/R/R/get_cached_cases.R
+++ b/api/R/R/get_cached_cases.R
@@ -1,9 +1,9 @@
 get_cached_cases <-
-function(apikey, disease = DISEASE, refresh = FALSE, folder = "cache", ...) {
+function(apikey, disease = DISEASE, environment = ENVIRONMENT, refresh = FALSE, folder = "cache", ...) {
     if(!file.exists(folder)) {
         dir.create(folder)
     }
-    server <- get_server(disease)
+    server <- get_server(disease, environment)
     cachename <- cases_cachefile(server, folder, ...)
     if(!refresh && file.exists(cachename)) {
         return(read_csv(cachename))

--- a/api/R/R/get_cached_cases.R
+++ b/api/R/R/get_cached_cases.R
@@ -1,5 +1,5 @@
 get_cached_cases <-
-function(apikey, disease = DISEASE, environment = ENVIRONMENT, refresh = FALSE, folder = "cache", ...) {
+function(apikey, disease = 'covid-19', environment = 'production', refresh = FALSE, folder = "cache", ...) {
     if(!file.exists(folder)) {
         dir.create(folder)
     }

--- a/api/R/R/get_cached_cases.R
+++ b/api/R/R/get_cached_cases.R
@@ -1,8 +1,9 @@
 get_cached_cases <-
-function(apikey, server = GDH_URL, refresh = FALSE, folder = "cache", ...) {
+function(apikey, disease = DISEASE, refresh = FALSE, folder = "cache", ...) {
     if(!file.exists(folder)) {
         dir.create(folder)
     }
+    server <- get_server(disease)
     cachename <- cases_cachefile(server, folder, ...)
     if(!refresh && file.exists(cachename)) {
         return(read_csv(cachename))

--- a/api/R/R/get_cases.R
+++ b/api/R/R/get_cases.R
@@ -1,5 +1,6 @@
 get_cases <-
-function(apikey, server = GDH_URL, ...) {
+function(apikey, disease = 'covid-19', ...) {
+    server <- get_server(disease)
     data <- sprintf('{"format": "csv", "query": "%s"}', trimws(stringify_filters(...)))
     res <- POST(paste0(server, downloadAsync), body = data,
                 add_headers("Content-Type" = "application/json",

--- a/api/R/R/get_cases.R
+++ b/api/R/R/get_cases.R
@@ -1,5 +1,5 @@
 get_cases <-
-function(apikey, disease = DISEASE, environment = ENVIRONMENT, ...) {
+function(apikey, disease = 'covid-19', environment = 'production', ...) {
     server <- get_server(disease, environment)
     data <- sprintf('{"format": "csv", "query": "%s"}', trimws(stringify_filters(...)))
     res <- POST(paste0(server, downloadAsync), body = data,

--- a/api/R/R/get_cases.R
+++ b/api/R/R/get_cases.R
@@ -1,6 +1,6 @@
 get_cases <-
-function(apikey, disease = 'covid-19', ...) {
-    server <- get_server(disease)
+function(apikey, disease = DISEASE, environment = ENVIRONMENT, ...) {
+    server <- get_server(disease, environment)
     data <- sprintf('{"format": "csv", "query": "%s"}', trimws(stringify_filters(...)))
     res <- POST(paste0(server, downloadAsync), body = data,
                 add_headers("Content-Type" = "application/json",

--- a/api/R/R/get_server.R
+++ b/api/R/R/get_server.R
@@ -1,0 +1,4 @@
+get_server <-
+function(disease = DISEASE) {
+    return(sprintf('https://data.%s.global.health', disease))
+}

--- a/api/R/R/get_server.R
+++ b/api/R/R/get_server.R
@@ -2,7 +2,7 @@ get_server <-
 function(disease = DISEASE, environment = ENVIRONMENT) {
     server_from_environment <- Sys.getenv('GDH_URL')
     if (server_from_environment != "") {
-        return server_from_environment
+        return(server_from_environment)
     }
     if (environment == 'production') {
         return(sprintf('https://data.%s.global.health', disease))

--- a/api/R/R/get_server.R
+++ b/api/R/R/get_server.R
@@ -1,4 +1,12 @@
 get_server <-
-function(disease = DISEASE) {
-    return(sprintf('https://data.%s.global.health', disease))
+function(disease = DISEASE, environment = ENVIRONMENT) {
+    server_from_environment <- Sys.getenv('GDH_URL')
+    if (server_from_environment != "") {
+        return server_from_environment
+    }
+    if (environment == 'production') {
+        return(sprintf('https://data.%s.global.health', disease))
+    } else {
+        return(sprintf('https://%s-data.%s.global.health'), environment, disease)
+    }
 }

--- a/api/R/man/get_cached_cases.Rd
+++ b/api/R/man/get_cached_cases.Rd
@@ -13,7 +13,7 @@ Unless you always need to be working with the latest data, we recommend
 using this function instead of \code{\link{get_cases}}.
 }
 \usage{
-get_cached_cases(apikey, disease = 'covid-19', refresh = FALSE, folder = "cache", \dots)
+get_cached_cases(apikey, disease = 'covid-19', environment = 'production', refresh = FALSE, folder = "cache", \dots)
 }
 \arguments{
   \item{apikey}{
@@ -23,6 +23,9 @@ and clicking on Profile.
 }
   \item{disease}{
 Identify the outbreak for which you want to fetch data; the default is COVID-19.
+}
+  \item{environment}{
+Specify the environment whose data you want to use: default is production, alternatives are dev or qa.
 }
   \item{refresh}{
 Optional, if set to TRUE, refreshes the cache and returns the latest version of

--- a/api/R/man/get_cached_cases.Rd
+++ b/api/R/man/get_cached_cases.Rd
@@ -13,16 +13,16 @@ Unless you always need to be working with the latest data, we recommend
 using this function instead of \code{\link{get_cases}}.
 }
 \usage{
-get_cached_cases(apikey, server = GDH_URL, refresh = FALSE, folder = "cache", \dots)
+get_cached_cases(apikey, disease = 'covid-19', refresh = FALSE, folder = "cache", \dots)
 }
 \arguments{
   \item{apikey}{
 Put your Global.health API key here. You can get a free API key by signing
-up at \url{https://data.covid-19.global.health} and clicking on Profile.
+up at \url{https://data.covid-19.global.health} (or another server instance)
+and clicking on Profile.
 }
-  \item{server}{
-If you are using a self-hosted version of Global.health, put the URL to it
-here. This is not needed if you are using the main instance.
+  \item{disease}{
+Identify the outbreak for which you want to fetch data; the default is COVID-19.
 }
   \item{refresh}{
 Optional, if set to TRUE, refreshes the cache and returns the latest version of

--- a/api/R/man/get_cases.Rd
+++ b/api/R/man/get_cases.Rd
@@ -10,7 +10,7 @@ Unless you always need to be working with the latest data, we recommend
 using \code{\link{get_cached_cases}} instead of this function.
 }
 \usage{
-get_cases(apikey, disease = 'covid-19', \dots)
+get_cases(apikey, disease = 'covid-19', environment = 'production', \dots)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -20,6 +20,9 @@ up at \url{https://data.covid-19.global.health} and clicking on Profile.
 }
   \item{disease}{
 Identify the outbreak for which you want to fetch data; the default is COVID-19.
+}
+  \item{environment}{
+Specify the environment whose data you want to use: default is production, alternatives are dev or qa.
 }
   \item{\dots}{
 Filters to use for data. Currently the only supported filter is 'country'

--- a/api/R/man/get_cases.Rd
+++ b/api/R/man/get_cases.Rd
@@ -10,7 +10,7 @@ Unless you always need to be working with the latest data, we recommend
 using \code{\link{get_cached_cases}} instead of this function.
 }
 \usage{
-get_cases(apikey, server = GDH_URL, \dots)
+get_cases(apikey, disease = 'covid-19', \dots)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -18,9 +18,8 @@ get_cases(apikey, server = GDH_URL, \dots)
 Put your Global.health API key here. You can get a free API key by signing
 up at \url{https://data.covid-19.global.health} and clicking on Profile.
 }
-  \item{server}{
-If you are using a self-hosted version of Global.health, put the URL to it
-here. This is not needed if you are using the main instance.
+  \item{disease}{
+Identify the outbreak for which you want to fetch data; the default is COVID-19.
 }
   \item{\dots}{
 Filters to use for data. Currently the only supported filter is 'country'

--- a/api/README.md
+++ b/api/README.md
@@ -15,8 +15,8 @@ which describes the columns in the downloaded data.
 To download data using one of our supported languages, you first need an API
 key. Here are the steps to get one:
 
-1. Login to the database at https://data.covid-19.global.health
-1. Go to your profile at https://data.covid-19.global.health/profile
+1. Login to the database at https://data.covid-19.global.health (or the instance pertaining to the outbreak you're interested in)
+1. Go to your profile; click your user icon in the top-right corner, then "Profile" in the menu
 1. Click Reset API Key (you only need to do this once)
 1. Copy the API key
 
@@ -70,9 +70,10 @@ You can also use R's in-built `help()` to access the documentation.
 Download the [gdh.py](python/gdh.py) script to a folder, then:
 
 ```python
-from gdh import get_cases
+from gdh import GlobalDotHealth
 key = "API KEY HERE"
-c1 = get_cases(key, country="NZ")
+covid_line_list = GlobalDotHealth(key, 'covid-19')
+c1 = covid_line_list.get_cases(country="NZ")
 ```
 
 This will download the New Zealand case data from the database. Re-downloading
@@ -81,11 +82,12 @@ is a `get_cached_cases()` function which caches the data download which can be
 used in later calls:
 
 ```python
-from gdh import get_cases
+from gdh import GlobalDotHealth
 key = "API KEY HERE"
-c1 = get_cached_cases(key, country="NZ")
+covid_line_list = GlobalDotHealth(key, 'covid-19')
+c1 = covid_line_list.get_cached_cases(country="NZ")
 # use refresh=True to update the cache
-c1 = get_cached_cases(key, country="NZ", refresh=True)
+c1 = covid_line_list.get_cached_cases(country="NZ", refresh=True)
 ```
 
 [httr]: https://httr.r-lib.org/

--- a/api/python/gdh.py
+++ b/api/python/gdh.py
@@ -27,6 +27,11 @@ FILTERS = {
     "country"
 }
 
+ENVIRONMENTS = {
+    "production",
+    "dev",
+    "qa"
+}
 
 def stringify_filters(**kwargs):
     if not kwargs:
@@ -53,13 +58,16 @@ def cases_cachefile(server, folder="cache", **kwargs):
 
 
 class GlobalDotHealth:
-    def __init__(self, apikey, disease='covid-19'):
+    def __init__(self, apikey, disease='covid-19', environment = 'production'):
         # Let someone override our URL explicitly
         if server := os.getenv('GDH_URL'):
             self.server = server
         else:
-            # Otherwise, build a production URL from the disease name
-            self.server = f'https://data.{disease}.global.health'
+            # Otherwise, build a URL from the disease name/environment
+            if environment == 'production':
+                self.server = f'https://data.{disease}.global.health'
+            else:
+                self.server = f'https://{environment}-data.{disease}.global.health'
         self.apikey = apikey
 
     def get_cases(self, **kwargs):

--- a/api/python/test_gdh.py
+++ b/api/python/test_gdh.py
@@ -16,6 +16,6 @@ def test_stringify_filters(source, expected):
 
 def test_cases_cachefile():
     assert (
-        cases_cachefile(country="Belgium")
+        cases_cachefile('https://data.covid-19.global.health', country="Belgium")
         == "cache/e6ee72213b1c28500279d56c119fb9eccb2d5c67b0b6167ca241980a3bfc7762.csv"
     )


### PR DESCRIPTION
Replaced the `server` parameter with a `disease` parameter, so instead of saying "the production covid-19 line list or you have to give us a full URL", we say "the production covid-19 line list or you ask for another disease".

I used different approaches in Python and R to accept this parameter: a class constructor in Python and changing the function argument in R. I don't get the impression that R programmers expect or use classes much, and I found three different implementations of classes which made me wonder if I might pick a "wrong" one that users don't expect to see.

I'm not fully satisfied with this solution as you now can't specify self-hosted or a dev/qa instance. But I couldn't work out a way to easily parameterise the disease name (which gives the "marketing" benefit that we advertise flexibility for different diseases) as well as the other fields. Perhaps we still let you set a custom URL in an env var? Would R users expect that as a customisation point?