### PR TITLE
#2814 sign in email send correctly to users who register without google account

### DIFF
--- a/verification/curator-service/api/src/clients/email-client.ts
+++ b/verification/curator-service/api/src/clients/email-client.ts
@@ -64,7 +64,6 @@ export default class EmailClient {
         subject: string,
         message: string,
     ): Promise<unknown> {
-
         if (this.serviceEnv == 'locale2e') {
             return;
         }

--- a/verification/curator-service/api/src/util/instance-details.ts
+++ b/verification/curator-service/api/src/util/instance-details.ts
@@ -1,5 +1,5 @@
 const urlMap: { [idx: string]: { [idx: string]: string } } = {
-    'covid-19': {
+    'COVID-19': {
         local: 'http://localhost:3002',
         dev: 'https://dev-data.covid-19.global.health',
         qa: 'https://qa-data.covid-19.global.health',
@@ -12,7 +12,7 @@ export function baseURL(disease: string, environment: string): string {
 }
 
 const welcomeMessages: { [idx: string]: string } = {
-    'covid-19': `<p>Thank you for registering with Global.health! We're thrilled to have you join our international community and mission to advance the global response to infectious diseases through the sharing of trusted and open public health data.</p>
+    'COVID-19': `<p>Thank you for registering with Global.health! We're thrilled to have you join our international community and mission to advance the global response to infectious diseases through the sharing of trusted and open public health data.</p>
         <p>Here are a few things you can do:</p>
         <ul>
             <li>Filter and export <a href="https://data.covid-19.global.health">G.h Data</a> containing detailed information on over 50 million anonymized COVID-19 cases from over 100 countries.</li>


### PR DESCRIPTION
The object had an email message with a lowercase key.
Changes:
- changed the key of an object with an email message to uppercase for correct reference