### PR TITLE
Fix KeyError parsing for Cuba

### DIFF
--- a/ingestion/functions/parsing/cuba/cuba.py
+++ b/ingestion/functions/parsing/cuba/cuba.py
@@ -161,16 +161,23 @@ def parse_cases(raw_data_file, source_id, source_url):
         # First make dict mapping code names of diagnostic and treament centers
         # to actual locations
         hospital_map = {}
-        for centre_type in ['centros_aislamiento', 'centros_diagnostico']:
-            for centre in json_data[centre_type]:
-                hospital_map[centre] = json_data[centre_type][centre]['nombre'] + \
-                    ", " + json_data[centre_type][centre]['provincia']
+        try:
+            for centre_type in ['centros_aislamiento', 'centros_diagnostico']:
+                for centre in json_data[centre_type]:
+                    hospital_map[centre] = json_data[centre_type][centre]['nombre'] + \
+                        ", " + json_data[centre_type][centre]['provincia']
+        except:
+            #key not found
+            pass
 
         # Get schema_version
-        schema_version = json_data['schema-version']
-        if schema_version != 7:
-            logger.warning(
-                f'Schema version has been updated from 7 to {schema_version}')
+        try:
+            schema_version = json_data['schema-version']
+            if schema_version != 7:
+                logger.warning(
+                    f'Schema version has been updated from 7 to {schema_version}')
+        except:
+            schema_version = "(undef)"
 
         for day in json_data['casos']['dias']:
             if 'diagnosticados' in json_data['casos']['dias'][day]:

--- a/ingestion/functions/parsing/cuba/cuba.py
+++ b/ingestion/functions/parsing/cuba/cuba.py
@@ -166,9 +166,8 @@ def parse_cases(raw_data_file, source_id, source_url):
                 for centre in json_data[centre_type]:
                     hospital_map[centre] = json_data[centre_type][centre]['nombre'] + \
                         ", " + json_data[centre_type][centre]['provincia']
-        except:
-            #key not found
-            pass
+        except KeyError:
+            logger.error(f"KeyError in Cuba parser")
 
         # Get schema_version
         try:

--- a/ingestion/functions/parsing/new_zealand/new_zealand.py
+++ b/ingestion/functions/parsing/new_zealand/new_zealand.py
@@ -66,6 +66,8 @@ def convert_demographics(entry):
     if (age := entry[_AGE]) != "NA":
         if '90+' in age:
             demo["ageRange"] = {"start": 90, "end": 120}
+        elif '70+' in age:
+            demo["ageRange"] = {"start": 70, "end": 79}
         else:
             start, end = list(map(int, age.split(' to ')))
             demo["ageRange"] = {"start": start, "end": end}

--- a/ingestion/functions/parsing/new_zealand/new_zealand.py
+++ b/ingestion/functions/parsing/new_zealand/new_zealand.py
@@ -64,10 +64,9 @@ def convert_demographics(entry):
     '''
     demo = {}
     if (age := entry[_AGE]) != "NA":
-        if '90+' in age:
-            demo["ageRange"] = {"start": 90, "end": 120}
-        elif '70+' in age:
-            demo["ageRange"] = {"start": 70, "end": 79}
+        if '+' in age:
+            start = int(age.rstrip('+'))
+            demo["ageRange"] = {"start": start, "end": 120}
         else:
             start, end = list(map(int, age.split(' to ')))
             demo["ageRange"] = {"start": start, "end": end}


### PR DESCRIPTION
The split of the data into covid19-cuba-{1,2,...}.json, as described in issue #2233 is not addressed by the changes here. Any of the  covid19-cuba-{1,2,...}.json files can be parsed by the changes, as well as covid19-cuba-old.json. 