### PR TITLE
2714 batch upsert

### DIFF
--- a/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
@@ -86,6 +86,19 @@ class CaseController:
             # PreconditionError means it's a case, but not one we can use
             return pe.args[0], 422
 
+    def batch_upsert(self, body: dict):
+        """Upsert a collection of cases (updating ones that already exist, inserting
+        new cases). This method can potentially return a 207 mixed status as each case is
+        handled separately. The response will report the number of cases inserted, the
+        number updated, and any validation errors encountered."""
+        if body is None:
+            return "", 415
+        cases = body.get('cases')
+        if cases is None:
+            return "", 400
+        if len(cases) == 0:
+            return "", 400
+
     def create_case_if_valid(self, maybe_case: dict):
         """Attempts to create a case from an input dictionary and validate it against
         the application rules. Raises ValueError or PreconditionError on invalid input."""

--- a/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
@@ -107,7 +107,7 @@ class CaseController:
                 usable_cases.append(case)
             except Exception as e:
                 errors[str(i)] = e.args[0]
-        (created, updated) = self.store.batch_upsert(usable_cases)
+        (created, updated) = self.store.batch_upsert(usable_cases) if len(usable_cases) > 0 else (0,0)
         status = 200 if len(errors) == 0 else 207
         response = {"numCreated": created, "numUpdated": updated, "errors": errors}
         return jsonify(response), status

--- a/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
@@ -94,7 +94,7 @@ class CaseController:
         number updated, and any validation errors encountered."""
         if body is None:
             return "", 415
-        cases = body.get('cases')
+        cases = body.get("cases")
         if cases is None:
             return "", 400
         if len(cases) == 0:
@@ -109,11 +109,7 @@ class CaseController:
                 errors[str(i)] = e.args[0]
         (created, updated) = self.store.batch_upsert(usable_cases)
         status = 200 if len(errors) == 0 else 207
-        response = {
-            'numCreated': created,
-            'numUpdated': updated,
-            'errors': errors
-        }
+        response = {"numCreated": created, "numUpdated": updated, "errors": errors}
         return jsonify(response), status
 
     def create_anonymised_case_if_valid(self, maybe_case: dict):
@@ -134,8 +130,13 @@ class CaseController:
     def anonymise_case(case: Case):
         """Ensure that a stable one-way hash of the source entry ID is stored, and
         not the source entry ID itself."""
-        if case.caseReference is not None and case.caseReference.sourceEntryId is not None:
-            case.caseReference.sourceEntryId = sha256(case.caseReference.sourceEntryId.encode('utf-8')).hexdigest()
+        if (
+            case.caseReference is not None
+            and case.caseReference.sourceEntryId is not None
+        ):
+            case.caseReference.sourceEntryId = sha256(
+                case.caseReference.sourceEntryId.encode("utf-8")
+            ).hexdigest()
 
     @staticmethod
     def parse_filter(filter: str) -> Filter:

--- a/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
@@ -98,6 +98,22 @@ class CaseController:
             return "", 400
         if len(cases) == 0:
             return "", 400
+        errors = {}
+        usable_cases = []
+        for i, maybe_case in enumerate(cases):
+            try:
+                self.create_case_if_valid(maybe_case)
+                usable_cases.append(maybe_case)
+            except Exception as e:
+                errors[str(i)] = e.args[0]
+        (created, updated) = self.store.batch_upsert(usable_cases)
+        status = 200 if len(errors) == 0 else 207
+        response = {
+            'numCreated': created,
+            'numUpdated': updated,
+            'errors': errors
+        }
+        return jsonify(response), status
 
     def create_case_if_valid(self, maybe_case: dict):
         """Attempts to create a case from an input dictionary and validate it against

--- a/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/reusable_data_service/controller/case_controller.py
@@ -1,5 +1,6 @@
 from flask import jsonify
 from datetime import date
+from hashlib import sha256
 from reusable_data_service.model.case import Case
 from reusable_data_service.model.filter import (
     Anything,
@@ -63,7 +64,7 @@ class CaseController:
         if num_cases <= 0:
             return "Must create a positive number of cases", 400
         try:
-            case = self.create_case_if_valid(maybe_case)
+            case = self.create_anonymised_case_if_valid(maybe_case)
             for i in range(num_cases):
                 self.store.insert_case(case)
             return "", 201
@@ -77,7 +78,7 @@ class CaseController:
     def validate_case_dictionary(self, maybe_case: dict):
         """Check whether a case _could_ be valid, without storing it if it is."""
         try:
-            case = self.create_case_if_valid(maybe_case)
+            case = self.create_anonymised_case_if_valid(maybe_case)
             return "", 204
         except ValueError as ve:
             # ValueError means we can't even turn this into a case
@@ -102,8 +103,8 @@ class CaseController:
         usable_cases = []
         for i, maybe_case in enumerate(cases):
             try:
-                self.create_case_if_valid(maybe_case)
-                usable_cases.append(maybe_case)
+                case = self.create_anonymised_case_if_valid(maybe_case)
+                usable_cases.append(case)
             except Exception as e:
                 errors[str(i)] = e.args[0]
         (created, updated) = self.store.batch_upsert(usable_cases)
@@ -115,16 +116,26 @@ class CaseController:
         }
         return jsonify(response), status
 
