### PR TITLE
#2783 limit number of failed login and reset password requests

### DIFF
--- a/verification/curator-service/api/package-lock.json
+++ b/verification/curator-service/api/package-lock.json
@@ -22,6 +22,7 @@
         "envalid": "^7.2.2",
         "express": "^4.17.1",
         "express-openapi-validator": "^4.9.0",
+        "express-rate-limit": "^6.5.1",
         "express-session": "^1.17.1",
         "express-winston": "^4.2.0",
         "i18n-iso-countries": "^7.3.0",
@@ -4187,6 +4188,17 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.5.1.tgz",
+      "integrity": "sha512-pxO6ioBLd3i8IHL+RmJtL4noYzte5fugoMdaDabtU4hcg53+x0QkTwfPtM7vWD0YUaXQgNj9NRdzmps+CHEHlA==",
+      "engines": {
+        "node": ">= 12.9.0"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
+      }
     },
     "node_modules/express-session": {
       "version": "1.17.2",
@@ -13368,6 +13380,12 @@
           "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
         }
       }
+    },
+    "express-rate-limit": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.5.1.tgz",
+      "integrity": "sha512-pxO6ioBLd3i8IHL+RmJtL4noYzte5fugoMdaDabtU4hcg53+x0QkTwfPtM7vWD0YUaXQgNj9NRdzmps+CHEHlA==",
+      "requires": {}
     },
     "express-session": {
       "version": "1.17.2",

--- a/verification/curator-service/api/package.json
+++ b/verification/curator-service/api/package.json
@@ -77,6 +77,7 @@
     "envalid": "^7.2.2",
     "express": "^4.17.1",
     "express-openapi-validator": "^4.9.0",
+    "express-rate-limit": "^6.5.1",
     "express-session": "^1.17.1",
     "express-winston": "^4.2.0",
     "i18n-iso-countries": "^7.3.0",

--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -502,7 +502,7 @@ export class AuthController {
 
                     updateFailedAttempts(
                         user._id,
-                        AttemptName.ResetPassword,
+                        AttemptName.ForgotPassword,
                         attemptsNumber,
                     );
 
@@ -606,7 +606,7 @@ export class AuthController {
                     if (!passwordResetToken) {
                         updateFailedAttempts(
                             userId,
-                            AttemptName.ForgotPassword,
+                            AttemptName.ResetPasswordWithToken,
                             attemptsNumber,
                         );
                         throw new Error(
@@ -622,7 +622,7 @@ export class AuthController {
                     if (!isValid) {
                         updateFailedAttempts(
                             userId,
-                            AttemptName.ForgotPassword,
+                            AttemptName.ResetPasswordWithToken,
                             attemptsNumber,
                         );
                         throw new Error(
@@ -651,7 +651,11 @@ export class AuthController {
                     // Send confirmation email to the user
                     const user = result.value as IUser;
 
-                    updateFailedAttempts(userId, AttemptName.ForgotPassword, 0);
+                    updateFailedAttempts(
+                        userId,
+                        AttemptName.ResetPasswordWithToken,
+                        0,
+                    );
 
                     await this.emailClient.send(
                         [user.email],

--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -26,7 +26,7 @@ import { baseURL, welcomeEmail } from '../util/instance-details';
 import {
     setupFailedAttempts,
     handleCheckFailedAttempts,
-    attemptName,
+    AttemptName,
     updateFailedAttempts,
 } from '../model/failed_attempts';
 import {
@@ -418,7 +418,7 @@ export class AuthController {
                     const { success, attemptsNumber } =
                         await handleCheckFailedAttempts(
                             currentUser._id,
-                            attemptName.ResetPassword,
+                            AttemptName.ResetPassword,
                         );
 
                     if (!success)
@@ -435,7 +435,7 @@ export class AuthController {
                     if (!isValidPassword) {
                         updateFailedAttempts(
                             currentUser._id,
-                            attemptName.ResetPassword,
+                            AttemptName.ResetPassword,
                             attemptsNumber,
                         );
 
@@ -446,7 +446,7 @@ export class AuthController {
 
                     updateFailedAttempts(
                         currentUser._id,
-                        attemptName.ResetPassword,
+                        AttemptName.ResetPassword,
                         0,
                     );
 
@@ -490,7 +490,7 @@ export class AuthController {
                     const { success, attemptsNumber } =
                         await handleCheckFailedAttempts(
                             user._id,
-                            attemptName.ForgotPassword,
+                            AttemptName.ForgotPassword,
                         );
 
                     if (!success) {
@@ -502,7 +502,7 @@ export class AuthController {
 
                     updateFailedAttempts(
                         user._id,
-                        attemptName.ResetPassword,
+                        AttemptName.ResetPassword,
                         attemptsNumber,
                     );
 
@@ -590,7 +590,7 @@ export class AuthController {
                     const { success, attemptsNumber } =
                         await handleCheckFailedAttempts(
                             userId,
-                            attemptName.ResetPasswordWithToken,
+                            AttemptName.ResetPasswordWithToken,
                         );
 
                     if (!success)
@@ -606,7 +606,7 @@ export class AuthController {
                     if (!passwordResetToken) {
                         updateFailedAttempts(
                             userId,
-                            attemptName.ForgotPassword,
+                            AttemptName.ForgotPassword,
                             attemptsNumber,
                         );
                         throw new Error(
@@ -622,7 +622,7 @@ export class AuthController {
                     if (!isValid) {
                         updateFailedAttempts(
                             userId,
-                            attemptName.ForgotPassword,
+                            AttemptName.ForgotPassword,
                             attemptsNumber,
                         );
                         throw new Error(
@@ -651,7 +651,7 @@ export class AuthController {
                     // Send confirmation email to the user
                     const user = result.value as IUser;
 
-                    updateFailedAttempts(userId, attemptName.ForgotPassword, 0);
+                    updateFailedAttempts(userId, AttemptName.ForgotPassword, 0);
 
                     await this.emailClient.send(
                         [user.email],
@@ -833,7 +833,7 @@ export class AuthController {
                         const { success, attemptsNumber } =
                             await handleCheckFailedAttempts(
                                 user._id,
-                                attemptName.Login,
+                                AttemptName.Login,
                             );
 
                         if (!success)
@@ -854,7 +854,7 @@ export class AuthController {
                         if (!isValidPassword) {
                             updateFailedAttempts(
                                 user._id,
-                                attemptName.Login,
+                                AttemptName.Login,
                                 attemptsNumber,
                             );
 
@@ -863,7 +863,7 @@ export class AuthController {
                             });
                         }
 
-                        updateFailedAttempts(user._id, attemptName.Login, 0);
+                        updateFailedAttempts(user._id, AttemptName.Login, 0);
                         done(null, user);
                     } catch (error) {
                         done(error);

--- a/verification/curator-service/api/src/model/failed_attempts.ts
+++ b/verification/curator-service/api/src/model/failed_attempts.ts
@@ -1,0 +1,88 @@
+import { Collection, ObjectId } from 'mongodb';
+import db from './database';
+
+/*
+ * This is a minimal case schema to support some source-related behaviour.
+ * The full schema for cases is in the data service.
+ */
+
+const maxNumberOfFailedLogins = 8;
+const timeWindowForFailedLogins = 60; //min
+
+type attemptName = 'loginAttempt' | 'registerAttempt' | 'resetPasswordAttempt';
+
+export type IfailedAttempts = {
+    _id: ObjectId;
+    userId: ObjectId;
+    loginAttempt: {
+        count: number;
+        createdAt: Date;
+    };
+    registerAttempt: {
+        count: number;
+        createdAt: Date;
+    };
+    resetPasswordAttempt: {
+        count: number;
+        createdAt: Date;
+    };
+};
+
+export const failed_attempts = () =>
+    db().collection('failed_attempts') as Collection<IfailedAttempts>;
+
+export const setupFailedAttempts = async (userId: ObjectId) => {
+    await failed_attempts().insertOne({
+        _id: new ObjectId(),
+        userId: userId,
+        loginAttempt: {
+            count: 0,
+            createdAt: new Date(),
+        },
+        registerAttempt: {
+            count: 0,
+            createdAt: new Date(),
+        },
+        resetPasswordAttempt: {
+            count: 0,
+            createdAt: new Date(),
+        },
+    });
+};
+
+export const handleCheckFailedAttempts = async (
+    userId: ObjectId,
+    attemptName: attemptName,
+) => {
+    const attempts = (await failed_attempts().findOne({
+        userId: userId,
+    })) as IfailedAttempts;
+
+    let attemptsNumber = attempts[attemptName].count + 1;
+
+    const diffTimeMin =
+        Math.floor(
+            Math.abs(Date.now() - attempts[attemptName].createdAt.getTime()) /
+                1000,
+        ) / 60;
+
+    if (diffTimeMin >= timeWindowForFailedLogins) attemptsNumber = 1;
+
+    if (attemptsNumber > maxNumberOfFailedLogins) {
+        await failed_attempts().updateOne(
+            { userId: userId },
+            {
+                $set: {
+                    [attemptName]: {
+                        count: attemptsNumber,
+                        createdAt: new Date(),
+                    },
+                },
+            },
+        );
+
+        return { success: false, attemptsNumber };
+    }
+
+    return { success: true, attemptsNumber };
+};

--- a/verification/curator-service/api/src/model/failed_attempts.ts
+++ b/verification/curator-service/api/src/model/failed_attempts.ts
@@ -20,7 +20,7 @@ const numberTimeLimiters = {
     },
 };
 
-export enum attemptName {
+export enum AttemptName {
     Login = 'loginAttempt',
     ResetPassword = 'resetPasswordAttempt',
     ForgotPassword = 'forgotPasswordAttempt',
@@ -76,7 +76,7 @@ export const setupFailedAttempts = async (userId: ObjectId) => {
 
 export const handleCheckFailedAttempts = async (
     userId: ObjectId,
-    attemptName: attemptName,
+    attemptName: AttemptName,
 ) => {
     let attempts = await failedAttempts().findOne({
         userId,
@@ -112,7 +112,7 @@ export const handleCheckFailedAttempts = async (
 
 export const updateFailedAttempts = async (
     userId: ObjectId,
-    attemptName: attemptName,
+    attemptName: AttemptName,
     attemptsNumber: number,
 ) => {
     await failedAttempts().updateOne(

--- a/verification/curator-service/api/src/model/failed_attempts.ts
+++ b/verification/curator-service/api/src/model/failed_attempts.ts
@@ -4,19 +4,19 @@ import db from './database';
 const numberTimeLimiters = {
     loginAttempt: {
         maxNumberOfFailedLogins: 8,
-        timeWindowForFailedLogins: 60, //min
+        timeWindowForFailedLoginsMinutes: 60,
     },
     resetPasswordAttempt: {
         maxNumberOfFailedLogins: 8,
-        timeWindowForFailedLogins: 60,
+        timeWindowForFailedLoginsMinutes: 60,
     },
     forgotPasswordAttempt: {
         maxNumberOfFailedLogins: 8,
-        timeWindowForFailedLogins: 60,
+        timeWindowForFailedLoginsMinutes: 60,
     },
     resetPasswordWithTokenAttempt: {
         maxNumberOfFailedLogins: 8,
-        timeWindowForFailedLogins: 60,
+        timeWindowForFailedLoginsMinutes: 60,
     },
 };
 
@@ -98,7 +98,8 @@ export const handleCheckFailedAttempts = async (
         ) / 60;
 
     if (
-        diffTimeMin >= numberTimeLimiters[attemptName].timeWindowForFailedLogins
+        diffTimeMin >=
+        numberTimeLimiters[attemptName].timeWindowForFailedLoginsMinutes
     )
         attemptsNumber = 1;
 

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -7,8 +7,7 @@ export const loginLimiter = rateLimit({
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
     handler: function (req, res /*next*/) {
         return res.status(429).json({
-            message:
-                'You sent too many requests. Please wait a while then try again',
+            message: 'Too many failed login attempts, please try again later',
         });
     },
 });
@@ -28,7 +27,33 @@ export const registerLimiter = rateLimit({
 
 export const resetPasswordLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 60 minutes
-    max: 3,
+    max: 4,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: function (req, res) {
+        return res.status(429).json({
+            message:
+                'You sent too many requests. Please wait a while then try again',
+        });
+    },
+});
+
+export const forgotPasswordLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 60 minutes
+    max: 4,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: function (req, res) {
+        return res.status(429).json({
+            message:
+                'You sent too many requests. Please wait a while then try again',
+        });
+    },
+});
+
+export const resetPasswordWithTokenLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 60 minutes
+    max: 4,
     standardHeaders: true,
     legacyHeaders: false,
     handler: function (req, res) {

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -1,7 +1,7 @@
 import rateLimit from 'express-rate-limit';
 
 export const loginLimiter = rateLimit({
-    windowMs: 20 * 60 * 1000, // 20 minutes
+    windowMs: 60 * 60 * 1000, // 60 minutes
     max: 4, // Limit each IP to 4 requests per `window` (here, per 20 minutes)
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
@@ -26,7 +26,7 @@ export const registerLimiter = rateLimit({
 });
 
 export const resetPasswordLimiter = rateLimit({
-    windowMs: 30 * 60 * 1000, // 30 minutes
+    windowMs: 60 * 60 * 1000, // 60 minutes
     max: 4,
     standardHeaders: true,
     legacyHeaders: false,

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -1,0 +1,40 @@
+import rateLimit from 'express-rate-limit';
+
+export const loginLimiter = rateLimit({
+    windowMs: 20 * 60 * 1000, // 20 minutes
+    max: 4, // Limit each IP to 4 requests per `window` (here, per 20 minutes)
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    handler: function (req, res /*next*/) {
+        return res.status(429).json({
+            message:
+                'You sent too many requests. Please wait a while then try again',
+        });
+    },
+});
+
+export const registerLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 60 minutes
+    max: 4,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: function (req, res) {
+        return res.status(429).json({
+            message:
+                'You sent too many requests. Please wait a while then try again',
+        });
+    },
+});
+
+export const resetPasswordLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000, // 60 minutes
+    max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: function (req, res) {
+        return res.status(429).json({
+            message:
+                'You sent too many requests. Please wait a while then try again',
+        });
+    },
+});

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -26,7 +26,7 @@ export const registerLimiter = rateLimit({
 });
 
 export const resetPasswordLimiter = rateLimit({
-    windowMs: 60 * 60 * 1000, // 60 minutes
+    windowMs: 30 * 60 * 1000, // 30 minutes
     max: 4,
     standardHeaders: true,
     legacyHeaders: false,

--- a/verification/curator-service/ui/.gitignore
+++ b/verification/curator-service/ui/.gitignore
@@ -1,6 +1,7 @@
 # Env files
 .env
 .env.staging
+.env.development
 
 # Don't include CSVs, except for Cypress fixtures.
 *.csv

--- a/verification/curator-service/ui/cypress/integration/components/LandingPage.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LandingPage.spec.ts
@@ -53,6 +53,18 @@ describe('LandingPage', function () {
         cy.get('#password').type('tT$5');
         cy.get('button[data-testid="sign-up-button"]').click();
         cy.contains(/Minimum 8 characters required/i);
+
+        //check score 1 strength of password
+        cy.get('#password').focus().clear();
+        cy.get('#password').type('Tt1ttttt');
+        cy.get('button[data-testid="sign-up-button"]').click();
+        cy.contains(/Password too weak/i);
+
+        //check score 2 strength of password
+        cy.get('#password').focus().clear();
+        cy.get('#password').type('tT$5aaaaa');
+        cy.get('button[data-testid="sign-up-button"]').click();
+        cy.contains(/Password too weak/i);
     });
 
     it('Validates emails', function () {
@@ -123,6 +135,18 @@ describe('LandingPage', function () {
         cy.get('#password').type('tT$5');
         cy.get('button[data-testid="change-password-button"]').click();
         cy.contains('Minimum 8 characters required!');
+
+        //check score 1 strength of password
+        cy.get('#password').focus().clear();
+        cy.get('#password').type('Tt1ttttt');
+        cy.get('button[data-testid="change-password-button"]').click();
+        cy.contains('Password too weak');
+
+        //check score 2 strength of password
+        cy.get('#password').focus().clear();
+        cy.get('#password').type('tT$5aaaaa');
+        cy.get('button[data-testid="change-password-button"]').click();
+        cy.contains('Password too weak');
     });
 
     it('Homepage with logged out user', function () {
@@ -185,5 +209,28 @@ describe('LandingPage', function () {
         cy.contains('Uploads');
         cy.contains('Manage users').should('not.exist');
         cy.contains('Terms of use');
+    });
+
+    it('Limit number of requests to register and login ', function () {
+        cy.visit('/');
+        cy.get('#email').type('test@example.com');
+        cy.get('#confirmEmail').type('test@example.com');
+        cy.get('#password').type('tT$5aaaaak');
+        cy.get('#passwordConfirmation').type('tT$5aaaaak');
+        cy.get('#isAgreementChecked').check();
+        for (let i = 0; i < 5; i++) {
+            cy.get('button[data-testid="sign-up-button"]').click();
+        }
+        cy.contains(
+            /You sent too many requests. Please wait a while then try again/i,
+        );
+
+        cy.contains('Sign in!').click();
+        cy.get('#email').type('test@example.com');
+        cy.get('#password').type('test');
+        for (let i = 0; i < 5; i++) {
+            cy.get('button[data-testid="sign-in-button"]').click();
+        }
+        cy.contains(/Too many failed login attempts, please try again later/i);
     });
 });

--- a/verification/curator-service/ui/cypress/integration/components/ProfileTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/ProfileTest.spec.ts
@@ -20,10 +20,12 @@ describe('Profile', function () {
             email: 'alice@test.com',
             roles: ['curator'],
         });
-        cy.visit('/')
+        cy.visit('/');
         cy.visit('/profile');
 
-        cy.get('[data-testid="change-your-password-title"]').should('not.exist');
+        cy.get('[data-testid="change-your-password-title"]').should(
+            'not.exist',
+        );
     });
 
     it('Checks if the change pass form validation works well', function () {
@@ -52,6 +54,18 @@ describe('Profile', function () {
         cy.get('#password').type('tT$5');
         cy.get('button[data-testid="change-password-button"]').click();
         cy.contains('Minimum 8 characters required!');
+
+        //check score 1 strength of password
+        cy.get('#password').focus().clear();
+        cy.get('#password').type('Tt1ttttt');
+        cy.get('button[data-testid="change-password-button"]').click();
+        cy.contains('Password too weak');
+
+        //check score 2 strength of password
+        cy.get('#password').focus().clear();
+        cy.get('#password').type('tT$5aaaaa');
+        cy.get('button[data-testid="change-password-button"]').click();
+        cy.contains('Password too weak');
     });
 
     it('Checks if the validates the repeated password', function () {

--- a/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/UsersTest.spec.ts
@@ -11,7 +11,7 @@ describe('Manage users page', function () {
             roles: ['curator'],
         });
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
-        cy.visit('/')
+        cy.visit('/');
         cy.visit('/users');
 
         cy.contains('Alice');
@@ -33,8 +33,8 @@ describe('Manage users page', function () {
             roles: ['curator'],
         });
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
-        cy.visit('/')
-        cy.visit('/users')
+        cy.visit('/');
+        cy.visit('/users');
         cy.contains('Bob');
         cy.get('div[data-testid="Bob-select-roles"]').contains('curator');
         cy.get('div[data-testid="Bob-select-roles"]')
@@ -60,7 +60,7 @@ describe('Manage users page', function () {
             .should('not.exist');
 
         // Roles are maintained on refresh
-        cy.visit('/')
+        cy.visit('/');
         cy.visit('/users');
         cy.get('div[data-testid="Bob-select-roles"]').contains('admin');
         cy.get('div[data-testid="Bob-select-roles"]')
@@ -70,7 +70,7 @@ describe('Manage users page', function () {
 
     it('Updated roles propagate to other pages', function () {
         cy.login({ name: 'Alice', email: 'alice@test.com', roles: ['admin'] });
-        cy.visit('/')
+        cy.visit('/');
         cy.visit('/users');
 
         // Select new role
@@ -85,7 +85,7 @@ describe('Manage users page', function () {
         cy.contains('Line list');
 
         // Profile page is updated
-        cy.visit('/')
+        cy.visit('/');
         cy.visit('/profile');
         cy.contains('admin');
         cy.contains('curator');

--- a/verification/curator-service/ui/package-lock.json
+++ b/verification/curator-service/ui/package-lock.json
@@ -36,6 +36,7 @@
                 "react-gtm-module": "^2.0.11",
                 "react-helmet": "^6.1.0",
                 "react-highlight-words": "^0.17.0",
+                "react-password-strength-bar": "^0.4.1",
                 "react-redux": "^7.2.5",
                 "react-router-dom": "^5.3.0",
                 "react-router-last-location": "^2.0.1",
@@ -23245,6 +23246,18 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
+        "node_modules/react-password-strength-bar": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/react-password-strength-bar/-/react-password-strength-bar-0.4.1.tgz",
+            "integrity": "sha512-2NvYz4IUU8k7KDZgsXKoJWreKCZLKGaqF5QhIVhc09OsPBFXFMh0BeghNkBIRkaxLeI7/xjivknDCYfluBCXKA==",
+            "dependencies": {
+                "zxcvbn": "4.4.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.6",
+                "react-dom": ">=16.8.6"
+            }
+        },
         "node_modules/react-redux": {
             "version": "7.2.6",
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
@@ -29433,6 +29446,11 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/zxcvbn": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+            "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ=="
         }
     },
     "dependencies": {
@@ -47414,6 +47432,14 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         },
+        "react-password-strength-bar": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/react-password-strength-bar/-/react-password-strength-bar-0.4.1.tgz",
+            "integrity": "sha512-2NvYz4IUU8k7KDZgsXKoJWreKCZLKGaqF5QhIVhc09OsPBFXFMh0BeghNkBIRkaxLeI7/xjivknDCYfluBCXKA==",
+            "requires": {
+                "zxcvbn": "4.4.2"
+            }
+        },
         "react-redux": {
             "version": "7.2.6",
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
@@ -52288,6 +52314,11 @@
                 "property-expr": "^2.0.4",
                 "toposort": "^2.0.2"
             }
+        },
+        "zxcvbn": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+            "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ=="
         }
     }
 }

--- a/verification/curator-service/ui/package.json
+++ b/verification/curator-service/ui/package.json
@@ -31,6 +31,7 @@
         "react-gtm-module": "^2.0.11",
         "react-helmet": "^6.1.0",
         "react-highlight-words": "^0.17.0",
+        "react-password-strength-bar": "^0.4.1",
         "react-redux": "^7.2.5",
         "react-router-dom": "^5.3.0",
         "react-router-last-location": "^2.0.1",

--- a/verification/curator-service/ui/src/components/Profile.test.tsx
+++ b/verification/curator-service/ui/src/components/Profile.test.tsx
@@ -193,10 +193,10 @@ describe('<Profile />', () => {
         render(<Profile />, { initialState: noUserInfoState });
 
         userEvent.type(screen.getByLabelText('Old Password'), '1234567');
-        userEvent.type(screen.getByLabelText('New password'), 'asdD?234');
+        userEvent.type(screen.getByLabelText('New password'), 'asdD?234df');
         userEvent.type(
             screen.getByLabelText('Repeat new password'),
-            'asdD?234',
+            'asdD?234df',
         );
 
         userEvent.click(
@@ -225,10 +225,10 @@ describe('<Profile />', () => {
         render(<Profile />, { initialState: noUserInfoState });
 
         userEvent.type(screen.getByLabelText('Old Password'), '1234567');
-        userEvent.type(screen.getByLabelText('New password'), 'asdD?234');
+        userEvent.type(screen.getByLabelText('New password'), 'asdD?234df');
         userEvent.type(
             screen.getByLabelText('Repeat new password'),
-            'asdD?234',
+            'asdD?234df',
         );
 
         userEvent.click(

--- a/verification/curator-service/ui/src/components/Profile.tsx
+++ b/verification/curator-service/ui/src/components/Profile.tsx
@@ -33,6 +33,7 @@ import Alert from '@material-ui/lab/Alert';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { SnackbarAlert } from './SnackbarAlert';
 import Helmet from 'react-helmet';
+import PasswordStrengthBar from 'react-password-strength-bar';
 
 const styles = makeStyles((theme: Theme) => ({
     root: {
@@ -119,6 +120,7 @@ export function ChangePasswordFormInProfile(): JSX.Element {
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
+    const [passwordStrenght, setPasswordStrenght] = useState<number>(0);
     const [oldPasswordVisible, setOldPasswordVisible] = useState(false);
     const [passwordVisible, setPasswordVisible] = useState(false);
     const [passwordConfirmationVisible, setPasswordConfirmationVisible] =
@@ -138,6 +140,9 @@ export function ChangePasswordFormInProfile(): JSX.Element {
             .matches(uppercaseRegex, 'one uppercase required!')
             .matches(numericRegex, 'one number required!')
             .min(8, 'Minimum 8 characters required!')
+            .test('password-strong-enough', 'Password too weak', () => {
+                return passwordStrenght > 2;
+            })
             .test(
                 'passwords-different',
                 "New password can't be the same as old password",
@@ -279,6 +284,14 @@ export function ChangePasswordFormInProfile(): JSX.Element {
                             </InputAdornment>
                         }
                         label="New password"
+                    />
+                    <PasswordStrengthBar
+                        password={formik.values.password}
+                        scoreWords={[]}
+                        shortScoreWord=""
+                        onChangeScore={(score) => {
+                            setPasswordStrenght(score);
+                        }}
                     />
                     <FormHelperText>
                         {formik.touched.password && formik.errors.password}

--- a/verification/curator-service/ui/src/components/Profile.tsx
+++ b/verification/curator-service/ui/src/components/Profile.tsx
@@ -120,7 +120,7 @@ export function ChangePasswordFormInProfile(): JSX.Element {
     const classes = useStyles();
     const dispatch = useAppDispatch();
 
-    const [passwordStrenght, setPasswordStrenght] = useState<number>(0);
+    const [passwordStrength, setPasswordStrength] = useState(0);
     const [oldPasswordVisible, setOldPasswordVisible] = useState(false);
     const [passwordVisible, setPasswordVisible] = useState(false);
     const [passwordConfirmationVisible, setPasswordConfirmationVisible] =
@@ -149,7 +149,7 @@ export function ChangePasswordFormInProfile(): JSX.Element {
                 },
             )
             .test('password-strong-enough', 'Password too weak', () => {
-                return passwordStrenght > 2;
+                return passwordStrength > 2;
             }),
         passwordConfirmation: Yup.string().test(
             'passwords-match',
@@ -289,8 +289,8 @@ export function ChangePasswordFormInProfile(): JSX.Element {
                         password={formik.values.password}
                         scoreWords={[]}
                         shortScoreWord=""
-                        onChangeScore={(score) => {
-                            setPasswordStrenght(score);
+                        onChangeScore={(score: number) => {
+                            setPasswordStrength(score);
                         }}
                     />
                     <FormHelperText>

--- a/verification/curator-service/ui/src/components/Profile.tsx
+++ b/verification/curator-service/ui/src/components/Profile.tsx
@@ -140,9 +140,7 @@ export function ChangePasswordFormInProfile(): JSX.Element {
             .matches(uppercaseRegex, 'one uppercase required!')
             .matches(numericRegex, 'one number required!')
             .min(8, 'Minimum 8 characters required!')
-            .test('password-strong-enough', 'Password too weak', () => {
-                return passwordStrenght > 2;
-            })
+            .required('Required!')
             .test(
                 'passwords-different',
                 "New password can't be the same as old password",
@@ -150,7 +148,9 @@ export function ChangePasswordFormInProfile(): JSX.Element {
                     return this.parent.oldPassword !== value;
                 },
             )
-            .required('Required!'),
+            .test('password-strong-enough', 'Password too weak', () => {
+                return passwordStrenght > 2;
+            }),
         passwordConfirmation: Yup.string().test(
             'passwords-match',
             'Passwords must match',

--- a/verification/curator-service/ui/src/components/landing-page/ChangePasswordForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/ChangePasswordForm.tsx
@@ -124,10 +124,10 @@ export default function ChangePasswordForm({
             .matches(uppercaseRegex, 'one uppercase required!')
             .matches(numericRegex, 'one number required!')
             .min(8, 'Minimum 8 characters required!')
+            .required('Required!')
             .test('password-strong-enough', 'Password too weak', () => {
                 return passwordStrength > 2;
-            })
-            .required('Required!'),
+            }),
         passwordConfirmation: Yup.string().test(
             'passwords-match',
             'Passwords must match',

--- a/verification/curator-service/ui/src/components/landing-page/ChangePasswordForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/ChangePasswordForm.tsx
@@ -89,7 +89,7 @@ export default function ChangePasswordForm({
     const dispatch = useAppDispatch();
     const history = useHistory();
 
-    const [passwordStrenght, setPasswordStrenght] = useState<number>(0);
+    const [passwordStrength, setPasswordStrength] = useState(0);
     const passwordReset = useAppSelector(selectPasswordReset);
     const [passwordVisible, setPasswordVisible] = useState(false);
     const [passwordConfirmationVisible, setPasswordConfirmationVisible] =
@@ -125,7 +125,7 @@ export default function ChangePasswordForm({
             .matches(numericRegex, 'one number required!')
             .min(8, 'Minimum 8 characters required!')
             .test('password-strong-enough', 'Password too weak', () => {
-                return passwordStrenght > 2;
+                return passwordStrength > 2;
             })
             .required('Required!'),
         passwordConfirmation: Yup.string().test(
@@ -212,8 +212,8 @@ export default function ChangePasswordForm({
                                 password={formik.values.password}
                                 scoreWords={[]}
                                 shortScoreWord=""
-                                onChangeScore={(score) => {
-                                    setPasswordStrenght(score);
+                                onChangeScore={(score: number) => {
+                                    setPasswordStrength(score);
                                 }}
                             />
                             <FormHelperText>

--- a/verification/curator-service/ui/src/components/landing-page/ChangePasswordForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/ChangePasswordForm.tsx
@@ -18,6 +18,7 @@ import Visibility from '@material-ui/icons/Visibility';
 import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
+import PasswordStrengthBar from 'react-password-strength-bar';
 
 const useStyles = makeStyles((theme: Theme) => ({
     checkboxRoot: {
@@ -88,6 +89,7 @@ export default function ChangePasswordForm({
     const dispatch = useAppDispatch();
     const history = useHistory();
 
+    const [passwordStrenght, setPasswordStrenght] = useState<number>(0);
     const passwordReset = useAppSelector(selectPasswordReset);
     const [passwordVisible, setPasswordVisible] = useState(false);
     const [passwordConfirmationVisible, setPasswordConfirmationVisible] =
@@ -122,6 +124,9 @@ export default function ChangePasswordForm({
             .matches(uppercaseRegex, 'one uppercase required!')
             .matches(numericRegex, 'one number required!')
             .min(8, 'Minimum 8 characters required!')
+            .test('password-strong-enough', 'Password too weak', () => {
+                return passwordStrenght > 2;
+            })
             .required('Required!'),
         passwordConfirmation: Yup.string().test(
             'passwords-match',
@@ -202,6 +207,14 @@ export default function ChangePasswordForm({
                                     </InputAdornment>
                                 }
                                 label="Password"
+                            />
+                            <PasswordStrengthBar
+                                password={formik.values.password}
+                                scoreWords={[]}
+                                shortScoreWord=""
+                                onChangeScore={(score) => {
+                                    setPasswordStrenght(score);
+                                }}
                             />
                             <FormHelperText>
                                 {formik.touched.password &&

--- a/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
@@ -126,13 +126,13 @@ export default function SignUpForm({
             },
         ),
         password: Yup.string()
-            .test('password-strong-enough', 'Password too weak', () => {
-                return passwordStrenght > 2;
-            })
             .matches(lowercaseRegex, 'One lowercase required')
             .matches(uppercaseRegex, 'One uppercase required')
             .matches(numericRegex, 'One number required')
             .min(8, 'Minimum 8 characters required')
+            .test('password-strong-enough', 'Password too weak', () => {
+                return passwordStrenght > 2;
+            })
             .required('This field is required'),
         passwordConfirmation: Yup.string().test(
             'passwords-match',

--- a/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
@@ -21,6 +21,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 import GoogleButton from 'react-google-button';
 import { sendCustomGtmEvent } from '../util/helperFunctions';
+import PasswordStrengthBar from 'react-password-strength-bar';
 
 const useStyles = makeStyles((theme: Theme) => ({
     checkboxRoot: {
@@ -99,6 +100,7 @@ export default function SignUpForm({
     const dispatch = useAppDispatch();
 
     const [passwordVisible, setPasswordVisible] = useState(false);
+    const [passwordStrenght, setPasswordStrenght] = useState<number>(0);
     const [passwordConfirmationVisible, setPasswordConfirmationVisible] =
         useState(false);
 
@@ -124,6 +126,9 @@ export default function SignUpForm({
             },
         ),
         password: Yup.string()
+            .test('password-strong-enough', 'Password too weak', () => {
+                return passwordStrenght > 2;
+            })
             .matches(lowercaseRegex, 'One lowercase required')
             .matches(uppercaseRegex, 'One uppercase required')
             .matches(numericRegex, 'One number required')
@@ -191,6 +196,7 @@ export default function SignUpForm({
                             helperText={
                                 formik.touched.email && formik.errors.email
                             }
+                            style={{ marginBottom: 17 }}
                         />
 
                         <TextField
@@ -253,6 +259,14 @@ export default function SignUpForm({
                                     </InputAdornment>
                                 }
                                 label="Password"
+                            />
+                            <PasswordStrengthBar
+                                password={formik.values.password}
+                                scoreWords={[]}
+                                shortScoreWord=""
+                                onChangeScore={(score) => {
+                                    setPasswordStrenght(score);
+                                }}
                             />
                             <FormHelperText>
                                 {formik.touched.password &&

--- a/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
@@ -100,7 +100,7 @@ export default function SignUpForm({
     const dispatch = useAppDispatch();
 
     const [passwordVisible, setPasswordVisible] = useState(false);
-    const [passwordStrenght, setPasswordStrenght] = useState<number>(0);
+    const [passwordStrength, setPasswordStrength] = useState(0);
     const [passwordConfirmationVisible, setPasswordConfirmationVisible] =
         useState(false);
 
@@ -131,7 +131,7 @@ export default function SignUpForm({
             .matches(numericRegex, 'One number required')
             .min(8, 'Minimum 8 characters required')
             .test('password-strong-enough', 'Password too weak', () => {
-                return passwordStrenght > 2;
+                return passwordStrength > 2;
             })
             .required('This field is required'),
         passwordConfirmation: Yup.string().test(
@@ -264,8 +264,8 @@ export default function SignUpForm({
                                 password={formik.values.password}
                                 scoreWords={[]}
                                 shortScoreWord=""
-                                onChangeScore={(score) => {
-                                    setPasswordStrenght(score);
+                                onChangeScore={(score: number) => {
+                                    setPasswordStrength(score);
                                 }}
                             />
                             <FormHelperText>

--- a/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
+++ b/verification/curator-service/ui/src/components/landing-page/SignUpForm.tsx
@@ -130,10 +130,10 @@ export default function SignUpForm({
             .matches(uppercaseRegex, 'One uppercase required')
             .matches(numericRegex, 'One number required')
             .min(8, 'Minimum 8 characters required')
+            .required('This field is required')
             .test('password-strong-enough', 'Password too weak', () => {
                 return passwordStrength > 2;
-            })
-            .required('This field is required'),
+            }),
         passwordConfirmation: Yup.string().test(
             'passwords-match',
             'Passwords must match',


### PR DESCRIPTION
Changes:
- added single window (IP) rate limiters to sign-in, sign-up, reset password request
- added a new collection "failed_attempts" which holds states how many attempts were made for each of the previously mentioned endpoints from different IPs
- added function which controls how many attempts were made to the sign-in and reset password request endpoints and blocks it when the number of failed requests exceeds set amount 