### PR TITLE
#2812 user cannot sign in too many failed attempts change

### DIFF
--- a/verification/curator-service/api/src/controllers/auth.ts
+++ b/verification/curator-service/api/src/controllers/auth.ts
@@ -282,7 +282,7 @@ export class AuthController {
                         req.logIn(user, (err) => {
                             if (err) return next(err);
                         });
-
+                        loginLimiter.resetKey(req.ip);
                         res.status(200).json(user);
                     },
                 )(req, res, next);
@@ -474,6 +474,8 @@ export class AuthController {
                             .status(403)
                             .json({ message: 'Old password is incorrect' });
                     }
+
+                    resetPasswordLimiter.resetKey(req.ip);
 
                     updateFailedAttempts(
                         currentUser._id,
@@ -681,6 +683,8 @@ export class AuthController {
 
                     // Send confirmation email to the user
                     const user = result.value as IUser;
+
+                    resetPasswordWithTokenLimiter.resetKey(req.ip);
 
                     updateFailedAttempts(
                         userId,

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -24,7 +24,6 @@ export const registerLimiter = rateLimit({
                 'You sent too many requests. Please wait a while then try again',
         });
     },
-    skipSuccessfulRequests: true,
 });
 
 export const resetPasswordLimiter = rateLimit({
@@ -52,7 +51,6 @@ export const forgotPasswordLimiter = rateLimit({
                 'You sent too many requests. Please wait a while then try again',
         });
     },
-    skipSuccessfulRequests: true,
 });
 
 export const resetPasswordWithTokenLimiter = rateLimit({

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -2,7 +2,7 @@ import rateLimit from 'express-rate-limit';
 
 export const loginLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 60 minutes
-    max: 4, // Limit each IP to 4 requests per `window` (here, per 20 minutes)
+    max: 6, // Limit each IP to 4 requests per `window` (here, per 20 minutes)
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
     handler: function (req, res /*next*/) {
@@ -15,7 +15,7 @@ export const loginLimiter = rateLimit({
 
 export const registerLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 60 minutes
-    max: 4,
+    max: 6,
     standardHeaders: true,
     legacyHeaders: false,
     handler: function (req, res) {
@@ -29,7 +29,7 @@ export const registerLimiter = rateLimit({
 
 export const resetPasswordLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 60 minutes
-    max: 4,
+    max: 6,
     standardHeaders: true,
     legacyHeaders: false,
     handler: function (req, res) {
@@ -57,7 +57,7 @@ export const forgotPasswordLimiter = rateLimit({
 
 export const resetPasswordWithTokenLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 60 minutes
-    max: 4,
+    max: 6,
     standardHeaders: true,
     legacyHeaders: false,
     handler: function (req, res) {

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -2,7 +2,7 @@ import rateLimit from 'express-rate-limit';
 
 export const loginLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 60 minutes
-    max: 6, // Limit each IP to 4 requests per `window` (here, per 20 minutes)
+    max: 6, // Limit each IP to 6 requests per `window` (here, per 60 minutes)
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
     handler: function (req, res /*next*/) {

--- a/verification/curator-service/api/src/util/single-window-rate-limiters.ts
+++ b/verification/curator-service/api/src/util/single-window-rate-limiters.ts
@@ -42,7 +42,7 @@ export const resetPasswordLimiter = rateLimit({
 
 export const forgotPasswordLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 60 minutes
-    max: 4,
+    max: 6,
     standardHeaders: true,
     legacyHeaders: false,
     handler: function (req, res) {

--- a/verification/curator-service/ui/cypress/integration/components/LandingPage.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LandingPage.spec.ts
@@ -230,7 +230,7 @@ describe('LandingPage', function () {
         cy.contains('Sign in!').click();
         cy.get('#email').type('test@example.com');
         cy.get('#password').type('test');
-        for (let i = 0; i < 5; i++) {
+        for (let i = 0; i < 7; i++) {
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(1500);
             cy.get('button[data-testid="sign-in-button"]').click();

--- a/verification/curator-service/ui/cypress/integration/components/LandingPage.spec.ts
+++ b/verification/curator-service/ui/cypress/integration/components/LandingPage.spec.ts
@@ -218,7 +218,7 @@ describe('LandingPage', function () {
         cy.get('#password').type('tT$5aaaaak');
         cy.get('#passwordConfirmation').type('tT$5aaaaak');
         cy.get('#isAgreementChecked').check();
-        for (let i = 0; i < 5; i++) {
+        for (let i = 0; i < 7; i++) {
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(1500);
             cy.get('button[data-testid="sign-up-button"]').click();


### PR DESCRIPTION
Changes:
- removed skipping successful counting attempts on sign-up and reset password email link for single window rate limiters
- added resetting counting attempts on successful requests for sign-in, reset password with a token, reset the password on the user's profile for single window rate limiters
-  increased number of failed attempts for single window rate limiters