-    def create_case_if_valid(self, maybe_case: dict):
+    def create_anonymised_case_if_valid(self, maybe_case: dict):
         """Attempts to create a case from an input dictionary and validate it against
-        the application rules. Raises ValueError or PreconditionError on invalid input."""
+        the application rules. Implements anonymisation rules so that cases cannot be
+        reidentified against external source data.
+        Raises ValueError or PreconditionError on invalid input."""
         case = Case.from_dict(maybe_case)
         self.check_case_preconditions(case)
+        CaseController.anonymise_case(case)
         return case
 
     def check_case_preconditions(self, case: Case):
         if case.confirmationDate < self.outbreak_date:
             raise PreconditionError("Confirmation date is before outbreak began")
+
+    @staticmethod
+    def anonymise_case(case: Case):
+        """Ensure that a stable one-way hash of the source entry ID is stored, and
+        not the source entry ID itself."""
+        if case.caseReference is not None and case.caseReference.sourceEntryId is not None:
+            case.caseReference.sourceEntryId = sha256(case.caseReference.sourceEntryId.encode('utf-8')).hexdigest()
 
     @staticmethod
     def parse_filter(filter: str) -> Filter:

--- a/data-serving/reusable-data-service/reusable_data_service/main.py
+++ b/data-serving/reusable-data-service/reusable_data_service/main.py
@@ -35,9 +35,10 @@ def list_cases():
         return case_controller.create_case(potential_case, num_cases=count)
 
 
-@app.route("/api/cases/batchUpsert", methods = ['POST'])
+@app.route("/api/cases/batchUpsert", methods=["POST"])
 def batch_upsert_cases():
     return case_controller.batch_upsert(request.get_json())
+
 
 def set_up_controllers():
     global case_controller

--- a/data-serving/reusable-data-service/reusable_data_service/main.py
+++ b/data-serving/reusable-data-service/reusable_data_service/main.py
@@ -1,13 +1,13 @@
 from datetime import date
 from flask import Flask, request
 from . import CaseController, MongoStore
-from reusable_data_service.util.iso_json_encoder import ISOJSONEncoder
+from reusable_data_service.util.iso_json_encoder import DataServiceJSONEncoder
 
 import os
 import logging
 
 app = Flask(__name__)
-app.json_encoder = ISOJSONEncoder
+app.json_encoder = DataServiceJSONEncoder
 
 case_controller = None  # Will be set up in main()
 
@@ -34,6 +34,10 @@ def list_cases():
             count = 1
         return case_controller.create_case(potential_case, num_cases=count)
 
+
+@app.route("/api/cases/batchUpsert", methods = ['POST'])
+def batch_upsert_cases():
+    return case_controller.batch_upsert(request.get_json())
 
 def set_up_controllers():
     global case_controller

--- a/data-serving/reusable-data-service/reusable_data_service/model/case.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case.py
@@ -20,6 +20,11 @@ class DayZeroCase:
     to that function)."""
 
     _: dataclasses.KW_ONLY
+    """_id is treated as an opaque identifier by the model, allowing the
+    store to use whatever format it needs to uniquely identify a stored case.
+    The _id is allowed to be None, for cases that have been created but not
+    yet saved into a store."""
+    _id: str = dataclasses.field(init=False, default=None)
     confirmationDate: datetime.date = dataclasses.field(init=False)
     caseReference: CaseReference = dataclasses.field(init=False, default=None)
 
@@ -55,6 +60,13 @@ class DayZeroCase:
                 value = (
                     CaseReference.from_dict(caseRef) if caseRef is not None else None
                 )
+            elif key == "_id":
+                the_id = dictionary[key]
+                if isinstance(the_id, dict):
+                    # this came from a BSON objectID representation
+                    value = the_id["$oid"]
+                else:
+                    value = the_id
             else:
                 value = dictionary[key]
             setattr(case, key, value)

--- a/data-serving/reusable-data-service/reusable_data_service/model/case.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case.py
@@ -91,9 +91,8 @@ class DayZeroCase:
 
     @classmethod
     def date_fields(cls) -> list[str]:
