### PR TITLE
curator: add RECAPTCHA environment variable in build #2897

### DIFF
--- a/verification/curator-service/Dockerfile
+++ b/verification/curator-service/Dockerfile
@@ -41,6 +41,7 @@ ENV REACT_APP_PUBLIC_MAPBOX_TOKEN "pk.eyJ1IjoiaGVhbHRobWFwIiwiYSI6ImNrYzNjczdmcz
 # Set the Iubenda policy and cookie consent IDs. These are public so fine to be checked-in an image.
 ENV REACT_APP_POLICY_PUBLIC_ID "89575059"
 ENV REACT_APP_COOKIE_CONSENT_PUBLIC_ID "2070778"
+ENV REACT_APP_RECAPTCHA_SITE_KEY "6LdhjvwgAAAAALrxavR_zR58kxxap07D4ba8X-jE"
 
 RUN npm run build
 


### PR DESCRIPTION
RECAPTCHA_SITE_KEY can be made public, only the SECRET_KEY should
not be published.
