### PR TITLE
2712 dev scripts

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -69,7 +69,7 @@ Give your user all the permissions to access the portal and make CRUD updates.
 ./dev/make_superuser.sh $YOUR_GOOGLE_EMAIL
 ```
 
-Note that **the user must be logged-in into the portal before you can issue this command**.
+Note that **the user must be logged-in into the portal before you can issue this command**. To run it against a different instance/database, set `$GDH_DATABASE` to the appropriate connection string.
 
 **Windows users**
 

--- a/dev/make_superuser.sh
+++ b/dev/make_superuser.sh
@@ -6,6 +6,9 @@ set -e
 pushd `pwd`
 # We have to run docker-compose from this directory for it to pick up the .env file.
 cd `dirname "$0"`
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml exec mongo mongo covid19 --eval "var email='$1'; var roles=['admin', 'curator'];" /verification/scripts/roles.js
+
+# Tell us what database to use — default is covid19 but you can override it for other instances
+DB="${GDH_DATABASE:-covid19}"
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml exec mongo mongo "${DB}" --eval "var email='$1'; var roles=['admin', 'curator'];" /verification/scripts/roles.js
 # Restore directory.
 popd

--- a/dev/setup_db.sh
+++ b/dev/setup_db.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-export CONN="mongodb://localhost/covid19"
-export DB="covid19"
+export DB="${DB:-covid19}"
 
 npm --prefix=`dirname "$0"`/../data-serving/scripts/setup-db/ run-script migrate
 npm --prefix=`dirname "$0"`/../data-serving/scripts/setup-db/ run-script delete-all-cases


### PR DESCRIPTION
Allow `make_superuser.sh` to make superusers on other instances (this is typically OK security-wise as the person needs to have write access to that DB so could already do it).

Allow `setup_db.sh` to import data to arbitrary local databases (this is not permitted on other databases as it someone could accidentally drop production data if they have the connection string set in their environment: I have nearly done this before!)

Update the documentation for the scripts.