-        """Record where dates are kept because they sometimes need special treatment.
-        A subclass could override this method to indicate it stores additional date fields."""
-        return ["confirmationDate"]
+        """Record where dates are kept because they sometimes need special treatment."""
+        return [f.name for f in dataclasses.fields(cls) if f.type == datetime.date]
 
 
 # Actually we want to capture extra fields which can be specified dynamically:

--- a/data-serving/reusable-data-service/reusable_data_service/model/case.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case.py
@@ -4,6 +4,7 @@ import json
 
 from typing import Any
 
+from reusable_data_service.model.case_reference import CaseReference
 
 @dataclasses.dataclass()
 class DayZeroCase:
@@ -19,6 +20,7 @@ class DayZeroCase:
 
     _: dataclasses.KW_ONLY
     confirmationDate: datetime.date = dataclasses.field(init=False)
+    caseReference: CaseReference = dataclasses.field(init=False, default=None)
 
     @classmethod
     def from_json(cls, obj: str) -> type:

--- a/data-serving/reusable-data-service/reusable_data_service/model/case.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from reusable_data_service.model.case_reference import CaseReference
 
+
 @dataclasses.dataclass()
 class DayZeroCase:
     """This class implements the "day-zero" data schema for Global.health.
@@ -49,9 +50,11 @@ class DayZeroCase:
                     ).date()
                 else:
                     raise ValueError(f"Cannot interpret date {maybe_date}")
-            elif key == 'caseReference':
+            elif key == "caseReference":
                 caseRef = dictionary[key]
-                value = CaseReference.from_dict(caseRef) if caseRef is not None else None
+                value = (
+                    CaseReference.from_dict(caseRef) if caseRef is not None else None
+                )
             else:
                 value = dictionary[key]
             setattr(case, key, value)

--- a/data-serving/reusable-data-service/reusable_data_service/model/case.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case.py
@@ -67,6 +67,11 @@ class DayZeroCase:
             raise ValueError("Confirmation Date is mandatory")
         elif self.confirmationDate is None:
             raise ValueError("Confirmation Date must have a value")
+        if not hasattr(self, "caseReference"):
+            raise ValueError("Case Reference is mandatory")
+        elif self.caseReference is None:
+            raise ValueError("Case Reference must have a value")
+        self.caseReference.validate()
 
     def to_dict(self):
         """Return myself as a dictionary."""

--- a/data-serving/reusable-data-service/reusable_data_service/model/case.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case.py
@@ -49,6 +49,9 @@ class DayZeroCase:
                     ).date()
                 else:
                     raise ValueError(f"Cannot interpret date {maybe_date}")
+            elif key == 'caseReference':
+                caseRef = dictionary[key]
+                value = CaseReference.from_dict(caseRef) if caseRef is not None else None
             else:
                 value = dictionary[key]
             setattr(case, key, value)

--- a/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
@@ -7,3 +7,13 @@ class CaseReference:
     _: dataclasses.KW_ONLY
     sourceId: bson.ObjectId = dataclasses.field(init=False, default=None)
     sourceEntryId: str = dataclasses.field(init=False, default=None)
+
+    @staticmethod
+    def from_dict(d: dict[str, str]):
+        """Create a CaseReference from a dictionary representation."""
+        ref = CaseReference()
+        if 'sourceId' in d:
+            ref.sourceId = bson.ObjectId(d['sourceId'])
+        if 'sourceEntryId' in d:
+            ref.sourceEntryId = d['sourceEntryId']
+        return ref

--- a/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
@@ -13,7 +13,13 @@ class CaseReference:
         """Create a CaseReference from a dictionary representation."""
         ref = CaseReference()
         if 'sourceId' in d:
-            ref.sourceId = bson.ObjectId(d['sourceId'])
+            theId = d['sourceId']
+            if isinstance(theId, str):
+                ref.sourceId = bson.ObjectId(theId)
+            elif '$oid' in theId:
+                ref.sourceId = bson.ObjectId(theId['$oid'])
+            else:
+                raise ValueError(f"Cannot interpret {theId} as an ObjectId")
         if 'sourceEntryId' in d:
             ref.sourceEntryId = d['sourceEntryId']
         return ref

--- a/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
@@ -1,9 +1,11 @@
 import bson
 import dataclasses
 
+
 @dataclasses.dataclass
 class CaseReference:
     """Represents information about the source of a given case."""
+
     _: dataclasses.KW_ONLY
     sourceId: bson.ObjectId = dataclasses.field(init=False, default=None)
     sourceEntryId: str = dataclasses.field(init=False, default=None)
@@ -12,14 +14,14 @@ class CaseReference:
     def from_dict(d: dict[str, str]):
         """Create a CaseReference from a dictionary representation."""
         ref = CaseReference()
-        if 'sourceId' in d:
-            theId = d['sourceId']
+        if "sourceId" in d:
+            theId = d["sourceId"]
             if isinstance(theId, str):
                 ref.sourceId = bson.ObjectId(theId)
-            elif '$oid' in theId:
-                ref.sourceId = bson.ObjectId(theId['$oid'])
+            elif "$oid" in theId:
+                ref.sourceId = bson.ObjectId(theId["$oid"])
             else:
                 raise ValueError(f"Cannot interpret {theId} as an ObjectId")
-        if 'sourceEntryId' in d:
-            ref.sourceEntryId = d['sourceEntryId']
+        if "sourceEntryId" in d:
+            ref.sourceEntryId = d["sourceEntryId"]
         return ref

--- a/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
@@ -1,0 +1,9 @@
+import bson
+import dataclasses
+
+@dataclasses.dataclass
+class CaseReference:
+    """Represents information about the source of a given case."""
+    _: dataclasses.KW_ONLY
+    sourceId: bson.ObjectId = dataclasses.field(init=False, default=None)
+    sourceEntryId: str = dataclasses.field(init=False, default=None)

--- a/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
+++ b/data-serving/reusable-data-service/reusable_data_service/model/case_reference.py
@@ -8,7 +8,13 @@ class CaseReference:
 
     _: dataclasses.KW_ONLY
     sourceId: bson.ObjectId = dataclasses.field(init=False, default=None)
-    sourceEntryId: str = dataclasses.field(init=False, default=None)
+
+    def validate(self):
+        """Check whether I am consistent. Raise ValueError if not."""
+        if not hasattr(self, "sourceId"):
+            raise ValueError("Source ID is mandatory")
+        elif self.sourceId is None:
+            raise ValueError("Source ID must have a value")
 
     @staticmethod
     def from_dict(d: dict[str, str]):
@@ -22,6 +28,4 @@ class CaseReference:
                 ref.sourceId = bson.ObjectId(theId["$oid"])
             else:
                 raise ValueError(f"Cannot interpret {theId} as an ObjectId")
-        if "sourceEntryId" in d:
-            ref.sourceEntryId = d["sourceEntryId"]
         return ref

--- a/data-serving/reusable-data-service/reusable_data_service/stores/mongo_store.py
+++ b/data-serving/reusable-data-service/reusable_data_service/stores/mongo_store.py
@@ -56,8 +56,16 @@ class MongoStore:
 
     def batch_upsert(self, cases: List[Case]) -> Tuple[int, int]:
         dicts = [MongoStore.case_to_bson_compatible_dict(c) for c in cases]
-        self.get_case_collection().insert_many(dicts)
-        return len(cases), 0
+        needs_insert = lambda d: d['caseReference'] is None or d['caseReference']['sourceId'] is None or d['caseReference']['sourceEntryId'] is None
+        to_insert = [d for d in dicts if needs_insert(d)]
+        to_upsert = [d for d in dicts if not needs_insert(d)]
+        inserts = [pymongo.InsertOne(d) for d in to_insert]
+        replacements = [pymongo.ReplaceOne(filter = {
+            'caseReference.sourceId': d['caseReference']['sourceId'],
+            'caseReference.sourceEntryId': d['caseReference']['sourceEntryId'],
+            }, replacement = d, upsert = True) for d in to_upsert]
+        results = self.get_case_collection().bulk_write(inserts + replacements)
+        return results.inserted_count, results.modified_count
 
     @staticmethod
     def setup():

--- a/data-serving/reusable-data-service/reusable_data_service/util/iso_json_encoder.py
+++ b/data-serving/reusable-data-service/reusable_data_service/util/iso_json_encoder.py
@@ -1,12 +1,15 @@
 import flask.json
+import bson
 import datetime
 
 
-class ISOJSONEncoder(flask.json.JSONEncoder):
+class DataServiceJSONEncoder(flask.json.JSONEncoder):
     def default(self, obj):
         try:
             if isinstance(obj, datetime.date):
                 return obj.isoformat()
+            elif isinstance(obj, bson.ObjectId):
+                return str(obj)
             iterable = iter(obj)
         except TypeError:
             pass

--- a/data-serving/reusable-data-service/tests/data/case.minimal.json
+++ b/data-serving/reusable-data-service/tests/data/case.minimal.json
@@ -1,3 +1,6 @@
 {
-    "confirmationDate": "2021-12-31T01:23:45.678Z"
+    "confirmationDate": "2021-12-31T01:23:45.678Z",
+    "caseReference": {
+        "sourceId": "fedc09876543210987654321"
+    }
 }

--- a/data-serving/reusable-data-service/tests/test_case_controller.py
+++ b/data-serving/reusable-data-service/tests/test_case_controller.py
@@ -228,3 +228,16 @@ def test_batch_upsert_reports_errors(case_controller):
     assert response.json['errors'] == {
         '0': 'Confirmation Date is mandatory'
     }
+
+def test_batch_upsert_hides_original_source_entry_id(case_controller):
+    case_controller.store.upsert_create_count = 1 # create the case so we can read it later
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        case = json.loads(minimal_file.read())
+    case['caseReference'] = {
+        'sourceId': '12345678901234567890abcd',
+        'sourceEntryId': 'foo',
+    }
+    (response, status) = case_controller.batch_upsert({ 'cases': [case] })
+    assert status == 200
+    retrieved_case = case_controller.store.case_by_id('1')
+    assert retrieved_case.caseReference.sourceEntryId != 'foo'

--- a/data-serving/reusable-data-service/tests/test_case_controller.py
+++ b/data-serving/reusable-data-service/tests/test_case_controller.py
@@ -153,3 +153,18 @@ def test_validate_case_with_valid_case_returns_204_and_does_not_add_case(
     )
     assert status == 204
     assert case_controller.store.count_cases() == 0
+
+
+def test_batch_upsert_with_no_body_returns_415(case_controller):
+    (response, status) = case_controller.batch_upsert(None)
+    assert status == 415
+
+
+def test_batch_upsert_with_no_case_list_returns_400(case_controller):
+    (response, status) = case_controller.batch_upsert({})
+    assert status == 400
+
+
+def test_batch_upsert_with_empty_case_list_returns_400(case_controller):
+    (response, status) = case_controller.batch_upsert({ 'cases': [] })
+    assert status == 400

--- a/data-serving/reusable-data-service/tests/test_case_controller.py
+++ b/data-serving/reusable-data-service/tests/test_case_controller.py
@@ -31,7 +31,7 @@ class MemoryStore:
 
     def count_cases(self, *args):
         return len(self.cases)
-    
+
     def batch_upsert(self, cases: List[Case]):
         """For testing the case controller, a trivial implementation. Look to
         tests of the stores and integration tests for richer expressions of
