### PR TITLE
#2714 prepare to define full day zero schema

### DIFF
--- a/data-serving/reusable-data-service/data_service/day_zero_fields.json
+++ b/data-serving/reusable-data-service/data_service/day_zero_fields.json
@@ -1,0 +1,32 @@
+[
+    {
+        "key": "_id",
+        "type": "string",
+        "data_dictionary_text": "A unique identifier for this case, in the form of a mongoDB object identifier (24 characters 0-9a-f).",
+        "required": false
+    },
+    {
+        "key": "confirmationDate",
+        "type": "date",
+        "data_dictionary_text": "The date on which the case was confirmed. There will also be a confirmation event but the date is stored denormalised for efficiency.",
+        "required": true
+    },
+    {
+        "key": "caseReference",
+        "type": "CaseReference",
+        "data_dictionary_text": "Information about the source and status of this case.",
+        "required": true
+    },
+    {
+        "key": "caseExclusion",
+        "type": "CaseExclusion",
+        "data_dictionary_text": "If this case is excluded from the line list, information about when and why it was excluded.",
+        "required": false
+    },
+    {
+        "key": "location",
+        "type": "geofeature",
+        "data_dictionary_text": "The location associated with this case.",
+        "required": false
+    }
+]

--- a/data-serving/reusable-data-service/data_service/model/case.py
+++ b/data-serving/reusable-data-service/data_service/model/case.py
@@ -19,6 +19,7 @@ from data_service.util.errors import (
 
 observers = []
 
+
 def make_custom_case_class(name: str, field_models=[]) -> type:
     """Generate a class extending the DayZeroCase class with additional fields.
     field_models is a list of model objects describing the fields for the data dictionary
@@ -66,7 +67,9 @@ def remove_case_class_observer(observer: Callable[[type], None]) -> None:
 def reset_custom_case_fields() -> None:
     """When you want to get back to where you started, for example to load the field definitions from
     storage or if you're writing tests that modify the Case class."""
-    day_zero_field_definitions = json.loads(importlib.resources.read_text('data_service', 'day_zero_fields.json'))
+    day_zero_field_definitions = json.loads(
+        importlib.resources.read_text("data_service", "day_zero_fields.json")
+    )
     day_zero_fields = [Field.from_dict(f) for f in day_zero_field_definitions]
     make_custom_case_class("Case", day_zero_fields)
 

--- a/data-serving/reusable-data-service/data_service/model/case.py
+++ b/data-serving/reusable-data-service/data_service/model/case.py
@@ -1,11 +1,8 @@
 import dataclasses
 import datetime
-import json
-import flask.json
 
 from collections.abc import Callable
 from operator import attrgetter
-from typing import Any, List
 
 from data_service.model.case_exclusion_metadata import CaseExclusionMetadata
 from data_service.model.case_reference import CaseReference
@@ -45,39 +42,9 @@ class DayZeroCase(Document):
 
     custom_fields = []
 
-    @classmethod
-    def from_json(cls, obj: str) -> type:
-        """Create an instance of this class from a JSON representation."""
-        source = json.loads(obj)
-        return cls.from_dict(source)
-
-    @classmethod
-    def from_dict(cls, dictionary: dict[str, Any]) -> type:
-        case = cls()
-        for key in dictionary:
-            if key in cls.date_fields():
-                value = cls.interpret_date(dictionary[key])
-            elif key in cls.location_fields():
-                value = Feature.from_dict(dictionary[key])
-            elif key in cls.document_fields():
-                field_type = cls.field_type_for_key_path(key)
-                dict_description = dictionary[key]
-                value = (field_type.from_dict(dict_description) if dict_description is not None else None)
-            elif key == "_id":
-                the_id = dictionary[key]
-                if isinstance(the_id, dict):
-                    # this came from a BSON objectID representation
-                    value = the_id["$oid"]
-                else:
-                    value = the_id
-            else:
-                value = dictionary[key]
-            setattr(case, key, value)
-        case.validate()
-        return case
-
     def validate(self):
         """Check whether I am consistent. Raise ValidationError if not."""
+        super().validate()
         if not hasattr(self, "confirmationDate"):
             raise ValidationError("Confirmation Date is mandatory")
         elif self.confirmationDate is None:

--- a/data-serving/reusable-data-service/data_service/model/case.py
+++ b/data-serving/reusable-data-service/data_service/model/case.py
@@ -59,18 +59,10 @@ class DayZeroCase(Document):
                 value = cls.interpret_date(dictionary[key])
             elif key in cls.location_fields():
                 value = Feature.from_dict(dictionary[key])
-            elif key == "caseReference":
-                caseRef = dictionary[key]
-                value = (
-                    CaseReference.from_dict(caseRef) if caseRef is not None else None
-                )
-            elif key == "caseExclusion":
-                exclusion = dictionary[key]
-                value = (
-                    CaseExclusionMetadata.from_dict(exclusion)
-                    if exclusion is not None
-                    else None
-                )
+            elif key in cls.document_fields():
+                field_type = cls.field_type_for_key_path(key)
+                dict_description = dictionary[key]
+                value = (field_type.from_dict(dict_description) if dict_description is not None else None)
             elif key == "_id":
                 the_id = dictionary[key]
                 if isinstance(the_id, dict):

--- a/data-serving/reusable-data-service/data_service/model/case_reference.py
+++ b/data-serving/reusable-data-service/data_service/model/case_reference.py
@@ -14,6 +14,7 @@ class CaseReference(Document):
 
     def validate(self):
         """Check whether I am consistent. Raise ValueError if not."""
+        super().validate()
         if not hasattr(self, "sourceId"):
             raise ValueError("Source ID is mandatory")
         elif self.sourceId is None:

--- a/data-serving/reusable-data-service/data_service/model/document.py
+++ b/data-serving/reusable-data-service/data_service/model/document.py
@@ -180,13 +180,6 @@ class Document:
                     if dict_description is not None
                     else None
                 )
