### PR TITLE
#2714 list fields

### DIFF
--- a/data-serving/reusable-data-service/data_service/controller/schema_controller.py
+++ b/data-serving/reusable-data-service/data_service/controller/schema_controller.py
@@ -34,6 +34,7 @@ class SchemaController:
                 field.required,
                 field.default,
                 field.values,
+                field.is_list,
                 False,
             )
 
@@ -45,6 +46,7 @@ class SchemaController:
         required: bool = False,
         default: Optional[Union[bool, str, int, date]] = None,
         values: Optional[List[Any]] = None,
+        is_list: bool = False,
         store_field: bool = True,
     ):
         global Case
@@ -63,7 +65,9 @@ class SchemaController:
         If a field is required, set required = True. You must also set a default value so that
         existing cases have an initial setting for the field."""
         required = required if required is not None else False
-        field_model = Field(name, type_name, description, required, default, values)
+        field_model = Field(
+            name, type_name, description, required, default, values, is_list
+        )
         add_field_to_case_class(field_model)
         if store_field:
             self.store.add_field(field_model)

--- a/data-serving/reusable-data-service/data_service/day_zero_fields.json
+++ b/data-serving/reusable-data-service/data_service/day_zero_fields.json
@@ -69,6 +69,31 @@
         "is_list": true
     },
     {
+        "key": "race",
+        "type": "string",
+        "data_dictionary_text": "Race of the individual; can select multiple options.",
+        "required": true,
+        "values": [
+            "Native Hawaiian or Other Pacific Islander",
+            "Asian",
+            "American Indian or Alaska Native",
+            "Black or African American",
+            "White",
+            "other"
+        ],
+        "is_list": true
+    },
+    {
+        "key": "ethnicity",
+        "type": "string",
+        "data_dictionary_text": "Ethnicity of the individual, per the U.S. census definition.",
+        "values": [
+            "Hispanic or Latino",
+            "Not Hispanic or Latino",
+            "other"
+        ]
+    },
+    {
         "key": "confirmationDate",
         "type": "date",
         "data_dictionary_text": "The date on which the case was confirmed. There will also be a confirmation event but the date is stored denormalised for efficiency.",

--- a/data-serving/reusable-data-service/data_service/day_zero_fields.json
+++ b/data-serving/reusable-data-service/data_service/day_zero_fields.json
@@ -54,6 +54,21 @@
         ]
     },
     {
+        "key": "gender",
+        "type": "string",
+        "data_dictionary_text": "Gender identity of the individual; can select multiple options.",
+        "required": true,
+        "values": [
+            "man",
+            "woman",
+            "transgender",
+            "non-binary",
+            "other",
+            "unknown"
+        ],
+        "is_list": true
+    },
+    {
         "key": "confirmationDate",
         "type": "date",
         "data_dictionary_text": "The date on which the case was confirmed. There will also be a confirmation event but the date is stored denormalised for efficiency.",

--- a/data-serving/reusable-data-service/data_service/main.py
+++ b/data-serving/reusable-data-service/data_service/main.py
@@ -164,6 +164,7 @@ def add_field_to_case_schema():
             req.get("required"),
             req.get("default"),
             req.get("values"),
+            req.get("is_list"),
         )
         return "", 201
     except WebApplicationError as e:

--- a/data-serving/reusable-data-service/data_service/model/document.py
+++ b/data-serving/reusable-data-service/data_service/model/document.py
@@ -127,6 +127,8 @@ class Document:
                     fields += value.custom_field_values()
                 else:
                     fields += f.type.custom_none_field_values()
+            elif issubclass(f.type, list):
+                fields.append(",".join(value))
             else:
                 fields.append(str(value) if value is not None else "")
         return fields

--- a/data-serving/reusable-data-service/data_service/model/field.py
+++ b/data-serving/reusable-data-service/data_service/model/field.py
@@ -12,13 +12,16 @@ from data_service.util.errors import PreconditionUnsatisfiedError
 
 @dataclasses.dataclass
 class Field(Document):
-    """Represents a custom field in a Document object."""
+    """Represents a custom field in a Document object.
+    Note for future architects: I learned today that dataclasses fields can carry
+    custom metadata. It might make sense to reorganise things so that information
+    currently in the Field class is carried in that metadata instead."""
 
     key: str = dataclasses.field(init=True, default=None)
     type: str = dataclasses.field(init=True, default=None)
     data_dictionary_text: str = dataclasses.field(init=True, default=None)
     required: bool = dataclasses.field(init=True, default=False)
-    default: Optional[Union[bool, str, int, date]] = dataclasses.field(
+    default: Optional[Union[bool, str, int, date, Feature, AgeRange, CaseReference, CaseExclusionMetadata]] = dataclasses.field(
         init=True, default=None
     )
     values: Optional[List[Any]] = dataclasses.field(init=True, default=None)
@@ -63,7 +66,10 @@ class Field(Document):
         if self.is_list:
             return list
         else:
-            return self.model_type(self.type)
+            return self.element_type()
+    
+    def element_type(self) -> type:
+        return self.model_type(self.type)
 
     def dataclasses_tuples(self):
         # Note that the default value here is always None, even if I have a default value!

--- a/data-serving/reusable-data-service/data_service/model/field.py
+++ b/data-serving/reusable-data-service/data_service/model/field.py
@@ -22,6 +22,7 @@ class Field(Document):
         init=True, default=None
     )
     values: Optional[List[Any]] = dataclasses.field(init=True, default=None)
+    is_list: bool = dataclasses.field(init=True, default=False)
 
     STRING = "string"
     DATE = "date"
@@ -55,10 +56,14 @@ class Field(Document):
             dictionary.get("required"),
             dictionary.get("default", None),
             dictionary.get("values", None),
+            dictionary.get("is_list", False),
         )
 
     def python_type(self) -> type:
-        return self.model_type(self.type)
+        if self.is_list:
+            return list
+        else:
+            return self.model_type(self.type)
 
     def dataclasses_tuples(self):
         # Note that the default value here is always None, even if I have a default value!

--- a/data-serving/reusable-data-service/data_service/stores/mongo_store.py
+++ b/data-serving/reusable-data-service/data_service/stores/mongo_store.py
@@ -267,6 +267,7 @@ class MongoStore:
                 doc["data_dictionary_text"],
                 doc["required"],
                 doc["default"],
+                doc["is_list"],
             )
             for doc in self.get_schema_collection().find({})
         ]

--- a/data-serving/reusable-data-service/tests/data/case.excluded.json
+++ b/data-serving/reusable-data-service/tests/data/case.excluded.json
@@ -10,5 +10,6 @@
     "caseStatus": "omit_error",
     "pathogenStatus": "endemic",
     "sexAtBirth": "female",
-    "gender": ["woman"]
+    "gender": ["woman"],
+    "race": ["White"]
 }

--- a/data-serving/reusable-data-service/tests/data/case.excluded.json
+++ b/data-serving/reusable-data-service/tests/data/case.excluded.json
@@ -9,5 +9,6 @@
     },
     "caseStatus": "omit_error",
     "pathogenStatus": "endemic",
-    "sexAtBirth": "female"
+    "sexAtBirth": "female",
+    "gender": ["woman"]
 }

--- a/data-serving/reusable-data-service/tests/data/case.minimal.json
+++ b/data-serving/reusable-data-service/tests/data/case.minimal.json
@@ -6,5 +6,6 @@
     "caseStatus": "probable",
     "pathogenStatus": "emerging",
     "sexAtBirth": "female",
-    "gender": []
+    "gender": [],
+    "race": []
 }

--- a/data-serving/reusable-data-service/tests/data/case.minimal.json
+++ b/data-serving/reusable-data-service/tests/data/case.minimal.json
@@ -5,5 +5,6 @@
     },
     "caseStatus": "probable",
     "pathogenStatus": "emerging",
-    "sexAtBirth": "female"
+    "sexAtBirth": "female",
+    "gender": []
 }

--- a/data-serving/reusable-data-service/tests/data/case.with_location.json
+++ b/data-serving/reusable-data-service/tests/data/case.with_location.json
@@ -20,5 +20,6 @@
     "pathogenStatus": "unknown",
     "sexAtBirth": "female",
     "gender": ["non-binary", "other"],
-    "gender_other": "womxn"
+    "gender_other": "womxn",
+    "race": []
 }

--- a/data-serving/reusable-data-service/tests/data/case.with_location.json
+++ b/data-serving/reusable-data-service/tests/data/case.with_location.json
@@ -18,5 +18,7 @@
     },
     "caseStatus": "probable",
     "pathogenStatus": "unknown",
-    "sexAtBirth": "female"
+    "sexAtBirth": "female",
+    "gender": ["non-binary", "other"],
+    "gender_other": "womxn"
 }

--- a/data-serving/reusable-data-service/tests/test_case_model.py
+++ b/data-serving/reusable-data-service/tests/test_case_model.py
@@ -86,3 +86,19 @@ def test_apply_update_that_unsets_value():
     update = DocumentUpdate.from_dict({"confirmationDate": None})
     case.apply_update(update)
     assert case.confirmationDate is None
+
+
+def test_cannot_put_wrong_type_in_list():
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        case = Case.from_json(minimal_file.read())
+    case.gender = ["man", True]
+    with pytest.raises(ValidationError):
+        case.validate()
+
+
+def test_list_elements_must_come_from_acceptable_values():
+    with open("./tests/data/case.minimal.json", "r") as minimal_file:
+        case = Case.from_json(minimal_file.read())
+    case.gender = ["woman", "dalek"]
+    with pytest.raises(ValidationError):
+        case.validate()


### PR DESCRIPTION
This adds fields where you can supply multiple values (either from a list or free entry). Some observations:

1. in CSV/TSV download, the list is stored in a single field as a comma-separated string (`csv` gets the escaping correct in the downloaded file).
2. the interaction between a field being required and a list field currently means that the _list_ is required (but can be empty). The other interpretation would be that the list is required to contain something. There isn't really enough guidance in the [schema document](https://docs.google.com/document/d/1GpR0Sqkj3iGXAull9PL1pOHzJbyOAHPG8yxyt-OdPqs/edit) to make a call either way on this, or on whether any field is required.
3. I discovered today that you can attach custom metadata to a `dataclasses.Field` and that's probably a better idea for the `Document` class than carrying around a separate collection of `data_service.model.field.Field` objects. That said, I won't have time now to make that change: I document it as a gift to any future bored developer :).