@@ -184,60 +184,74 @@ def test_batch_upsert_with_no_case_list_returns_400(case_controller):
 
 
 def test_batch_upsert_with_empty_case_list_returns_400(case_controller):
-    (response, status) = case_controller.batch_upsert({ 'cases': [] })
+    (response, status) = case_controller.batch_upsert({"cases": []})
     assert status == 400
 
 
 def test_batch_upsert_creates_valid_case(case_controller):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         minimal_case_description = json.loads(minimal_file.read())
-    case_controller.store.upsert_create_count = 1 # store should create this case
-    (response, status) = case_controller.batch_upsert({ 'cases': [minimal_case_description] })
+    case_controller.store.upsert_create_count = 1  # store should create this case
+    (response, status) = case_controller.batch_upsert(
+        {"cases": [minimal_case_description]}
+    )
     assert status == 200
     assert case_controller.store.count_cases() == 1
-    assert response.json['numCreated'] == 1
-    assert response.json['numUpdated'] == 0
-    assert response.json['errors'] == {}
+    assert response.json["numCreated"] == 1
+    assert response.json["numUpdated"] == 0
+    assert response.json["errors"] == {}
+
 
 def test_batch_upsert_updates_valid_case(case_controller):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         minimal_case_description = json.loads(minimal_file.read())