-            elif key == "_id":
-                the_id = dictionary[key]
-                if isinstance(the_id, dict):
-                    # this came from a BSON objectID representation
-                    value = the_id["$oid"]
-                else:
-                    value = the_id
             else:
                 value = dictionary[key]
             setattr(doc, key, value)

--- a/data-serving/reusable-data-service/data_service/model/document.py
+++ b/data-serving/reusable-data-service/data_service/model/document.py
@@ -35,7 +35,7 @@ class Document:
 
     @classmethod
     def fields_of_class(cls, a_class: type) -> list[str]:
-        return [f.name for f in dataclasses.fields(cls) if f.type == a_class]
+        return [f.name for f in dataclasses.fields(cls) if issubclass(f.type, a_class)]
 
     @staticmethod
     def interpret_date(maybe_date) -> datetime.date:

--- a/data-serving/reusable-data-service/data_service/model/document.py
+++ b/data-serving/reusable-data-service/data_service/model/document.py
@@ -18,6 +18,7 @@ from typing import Any, List
 @dataclasses.dataclass
 class Document:
     """The base class for anything that's going into the database."""
+
     custom_fields = []
 
     def to_dict(self):

--- a/data-serving/reusable-data-service/data_service/model/document.py
+++ b/data-serving/reusable-data-service/data_service/model/document.py
@@ -34,6 +34,10 @@ class Document:
         return cls.fields_of_class(Feature)
 
     @classmethod
+    def document_fields(cls) -> list[str]:
+        return cls.fields_of_class(Document)
+
+    @classmethod
     def fields_of_class(cls, a_class: type) -> list[str]:
         return [f.name for f in dataclasses.fields(cls) if issubclass(f.type, a_class)]
 

--- a/data-serving/reusable-data-service/data_service/model/field.py
+++ b/data-serving/reusable-data-service/data_service/model/field.py
@@ -30,7 +30,7 @@ class Field(Document):
         INTEGER: int,
         LOCATION: Feature,
         "CaseReference": CaseReference,
-        "CaseExclusion": CaseExclusionMetadata
+        "CaseExclusion": CaseExclusionMetadata,
     }
     acceptable_types = type_map.keys()
 
@@ -44,11 +44,11 @@ class Field(Document):
     @classmethod
     def from_dict(cls, dictionary):
         return cls(
-            dictionary.get('key'),
-            dictionary.get('type'),
-            dictionary.get('data_dictionary_text'),
-            dictionary.get('required'),
-            dictionary.get('default', None)
+            dictionary.get("key"),
+            dictionary.get("type"),
+            dictionary.get("data_dictionary_text"),
+            dictionary.get("required"),
+            dictionary.get("default", None),
         )
 
     def python_type(self) -> type:

--- a/data-serving/reusable-data-service/data_service/model/field.py
+++ b/data-serving/reusable-data-service/data_service/model/field.py
@@ -2,7 +2,10 @@ import dataclasses
 from datetime import date
 from typing import Optional, Union
 
+from data_service.model.case_exclusion_metadata import CaseExclusionMetadata
+from data_service.model.case_reference import CaseReference
 from data_service.model.document import Document
+from data_service.model.geojson import Feature
 from data_service.util.errors import PreconditionUnsatisfiedError
 
 
@@ -20,7 +23,15 @@ class Field(Document):
     STRING = "string"
     DATE = "date"
     INTEGER = "integer"
-    type_map = {STRING: str, DATE: date, INTEGER: int}
+    LOCATION = "geofeature"
+    type_map = {
+        STRING: str,
+        DATE: date,
+        INTEGER: int,
+        LOCATION: Feature,
+        "CaseReference": CaseReference,
+        "CaseExclusion": CaseExclusionMetadata
+    }
     acceptable_types = type_map.keys()
 
     @classmethod
@@ -29,6 +40,16 @@ class Field(Document):
             return cls.type_map[name]
         except KeyError:
             raise PreconditionUnsatisfiedError(f"cannot use type {name} in a Field")
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        return cls(
+            dictionary.get('key'),
+            dictionary.get('type'),
+            dictionary.get('data_dictionary_text'),
+            dictionary.get('required'),
+            dictionary.get('default', None)
+        )
 
     def python_type(self) -> type:
         return self.model_type(self.type)

--- a/data-serving/reusable-data-service/data_service/model/geojson.py
+++ b/data-serving/reusable-data-service/data_service/model/geojson.py
@@ -101,7 +101,6 @@ class Feature:
     @classmethod
     def custom_none_field_values(cls) -> List[str]:
         """Provide an application-specific report of this class's fields and values for CSV export."""
-        print("Asked for None values")
         return [""] * len(cls.field_getters)
 
     def custom_field_values(self) -> List[str]:

--- a/data-serving/reusable-data-service/data_service/stores/mongo_store.py
+++ b/data-serving/reusable-data-service/data_service/stores/mongo_store.py
@@ -194,7 +194,10 @@ class MongoStore:
     @staticmethod
     def case_model_iterator(mongo_iterator):
         """Turn an iterator of mongo results into an iterator of cases."""
-        return map(lambda c: Case.from_dict(MongoStore.mongo_document_to_json(c)), mongo_iterator)
+        return map(
+            lambda c: Case.from_dict(MongoStore.mongo_document_to_json(c)),
+            mongo_iterator,
+        )
 
     @staticmethod
     def setup():
@@ -241,7 +244,6 @@ class MongoStore:
         if isinstance(the_id, dict):
             dictionary["_id"] = the_id["$oid"]
         return dictionary
-
 
     @staticmethod
     def case_exclusion_to_bson_compatible_dict(exclusion: CaseExclusionMetadata):

--- a/data-serving/reusable-data-service/tests/test_case_controller_crud_actions.py
+++ b/data-serving/reusable-data-service/tests/test_case_controller_crud_actions.py
@@ -182,7 +182,7 @@ def test_batch_upsert_reports_errors(case_controller):
     response = case_controller.batch_upsert({"cases": [{}]})
     assert response.numCreated == 0
     assert response.numUpdated == 0
-    assert response.errors == {"0": "Confirmation Date is mandatory"}
+    assert response.errors == {"0": "confirmationDate must have a value"}
 
 
 def test_download_with_no_query_is_ok(case_controller):


### PR DESCRIPTION
In this branch:

- all document validation is made generic (i.e. no field names/types are assumed in the validation logic) and pushed up to the Document class.
- all fields are defined using the `Field` model, including those on the day zero schema.
- `DayZeroCase` class is removed as these fields can be added directly to the `Case` class.
- JSON file defining the day zero data dictionary.

With these changes in place, we can easily implement the day zero data dictionary by editing the JSON file.