### PR TITLE
2714 batch update query

### DIFF
--- a/data-serving/reusable-data-service/data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/data_service/controller/case_controller.py
@@ -57,12 +57,10 @@ class CaseController:
         if limit <= 0:
             raise PreconditionUnsatisfiedError("limit must be >0")
         predicate = CaseController.parse_filter(filter)
-        print(f"predicate: {predicate}")
         if predicate is None:
             raise ValidationError("cannot understand query")
         cases = self.store.fetch_cases(page, limit, predicate)
         count = self.store.count_cases(predicate)
-        print(f"cases: {cases}")
         nextPage = page + 1 if count > page * limit else None
         return CasePage(cases, count, nextPage)
 

--- a/data-serving/reusable-data-service/data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/data_service/controller/case_controller.py
@@ -241,11 +241,13 @@ class CaseController:
         of an update, and query indicates which cases to update.
         Raises ValidationError if any update leaves a case
         in an inconsistent state."""
+        if update is None:
+            raise PreconditionUnsatisfiedError("No update supplied")
         cases = self.list_cases(filter=query)
         updates = []
         for case in cases.cases:
             an_update = dict(update)
-            an_update['_id'] = case._id
+            an_update["_id"] = case._id
             updates.append(an_update)
         return self.batch_update(updates)
 

--- a/data-serving/reusable-data-service/data_service/controller/case_controller.py
+++ b/data-serving/reusable-data-service/data_service/controller/case_controller.py
@@ -1,3 +1,5 @@
+import sys
+
 from flask import jsonify
 from datetime import date
 from typing import List, Optional
@@ -243,7 +245,7 @@ class CaseController:
         in an inconsistent state."""
         if update is None:
             raise PreconditionUnsatisfiedError("No update supplied")
-        cases = self.list_cases(filter=query)
+        cases = self.list_cases(limit=sys.maxsize, filter=query)
         updates = []
         for case in cases.cases:
             an_update = dict(update)

--- a/data-serving/reusable-data-service/data_service/main.py
+++ b/data-serving/reusable-data-service/data_service/main.py
@@ -117,6 +117,16 @@ def batch_update():
         return jsonify({"message": e.args[0]}), e.http_code
 
 
+@app.route("/api/cases/batchUpdateQuery", methods=["POST"])
+def batch_update_query():
+    try:
+        req = request.get_json()
+        count = case_controller.batch_update_query(req.get("query"), req.get("case"))
+        return jsonify({"numModified": count}), 200
+    except WebApplicationError as e:
+        return jsonify({"message": e.args[0]}), e.http_code
+
+
 @app.route("/api/excludedCaseIds")
 def excluded_case_ids():
     try:

--- a/data-serving/reusable-data-service/tests/test_case_controller.py
+++ b/data-serving/reusable-data-service/tests/test_case_controller.py
@@ -585,3 +585,17 @@ def test_batch_update_raises_if_case_not_found(case_controller):
     update = {"_id": "1", "confirmationDate": date(2022, 5, 13)}
     with pytest.raises(NotFoundError):
         case_controller.batch_update([update])
+
+
+def test_batch_update_query_returns_modified_count(case_controller):
+    for i in range(4):
+        _ = case_controller.create_case(
+            {
+                "confirmationDate": date(2021, 6, i + 1),
+                "caseReference": {"sourceId": "123ab4567890123ef4567890"},
+            },
+        )
+    update = { "confirmationDate": date(2022, 5, 13) }
+    query = None # didn't implement rich queries on the test store
+    modified = case_controller.batch_update_query(query, update)
+    assert modified == 4

--- a/data-serving/reusable-data-service/tests/test_case_controller.py
+++ b/data-serving/reusable-data-service/tests/test_case_controller.py
@@ -595,7 +595,7 @@ def test_batch_update_query_returns_modified_count(case_controller):
                 "caseReference": {"sourceId": "123ab4567890123ef4567890"},
             },
         )
-    update = { "confirmationDate": date(2022, 5, 13) }
-    query = None # didn't implement rich queries on the test store
+    update = {"confirmationDate": date(2022, 5, 13)}
+    query = None  # didn't implement rich queries on the test store
     modified = case_controller.batch_update_query(query, update)
     assert modified == 4


### PR DESCRIPTION
Just like the existing data service, I do this the easy way by getting the list of cases matching the query and calling through to the other batch update behaviour. It would be possible to make this more efficient using a mongo update_many() command.