-    case_controller.store.upsert_create_count = 0 # store should update this case
-    (response, status) = case_controller.batch_upsert({ 'cases': [minimal_case_description] })
+    case_controller.store.upsert_create_count = 0  # store should update this case
+    (response, status) = case_controller.batch_upsert(
+        {"cases": [minimal_case_description]}
+    )
     assert status == 200
-    assert response.json['numCreated'] == 0
-    assert response.json['numUpdated'] == 1
-    assert response.json['errors'] == {}
+    assert response.json["numCreated"] == 0
+    assert response.json["numUpdated"] == 1
+    assert response.json["errors"] == {}
+
 
 def test_batch_upsert_reports_both_updates_and_inserts(case_controller):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         minimal_case_description = json.loads(minimal_file.read())
-    case_controller.store.upsert_create_count = 1 # store should create one, update other
-    (response, status) = case_controller.batch_upsert({ 'cases': [minimal_case_description, minimal_case_description] })
+    case_controller.store.upsert_create_count = (
+        1  # store should create one, update other
+    )
+    (response, status) = case_controller.batch_upsert(
+        {"cases": [minimal_case_description, minimal_case_description]}
+    )
     assert status == 200
-    assert response.json['numCreated'] == 1
-    assert response.json['numUpdated'] == 1
-    assert response.json['errors'] == {}
+    assert response.json["numCreated"] == 1
+    assert response.json["numUpdated"] == 1
+    assert response.json["errors"] == {}
+
 
 def test_batch_upsert_reports_errors(case_controller):
-    case_controller.store.upsert_create_count = 0 # store won't have anything to do in this test anyway
-    (response, status) = case_controller.batch_upsert({ 'cases': [{}] })
+    case_controller.store.upsert_create_count = (
+        0  # store won't have anything to do in this test anyway
+    )
+    (response, status) = case_controller.batch_upsert({"cases": [{}]})
     assert status == 207
-    assert response.json['numCreated'] == 0
-    assert response.json['numUpdated'] == 0
-    assert response.json['errors'] == {
-        '0': 'Confirmation Date is mandatory'
-    }
+    assert response.json["numCreated"] == 0
+    assert response.json["numUpdated"] == 0
+    assert response.json["errors"] == {"0": "Confirmation Date is mandatory"}
+
 
 def test_batch_upsert_hides_original_source_entry_id(case_controller):
-    case_controller.store.upsert_create_count = 1 # create the case so we can read it later
+    case_controller.store.upsert_create_count = (
+        1  # create the case so we can read it later
+    )
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         case = json.loads(minimal_file.read())
-    case['caseReference'] = {
-        'sourceId': '12345678901234567890abcd',
-        'sourceEntryId': 'foo',
+    case["caseReference"] = {
+        "sourceId": "12345678901234567890abcd",
+        "sourceEntryId": "foo",
     }
-    (response, status) = case_controller.batch_upsert({ 'cases': [case] })
+    (response, status) = case_controller.batch_upsert({"cases": [case]})
     assert status == 200
-    retrieved_case = case_controller.store.case_by_id('1')
-    assert retrieved_case.caseReference.sourceEntryId != 'foo'
+    retrieved_case = case_controller.store.case_by_id("1")
+    assert retrieved_case.caseReference.sourceEntryId != "foo"

--- a/data-serving/reusable-data-service/tests/test_case_end_to_end.py
+++ b/data-serving/reusable-data-service/tests/test_case_end_to_end.py
@@ -193,7 +193,7 @@ def test_batch_upsert_case(client_with_patched_mongo):
         json={
             "cases": [
                 {
-                    "confirmation_date": "2022-01-23T13:45:01.234Z",
+                    "confirmationDate": "2022-01-23T13:45:01.234Z",
                     "caseReference": {
                         "sourceId": "abcd12345678901234567890",
                         "sourceEntryId": "a secret",

--- a/data-serving/reusable-data-service/tests/test_case_end_to_end.py
+++ b/data-serving/reusable-data-service/tests/test_case_end_to_end.py
@@ -186,16 +186,22 @@ def test_post_case_validate_only(client_with_patched_mongo):
     assert get_response.status_code == 200
     assert len(get_response.json["cases"]) == 0
 
+
 def test_batch_upsert_case(client_with_patched_mongo):
-    post_response = client_with_patched_mongo.post("/api/cases/batchUpsert", json = {
-        "cases": [{
-            "confirmation_date": "2022-01-23T13:45:01.234Z",
-            "caseReference": {
-                "sourceId": "abcd12345678901234567890",
-                "sourceEntryId": "a secret",
-            }
-        }]
-    })
+    post_response = client_with_patched_mongo.post(
+        "/api/cases/batchUpsert",
+        json={
+            "cases": [
+                {
+                    "confirmation_date": "2022-01-23T13:45:01.234Z",
+                    "caseReference": {
+                        "sourceId": "abcd12345678901234567890",
+                        "sourceEntryId": "a secret",
+                    },
+                }
+            ]
+        },
+    )
     assert post_response.status_code == 200
     assert post_response.json["errors"] == {}
     # mongomock doesn't correctly track upserts for creation/replacement, so can't test numCreated/numUpdated

--- a/data-serving/reusable-data-service/tests/test_mongo_store.py
+++ b/data-serving/reusable-data-service/tests/test_mongo_store.py
@@ -9,6 +9,7 @@ from reusable_data_service.model.case_reference import CaseReference
 from reusable_data_service.model.filter import Anything
 from reusable_data_service.stores.mongo_store import MongoStore
 
+
 @pytest.fixture
 def mongo_store(monkeypatch):
     db = mongomock.MongoClient()
@@ -17,8 +18,9 @@ def mongo_store(monkeypatch):
         return db
 
     monkeypatch.setattr("pymongo.MongoClient", fake_mongo)
-    store = MongoStore('mongodb://localhost:27017/outbreak', 'outbreak', 'cases')
+    store = MongoStore("mongodb://localhost:27017/outbreak", "outbreak", "cases")
     yield store
+
 
 """
 Note that mongomock gets the inserted and updated counts of bulk write actions incorrect
@@ -26,11 +28,13 @@ Note that mongomock gets the inserted and updated counts of bulk write actions i
 So these tests don't read those values, they test the state of the database.
 """
 
+
 def test_store_inserts_case_with_no_case_reference(mongo_store):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         case = Case.from_json(minimal_file.read())
     (created, updated) = mongo_store.batch_upsert([case])
     assert mongo_store.count_cases(Anything()) == 1
+
 
 def test_store_inserts_case_with_empty_case_reference(mongo_store):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
@@ -38,6 +42,7 @@ def test_store_inserts_case_with_empty_case_reference(mongo_store):
     case.caseReference = CaseReference()
     (created, updated) = mongo_store.batch_upsert([case])
     assert mongo_store.count_cases(Anything()) == 1
+
 
 def test_store_inserts_case_with_populated_case_reference(mongo_store):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
@@ -49,6 +54,7 @@ def test_store_inserts_case_with_populated_case_reference(mongo_store):
     (created, updated) = mongo_store.batch_upsert([case])
     assert mongo_store.count_cases(Anything()) == 1
 
+
 def test_store_updates_case_with_known_case_reference(mongo_store):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         case = Case.from_json(minimal_file.read())
@@ -57,6 +63,6 @@ def test_store_updates_case_with_known_case_reference(mongo_store):
     caseReference.sourceEntryId = "1234"
     case.caseReference = caseReference
     mongo_store.insert_case(case)
-    case.confirmation_date = date(2022,1,13)
+    case.confirmation_date = date(2022, 1, 13)
     (created, updated) = mongo_store.batch_upsert([case])
     assert mongo_store.count_cases(Anything()) == 1

--- a/data-serving/reusable-data-service/tests/test_mongo_store.py
+++ b/data-serving/reusable-data-service/tests/test_mongo_store.py
@@ -2,6 +2,7 @@ import pytest
 import mongomock
 
 from bson import ObjectId
+from datetime import date
 
 from reusable_data_service.model.case import Case
 from reusable_data_service.model.case_reference import CaseReference
@@ -19,12 +20,16 @@ def mongo_store(monkeypatch):
     store = MongoStore('mongodb://localhost:27017/outbreak', 'outbreak', 'cases')
     yield store
 
+"""
+Note that mongomock gets the inserted and updated counts of bulk write actions incorrect
+(it seems to always consider ReplaceOne operations as updates, even if they insert).
+So these tests don't read those values, they test the state of the database.
+"""
+
 def test_store_inserts_case_with_no_case_reference(mongo_store):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         case = Case.from_json(minimal_file.read())
     (created, updated) = mongo_store.batch_upsert([case])
-    assert created == 1
-    assert updated == 0
     assert mongo_store.count_cases(Anything()) == 1
 
 def test_store_inserts_case_with_empty_case_reference(mongo_store):
@@ -32,8 +37,6 @@ def test_store_inserts_case_with_empty_case_reference(mongo_store):
         case = Case.from_json(minimal_file.read())
     case.caseReference = CaseReference()
     (created, updated) = mongo_store.batch_upsert([case])
-    assert created == 1
-    assert updated == 0
     assert mongo_store.count_cases(Anything()) == 1
 
 def test_store_inserts_case_with_populated_case_reference(mongo_store):
@@ -44,6 +47,16 @@ def test_store_inserts_case_with_populated_case_reference(mongo_store):
     caseReference.sourceEntryId = "1234"
     case.caseReference = caseReference
     (created, updated) = mongo_store.batch_upsert([case])
-    assert created == 1
-    assert updated == 0
+    assert mongo_store.count_cases(Anything()) == 1
+
+def test_store_updates_case_with_known_case_reference(mongo_store):
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        case = Case.from_json(minimal_file.read())
+    caseReference = CaseReference()
+    caseReference.sourceId = ObjectId()
+    caseReference.sourceEntryId = "1234"
+    case.caseReference = caseReference
+    mongo_store.insert_case(case)
+    case.confirmation_date = date(2022,1,13)
+    (created, updated) = mongo_store.batch_upsert([case])
     assert mongo_store.count_cases(Anything()) == 1

--- a/data-serving/reusable-data-service/tests/test_mongo_store.py
+++ b/data-serving/reusable-data-service/tests/test_mongo_store.py
@@ -1,6 +1,8 @@
 import pytest
 import mongomock
 
+from bson import ObjectId
+
 from reusable_data_service.model.case import Case
 from reusable_data_service.model.case_reference import CaseReference
 from reusable_data_service.model.filter import Anything
@@ -29,6 +31,18 @@ def test_store_inserts_case_with_empty_case_reference(mongo_store):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         case = Case.from_json(minimal_file.read())
     case.caseReference = CaseReference()
+    (created, updated) = mongo_store.batch_upsert([case])
+    assert created == 1
+    assert updated == 0
+    assert mongo_store.count_cases(Anything()) == 1
+
+def test_store_inserts_case_with_populated_case_reference(mongo_store):
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        case = Case.from_json(minimal_file.read())
+    caseReference = CaseReference()
+    caseReference.sourceId = ObjectId()
+    caseReference.sourceEntryId = "1234"
+    case.caseReference = caseReference
     (created, updated) = mongo_store.batch_upsert([case])
     assert created == 1
     assert updated == 0

--- a/data-serving/reusable-data-service/tests/test_mongo_store.py
+++ b/data-serving/reusable-data-service/tests/test_mongo_store.py
@@ -66,3 +66,13 @@ def test_store_inserts_case_even_with_known_case_reference(mongo_store):
     case.confirmation_date = date(2022, 1, 13)
     (created, updated) = mongo_store.batch_upsert([case])
     assert mongo_store.count_cases(Anything()) == 2
+
+
+def test_batch_upsert_updates_case_with_existing_object_id(mongo_store):
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        minimal_case = Case.from_json(minimal_file.read())
+    mongo_store.insert_case(minimal_case)
+    retrieved_case = mongo_store.fetch_cases(1, 10, Anything())[0]
+    retrieved_case.confirmationDate = date(2021, 6, 19)
+    (created, updated) = mongo_store.batch_upsert([retrieved_case])
+    assert mongo_store.count_cases(Anything()) == 1

--- a/data-serving/reusable-data-service/tests/test_mongo_store.py
+++ b/data-serving/reusable-data-service/tests/test_mongo_store.py
@@ -55,7 +55,7 @@ def test_store_inserts_case_with_populated_case_reference(mongo_store):
     assert mongo_store.count_cases(Anything()) == 1
 
 
-def test_store_updates_case_with_known_case_reference(mongo_store):
+def test_store_inserts_case_even_with_known_case_reference(mongo_store):
     with open("./tests/data/case.minimal.json", "r") as minimal_file:
         case = Case.from_json(minimal_file.read())
     caseReference = CaseReference()
@@ -65,4 +65,4 @@ def test_store_updates_case_with_known_case_reference(mongo_store):
     mongo_store.insert_case(case)
     case.confirmation_date = date(2022, 1, 13)
     (created, updated) = mongo_store.batch_upsert([case])
-    assert mongo_store.count_cases(Anything()) == 1
+    assert mongo_store.count_cases(Anything()) == 2

--- a/data-serving/reusable-data-service/tests/test_mongo_store.py
+++ b/data-serving/reusable-data-service/tests/test_mongo_store.py
@@ -1,0 +1,35 @@
+import pytest
+import mongomock
+
+from reusable_data_service.model.case import Case
+from reusable_data_service.model.case_reference import CaseReference
+from reusable_data_service.model.filter import Anything
+from reusable_data_service.stores.mongo_store import MongoStore
+
+@pytest.fixture
+def mongo_store(monkeypatch):
+    db = mongomock.MongoClient()
+
+    def fake_mongo(connection_string):
+        return db
+
+    monkeypatch.setattr("pymongo.MongoClient", fake_mongo)
+    store = MongoStore('mongodb://localhost:27017/outbreak', 'outbreak', 'cases')
+    yield store
+
+def test_store_inserts_case_with_no_case_reference(mongo_store):
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        case = Case.from_json(minimal_file.read())
+    (created, updated) = mongo_store.batch_upsert([case])
+    assert created == 1
+    assert updated == 0
+    assert mongo_store.count_cases(Anything()) == 1
+
+def test_store_inserts_case_with_empty_case_reference(mongo_store):
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        case = Case.from_json(minimal_file.read())
+    case.caseReference = CaseReference()
+    (created, updated) = mongo_store.batch_upsert([case])
+    assert created == 1
+    assert updated == 0
+    assert mongo_store.count_cases(Anything()) == 1


### PR DESCRIPTION
This adds the batchUpsert endpoint, which is how bulk uploads and automatic ingestion are supported. As previously discussed with @abhidg this doesn't include curator or revision metadata, because they're unused in the Covid-19 version.